### PR TITLE
Extract workflow memory service and wire CLI/data-access to it

### DIFF
--- a/commands/workflow.js
+++ b/commands/workflow.js
@@ -1,20 +1,15 @@
-const workflowDA = require('../data-access/workflows');
+const workflowMemory = require('../src/workflow-memory');
+const { createWorkflowRepository } = require('../src/platform/storage/repositories/workflow');
 
-function getWorkflowRepository(deps) {
-  if (deps.workflowRepository) {
-    return deps.workflowRepository;
-  }
+function getWorkflowServiceDeps(deps) {
   return {
-    saveWorkflow: (params) => workflowDA.saveWorkflow(deps, params),
-    recordStep: (params) => workflowDA.recordStep(deps, params),
-    stepOutcome: (params) => workflowDA.stepOutcome(deps, params),
-    getWorkflow: (params) => workflowDA.getWorkflow(deps, params),
+    jsonErrNoExit: deps.jsonErrNoExit,
+    workflowRepository: deps.workflowRepository || createWorkflowRepository(deps),
   };
 }
 
 function saveWorkflow(deps, args) {
-  const workflowRepository = getWorkflowRepository(deps);
-  return workflowRepository.saveWorkflow({
+  return workflowMemory.saveWorkflow(getWorkflowServiceDeps(deps), {
     id: args.id,
     name: args.name,
     project: args.project || null,
@@ -23,27 +18,24 @@ function saveWorkflow(deps, args) {
 }
 
 function recordStep(deps, args) {
-  const workflowRepository = getWorkflowRepository(deps);
-  return workflowRepository.recordStep({
+  return workflowMemory.recordStep(getWorkflowServiceDeps(deps), {
     workflow: args.workflow,
-    step: parseInt(args.step),
+    step: parseInt(args.step, 10),
     command: args.command,
   });
 }
 
 function stepOutcome(deps, args) {
-  const workflowRepository = getWorkflowRepository(deps);
-  return workflowRepository.stepOutcome({
+  return workflowMemory.stepOutcome(getWorkflowServiceDeps(deps), {
     workflow: args.workflow,
-    step: parseInt(args.step),
+    step: parseInt(args.step, 10),
     success: args.success === 'true',
     workaround: args.workaround || null,
   });
 }
 
 function getWorkflow(deps, args) {
-  const workflowRepository = getWorkflowRepository(deps);
-  return workflowRepository.getWorkflow({ id: args.id });
+  return workflowMemory.getWorkflow(getWorkflowServiceDeps(deps), { id: args.id });
 }
 
-module.exports = { saveWorkflow, recordStep, stepOutcome, getWorkflow };
+module.exports = { saveWorkflow, recordStep, stepOutcome, getWorkflow, getWorkflowServiceDeps };

--- a/data-access/workflows.js
+++ b/data-access/workflows.js
@@ -1,78 +1,27 @@
-const { TRUST_DELTA } = require('../constants');
+const workflowMemory = require('../src/workflow-memory');
+const { createWorkflowRepository } = require('../src/platform/storage/repositories/workflow');
 
-function saveWorkflow(deps, { id, name, project, stepsRaw }) {
-  const { sqlRun, jsonErrNoExit } = deps;
-  if (!id || !name) {
-    return jsonErrNoExit('Missing --id and --name');
-  }
-
-  sqlRun('INSERT OR IGNORE INTO procedural_memory (id, name, project) VALUES (?, ?, ?)', [id, name, project]);
-
-  if (stepsRaw) {
-    const steps = stepsRaw
-      .split(/\\n|\n/)
-      .map((s) => s.trim())
-      .filter(Boolean);
-    let stepNum = 1;
-    for (const cmd of steps) {
-      sqlRun(
-        'INSERT OR REPLACE INTO procedural_steps (workflow, step_num, command, success, attempts) VALUES (?, ?, ?, 1.0, 1)',
-        [id, stepNum, cmd],
-      );
-      stepNum++;
-    }
-    return { ok: true, stepsSaved: steps.length };
-  }
-  return { ok: true, stepsSaved: 0 };
+function workflowDeps(deps) {
+  return {
+    jsonErrNoExit: deps.jsonErrNoExit,
+    workflowRepository: deps.workflowRepository || createWorkflowRepository(deps),
+  };
 }
 
-function recordStep(deps, { workflow, step, command }) {
-  const { sqlRun, jsonErrNoExit } = deps;
-  if (!workflow || isNaN(step) || !command) {
-    return jsonErrNoExit('Missing --workflow, --step, --command');
-  }
-  sqlRun(
-    'INSERT OR REPLACE INTO procedural_steps (workflow, step_num, command, success, attempts) VALUES (?, ?, ?, 1.0, 1)',
-    [workflow, step, command],
-  );
-  return { ok: true };
+function saveWorkflow(deps, params) {
+  return workflowMemory.saveWorkflow(workflowDeps(deps), params);
 }
 
-function stepOutcome(deps, { workflow, step, success, workaround }) {
-  const { sqlJson, sqlRun, jsonErrNoExit } = deps;
-  if (!workflow || isNaN(step)) {
-    return jsonErrNoExit('Missing --workflow and --step');
-  }
-
-  if (success) {
-    sqlRun(
-      `UPDATE procedural_steps SET success = MIN(1.0, success + ${TRUST_DELTA.STEP_SUCCESS}), attempts = attempts + 1 WHERE workflow = ? AND step_num = ?`,
-      [workflow, step],
-    );
-  } else {
-    sqlRun(
-      `UPDATE procedural_steps SET success = MAX(0.0, success - ${Math.abs(TRUST_DELTA.STEP_FAILURE)}), attempts = attempts + 1, fail_workaround = ? WHERE workflow = ? AND step_num = ?`,
-      [workaround || null, workflow, step],
-    );
-  }
-  const updated = sqlJson(
-    'SELECT success, attempts, fail_workaround FROM procedural_steps WHERE workflow = ? AND step_num = ?',
-    [workflow, step],
-  );
-  return updated.length > 0 ? { ok: true, ...updated[0] } : { ok: true };
+function recordStep(deps, params) {
+  return workflowMemory.recordStep(workflowDeps(deps), params);
 }
 
-function getWorkflow(deps, { id }) {
-  const { sqlJson, jsonErrNoExit } = deps;
-  if (!id) {
-    return jsonErrNoExit('Missing --id');
-  }
-  const meta = sqlJson('SELECT * FROM procedural_memory WHERE id = ? LIMIT 1', [id]);
-  if (meta.length === 0) {
-    return { error: 'Workflow not found' };
-  }
-  const steps = sqlJson('SELECT * FROM procedural_steps WHERE workflow = ? ORDER BY step_num', [id]);
-  return { ...meta[0], steps };
+function stepOutcome(deps, params) {
+  return workflowMemory.stepOutcome(workflowDeps(deps), params);
 }
 
-module.exports = { saveWorkflow, recordStep, stepOutcome, getWorkflow };
+function getWorkflow(deps, params) {
+  return workflowMemory.getWorkflow(workflowDeps(deps), params);
+}
+
+module.exports = { saveWorkflow, recordStep, stepOutcome, workflowDeps, getWorkflow };

--- a/src/platform/storage/repositories/workflow.js
+++ b/src/platform/storage/repositories/workflow.js
@@ -1,20 +1,64 @@
-const workflows = require('../../../../data-access/workflows');
+const { TRUST_DELTA } = require('../../../../constants');
 
 function createWorkflowRepository(deps) {
-  return Object.freeze({
+  const { sqlJson, sqlRun } = deps;
+  const repository = {
+    insertWorkflow({ id, name, project }) {
+      return sqlRun('INSERT OR IGNORE INTO procedural_memory (id, name, project) VALUES (?, ?, ?)', [
+        id,
+        name,
+        project,
+      ]);
+    },
+    upsertStep({ workflow, stepNum, command, success, attempts }) {
+      return sqlRun(
+        'INSERT OR REPLACE INTO procedural_steps (workflow, step_num, command, success, attempts) VALUES (?, ?, ?, ?, ?)',
+        [workflow, stepNum, command, success, attempts],
+      );
+    },
+    recordStepSuccess({ workflow, stepNum }) {
+      return sqlRun(
+        `UPDATE procedural_steps SET success = MIN(1.0, success + ${TRUST_DELTA.STEP_SUCCESS}), attempts = attempts + 1 WHERE workflow = ? AND step_num = ?`,
+        [workflow, stepNum],
+      );
+    },
+    recordStepFailure({ workflow, stepNum, workaround }) {
+      return sqlRun(
+        `UPDATE procedural_steps SET success = MAX(0.0, success - ${Math.abs(TRUST_DELTA.STEP_FAILURE)}), attempts = attempts + 1, fail_workaround = ? WHERE workflow = ? AND step_num = ?`,
+        [workaround || null, workflow, stepNum],
+      );
+    },
+    findStepOutcome({ workflow, stepNum }) {
+      return sqlJson(
+        'SELECT success, attempts, fail_workaround FROM procedural_steps WHERE workflow = ? AND step_num = ?',
+        [workflow, stepNum],
+      );
+    },
+    findWorkflow(id) {
+      return sqlJson('SELECT * FROM procedural_memory WHERE id = ? LIMIT 1', [id]);
+    },
+    listWorkflowSteps(id) {
+      return sqlJson('SELECT * FROM procedural_steps WHERE workflow = ? ORDER BY step_num', [id]);
+    },
     saveWorkflow(params) {
-      return workflows.saveWorkflow(deps, params);
+      const workflowMemory = require('../../../workflow-memory');
+      return workflowMemory.saveWorkflow({ workflowRepository: repository, jsonErrNoExit: deps.jsonErrNoExit }, params);
     },
     recordStep(params) {
-      return workflows.recordStep(deps, params);
+      const workflowMemory = require('../../../workflow-memory');
+      return workflowMemory.recordStep({ workflowRepository: repository, jsonErrNoExit: deps.jsonErrNoExit }, params);
     },
     stepOutcome(params) {
-      return workflows.stepOutcome(deps, params);
+      const workflowMemory = require('../../../workflow-memory');
+      return workflowMemory.stepOutcome({ workflowRepository: repository, jsonErrNoExit: deps.jsonErrNoExit }, params);
     },
     getWorkflow(params) {
-      return workflows.getWorkflow(deps, params);
+      const workflowMemory = require('../../../workflow-memory');
+      return workflowMemory.getWorkflow({ workflowRepository: repository, jsonErrNoExit: deps.jsonErrNoExit }, params);
     },
-  });
+  };
+
+  return Object.freeze(repository);
 }
 
 module.exports = { createWorkflowRepository };

--- a/src/workflow-memory/index.js
+++ b/src/workflow-memory/index.js
@@ -1,0 +1,12 @@
+const workflows = require('./workflows');
+const steps = require('./steps');
+const scoring = require('./scoring');
+
+module.exports = {
+  ...workflows,
+  recordStep: steps.recordStep,
+  stepOutcome: steps.stepOutcome,
+  workflows,
+  steps,
+  scoring,
+};

--- a/src/workflow-memory/scoring.js
+++ b/src/workflow-memory/scoring.js
@@ -1,0 +1,33 @@
+const { TRUST_DELTA } = require('../../constants');
+
+const INITIAL_STEP_SUCCESS = 1.0;
+const INITIAL_STEP_ATTEMPTS = 1;
+const MIN_SUCCESS = 0.0;
+const MAX_SUCCESS = 1.0;
+
+function clampSuccess(value) {
+  return Math.max(MIN_SUCCESS, Math.min(MAX_SUCCESS, value));
+}
+
+function successDelta(wasSuccessful) {
+  return wasSuccessful ? TRUST_DELTA.STEP_SUCCESS : TRUST_DELTA.STEP_FAILURE;
+}
+
+function scoreStepOutcome({ currentSuccess = INITIAL_STEP_SUCCESS, currentAttempts = 0, success }) {
+  const numericSuccess = Number(currentSuccess);
+  const numericAttempts = Number(currentAttempts);
+  return {
+    success: clampSuccess(numericSuccess + successDelta(success)),
+    attempts: numericAttempts + 1,
+  };
+}
+
+module.exports = {
+  INITIAL_STEP_SUCCESS,
+  INITIAL_STEP_ATTEMPTS,
+  MIN_SUCCESS,
+  MAX_SUCCESS,
+  clampSuccess,
+  successDelta,
+  scoreStepOutcome,
+};

--- a/src/workflow-memory/steps.js
+++ b/src/workflow-memory/steps.js
@@ -1,0 +1,55 @@
+const { INITIAL_STEP_ATTEMPTS, INITIAL_STEP_SUCCESS } = require('./scoring');
+
+function parseWorkflowSteps(stepsRaw) {
+  if (!stepsRaw) {
+    return [];
+  }
+
+  return stepsRaw
+    .split(/\\n|\n/)
+    .map((step) => step.trim())
+    .filter(Boolean);
+}
+
+function normalizeStepNumber(step) {
+  const parsed = typeof step === 'number' ? step : parseInt(step, 10);
+  return Number.isNaN(parsed) ? NaN : parsed;
+}
+
+function recordStep(deps, { workflow, step, command }) {
+  const { workflowRepository, jsonErrNoExit } = deps;
+  const stepNumber = normalizeStepNumber(step);
+
+  if (!workflow || Number.isNaN(stepNumber) || !command) {
+    return jsonErrNoExit('Missing --workflow, --step, --command');
+  }
+
+  workflowRepository.upsertStep({
+    workflow,
+    stepNum: stepNumber,
+    command,
+    success: INITIAL_STEP_SUCCESS,
+    attempts: INITIAL_STEP_ATTEMPTS,
+  });
+  return { ok: true };
+}
+
+function stepOutcome(deps, { workflow, step, success, workaround }) {
+  const { workflowRepository, jsonErrNoExit } = deps;
+  const stepNumber = normalizeStepNumber(step);
+
+  if (!workflow || Number.isNaN(stepNumber)) {
+    return jsonErrNoExit('Missing --workflow and --step');
+  }
+
+  if (success) {
+    workflowRepository.recordStepSuccess({ workflow, stepNum: stepNumber });
+  } else {
+    workflowRepository.recordStepFailure({ workflow, stepNum: stepNumber, workaround: workaround || null });
+  }
+
+  const updated = workflowRepository.findStepOutcome({ workflow, stepNum: stepNumber });
+  return updated.length > 0 ? { ok: true, ...updated[0] } : { ok: true };
+}
+
+module.exports = { parseWorkflowSteps, normalizeStepNumber, recordStep, stepOutcome };

--- a/src/workflow-memory/workflows.js
+++ b/src/workflow-memory/workflows.js
@@ -1,0 +1,41 @@
+const { INITIAL_STEP_ATTEMPTS, INITIAL_STEP_SUCCESS } = require('./scoring');
+const { parseWorkflowSteps } = require('./steps');
+
+function saveWorkflow(deps, { id, name, project, stepsRaw }) {
+  const { workflowRepository, jsonErrNoExit } = deps;
+  if (!id || !name) {
+    return jsonErrNoExit('Missing --id and --name');
+  }
+
+  workflowRepository.insertWorkflow({ id, name, project });
+
+  const steps = parseWorkflowSteps(stepsRaw);
+  steps.forEach((command, index) => {
+    workflowRepository.upsertStep({
+      workflow: id,
+      stepNum: index + 1,
+      command,
+      success: INITIAL_STEP_SUCCESS,
+      attempts: INITIAL_STEP_ATTEMPTS,
+    });
+  });
+
+  return { ok: true, stepsSaved: steps.length };
+}
+
+function getWorkflow(deps, { id }) {
+  const { workflowRepository, jsonErrNoExit } = deps;
+  if (!id) {
+    return jsonErrNoExit('Missing --id');
+  }
+
+  const meta = workflowRepository.findWorkflow(id);
+  if (meta.length === 0) {
+    return { error: 'Workflow not found' };
+  }
+
+  const steps = workflowRepository.listWorkflowSteps(id);
+  return { ...meta[0], steps };
+}
+
+module.exports = { saveWorkflow, getWorkflow };

--- a/test/storage-repositories.test.js
+++ b/test/storage-repositories.test.js
@@ -99,23 +99,24 @@ describe('platform storage repositories', () => {
     );
   });
 
-  it('routes workflow commands through the workflow repository when supplied', () => {
+  it('routes workflow commands through the workflow-memory service and workflow repository when supplied', () => {
     const workflowRepository = {
-      saveWorkflow: vi.fn(() => ({ ok: true, stepsSaved: 0 })),
-      recordStep: vi.fn(),
-      stepOutcome: vi.fn(),
-      getWorkflow: vi.fn(),
+      insertWorkflow: vi.fn(),
+      upsertStep: vi.fn(),
     };
 
-    const result = workflowCmd.saveWorkflow({ workflowRepository }, { id: 'wf', name: 'Workflow', project: 'p' });
+    const result = workflowCmd.saveWorkflow(
+      { workflowRepository, jsonErrNoExit: vi.fn((message) => ({ error: message })) },
+      { id: 'wf', name: 'Workflow', project: 'p' },
+    );
 
     expect(result.ok).toBe(true);
-    expect(workflowRepository.saveWorkflow).toHaveBeenCalledWith({
+    expect(workflowRepository.insertWorkflow).toHaveBeenCalledWith({
       id: 'wf',
       name: 'Workflow',
       project: 'p',
-      stepsRaw: null,
     });
+    expect(workflowRepository.upsertStep).not.toHaveBeenCalled();
   });
 
   it('routes observation commands through the memory repository when supplied', () => {

--- a/test/workflow-memory.test.js
+++ b/test/workflow-memory.test.js
@@ -1,0 +1,130 @@
+const workflowMemory = require('../src/workflow-memory');
+const scoring = require('../src/workflow-memory/scoring');
+const steps = require('../src/workflow-memory/steps');
+
+function mockWorkflowRepository(overrides = {}) {
+  return {
+    insertWorkflow: vi.fn(),
+    upsertStep: vi.fn(),
+    recordStepSuccess: vi.fn(),
+    recordStepFailure: vi.fn(),
+    findStepOutcome: vi.fn(() => []),
+    findWorkflow: vi.fn(() => []),
+    listWorkflowSteps: vi.fn(() => []),
+    ...overrides,
+  };
+}
+
+describe('workflow-memory', () => {
+  describe('workflows', () => {
+    it('saves workflow metadata and normalized ordered steps without observation search deps', () => {
+      const workflowRepository = mockWorkflowRepository();
+      const result = workflowMemory.saveWorkflow(
+        { workflowRepository, jsonErrNoExit: vi.fn((message) => ({ error: message })) },
+        { id: 'wf-1', name: 'Deploy', project: 'lapis', stepsRaw: 'build\\ntest\n\nship' },
+      );
+
+      expect(result).toEqual({ ok: true, stepsSaved: 3 });
+      expect(workflowRepository.insertWorkflow).toHaveBeenCalledWith({ id: 'wf-1', name: 'Deploy', project: 'lapis' });
+      expect(workflowRepository.upsertStep).toHaveBeenNthCalledWith(1, {
+        workflow: 'wf-1',
+        stepNum: 1,
+        command: 'build',
+        success: 1.0,
+        attempts: 1,
+      });
+      expect(workflowRepository.upsertStep).toHaveBeenNthCalledWith(3, {
+        workflow: 'wf-1',
+        stepNum: 3,
+        command: 'ship',
+        success: 1.0,
+        attempts: 1,
+      });
+    });
+
+    it('gets workflow metadata with ordered steps from workflow storage only', () => {
+      const workflowRepository = mockWorkflowRepository({
+        findWorkflow: vi.fn(() => [{ id: 'wf-1', name: 'Deploy', project: 'lapis' }]),
+        listWorkflowSteps: vi.fn(() => [{ workflow: 'wf-1', step_num: 1, command: 'build' }]),
+      });
+
+      const result = workflowMemory.getWorkflow(
+        { workflowRepository, jsonErrNoExit: vi.fn((message) => ({ error: message })) },
+        { id: 'wf-1' },
+      );
+
+      expect(result.steps).toHaveLength(1);
+      expect(workflowRepository.findWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(workflowRepository.listWorkflowSteps).toHaveBeenCalledWith('wf-1');
+    });
+  });
+
+  describe('steps', () => {
+    it('records a step with the initial success score and attempts', () => {
+      const workflowRepository = mockWorkflowRepository();
+      const result = workflowMemory.recordStep(
+        { workflowRepository, jsonErrNoExit: vi.fn((message) => ({ error: message })) },
+        { workflow: 'wf-1', step: '2', command: 'test' },
+      );
+
+      expect(result).toEqual({ ok: true });
+      expect(workflowRepository.upsertStep).toHaveBeenCalledWith({
+        workflow: 'wf-1',
+        stepNum: 2,
+        command: 'test',
+        success: 1.0,
+        attempts: 1,
+      });
+    });
+
+    it('records successful outcomes and returns attempts from storage', () => {
+      const workflowRepository = mockWorkflowRepository({
+        findStepOutcome: vi.fn(() => [{ success: 1.0, attempts: 3, fail_workaround: null }]),
+      });
+
+      const result = workflowMemory.stepOutcome(
+        { workflowRepository, jsonErrNoExit: vi.fn((message) => ({ error: message })) },
+        { workflow: 'wf-1', step: 2, success: true },
+      );
+
+      expect(result).toEqual({ ok: true, success: 1.0, attempts: 3, fail_workaround: null });
+      expect(workflowRepository.recordStepSuccess).toHaveBeenCalledWith({ workflow: 'wf-1', stepNum: 2 });
+      expect(workflowRepository.findStepOutcome).toHaveBeenCalledWith({ workflow: 'wf-1', stepNum: 2 });
+    });
+
+    it('records failed outcomes with workarounds', () => {
+      const workflowRepository = mockWorkflowRepository({
+        findStepOutcome: vi.fn(() => [{ success: 0.8, attempts: 2, fail_workaround: 'retry with --force' }]),
+      });
+
+      const result = workflowMemory.stepOutcome(
+        { workflowRepository, jsonErrNoExit: vi.fn((message) => ({ error: message })) },
+        { workflow: 'wf-1', step: 2, success: false, workaround: 'retry with --force' },
+      );
+
+      expect(result.fail_workaround).toBe('retry with --force');
+      expect(workflowRepository.recordStepFailure).toHaveBeenCalledWith({
+        workflow: 'wf-1',
+        stepNum: 2,
+        workaround: 'retry with --force',
+      });
+    });
+
+    it('normalizes literal and real newlines in workflow step input', () => {
+      expect(steps.parseWorkflowSteps('one\\ntwo\nthree')).toEqual(['one', 'two', 'three']);
+    });
+  });
+
+  describe('scoring', () => {
+    it('calculates bounded success and failure score transitions', () => {
+      expect(scoring.scoreStepOutcome({ currentSuccess: 0.95, currentAttempts: 1, success: true })).toEqual({
+        success: 1.0,
+        attempts: 2,
+      });
+      expect(scoring.scoreStepOutcome({ currentSuccess: 0.1, currentAttempts: 4, success: false })).toEqual({
+        success: 0.0,
+        attempts: 5,
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Separate procedural workflow logic from CLI/data-access to improve testability and encapsulate scoring/step handling behavior.
- Provide a focused in-process service for workflow orchestration so storage repositories expose a small, consistent interface for steps and metadata.
- Make outcome scoring (success/attempt adjustments and workarounds) explicit and reusable so future features can reason about trust transitions.

### Description
- Add a new `src/workflow-memory` service split into `workflows.js`, `steps.js`, and `scoring.js`, and export a small index that exposes `saveWorkflow`, `getWorkflow`, `recordStep`, and `stepOutcome` helpers.
- Refactor `commands/workflow.js` and `data-access/workflows.js` to delegate to the new workflow-memory service using a `workflowRepository` abstraction created by `src/platform/storage/repositories/workflow.js`.
- Extend the storage repository at `src/platform/storage/repositories/workflow.js` with explicit methods for `insertWorkflow`, `upsertStep`, `recordStepSuccess`, `recordStepFailure`, `findStepOutcome`, `findWorkflow`, and `listWorkflowSteps`, and route its higher-level methods through the workflow-memory service when invoked.
- Add focused tests in `test/workflow-memory.test.js` and update `test/storage-repositories.test.js` to validate wiring, step normalization, initial attempt/success defaults, scoring bounds, and failure workarounds.

### Testing
- Ran the targeted unit tests with `npm test -- test/workflow-memory.test.js test/data-access-workflows.test.js test/storage-repositories.test.js` and all targeted tests passed.
- Ran the full test suite with `npm test` and observed three pre-existing failures in `test/edge-cases.test.js` related to code-analysis metadata assertions (these failures are unrelated to the workflow changes).
- Verified formatting for changed files with `npx oxfmt --check ...` and lint for the touched files with `npx oxlint ...`, both of which passed for the modified files.
- Note that an attempted run with the Jest-style `--runInBand` option failed because Vitest does not accept that flag, so the targeted tests were run without it and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a0dd7000832f9e220a3e623b1b54)