### PR TITLE
Add contributor & architecture docs, module map, and module-boundary annotations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ Fixes #
 - [ ] Smoke CLI tests pass: `node test/smoke-cli.js`
 - [ ] Lint passes: `npm run lint`
 - [ ] No regressions in existing test behavior
+- [ ] `docs/MODULE_MAP.md` updated if modules were added, removed, renamed, or dependency boundaries changed
 - [ ] If a test behavior change was legitimate, it is documented below
 
 ### Legitimate Test Behavior Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to LaPis
+
+LaPis is a modular Node.js runtime plus Pi extension for persistent agent memory. Use this guide to decide where to make a change, which dependency boundary to respect, and which checks to run before opening a PR.
+
+## Baseline verification commands
+
+Run these from a clean checkout before submitting a PR:
+
+```bash
+# 1. Full Vitest suite
+npm test
+
+# 2. Smoke-test every CLI command as a subprocess
+node test/smoke-cli.js
+
+# 3. Lint and formatting checks
+npm run check
+```
+
+All three should pass before merge. Documentation-only changes may not need the full smoke suite during iteration, but extraction/refactor PRs must run every command above.
+
+## Where to add a feature
+
+Start with the feature area, then add code in the owning module. If a change appears to need two feature modules directly importing each other, stop and add a small interface or route it through the owning integration module instead.
+
+| If you are changing...                                                                                                                                      | Add or update code in...                     | Notes                                                                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Observation CRUD, memory search, context loading, sessions, recall, dedupe, compaction, or workspaces                                                       | `src/memory-domain/`                         | This module owns declarative memory and must not depend on code/doc parsers.                        |
+| Saved procedures, workflow steps, step outcomes, or workflow scoring                                                                                        | `src/workflow-memory/`                       | Keep workflow state separate from observation ranking.                                              |
+| Repository registration, file scanning, parser selection, symbol extraction, edge extraction, incremental indexing, or source retrieval                     | `src/code-index/`                            | This module writes/serves the code-index read model; it must not include memory ranking logic.      |
+| Import/call graphs, blast radius, dead code, complexity, hotspots, cycles, PageRank, coupling, signal chains, layer violations, query winnowing, or PR risk | `src/code-analysis/`                         | Analysis consumes code-index read models and git metrics; it must not depend on Pi extension state. |
+| Markdown indexing, section search, backlinks, broken links, glossary terms, tutorial paths, code examples, or doc analytics                                 | `src/doc-index/`                             | Documentation features are independent; coverage may use only a narrow code-symbol lookup.          |
+| Trust decay/recovery or memory-to-code-symbol relationship updates                                                                                          | `src/trust-sync/`                            | This is the integration boundary between declarative memory and indexed code.                       |
+| CLI subcommand parsing/routing                                                                                                                              | `src/cli/commands/` and `src/cli/gateway.js` | Routers should delegate to feature services and avoid embedding business logic.                     |
+| JSON envelopes, compact output, LLM-facing transformations, or response metadata                                                                            | `src/platform/protocol/`                     | Presentation belongs at platform/protocol boundaries, not inside feature services.                  |
+| Database access helpers or feature repositories                                                                                                             | `src/platform/storage/` and `data-access/`   | Prefer repository interfaces over ad hoc SQL in feature modules.                                    |
+| Pi lifecycle hooks, tool schemas, repo detection, native health checks, or tool result formatting                                                           | `extensions/memory-layer/`                   | The extension is an adapter/composition layer; keep backend behavior in feature modules.            |
+| Rust code-intelligence experiments or Crosshash engine work                                                                                                 | `crosshash/`                                 | Keep Crosshash behind a process/API boundary until it becomes the canonical backend.                |
+
+For the authoritative table of module ownership, entry points, and allowed dependencies, update and consult [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md).
+
+## Project structure
+
+```text
+memory-store.js          # CLI entry point that delegates to cli.js
+cli.js                   # Runtime command dispatch setup
+extensions/memory-layer/ # Pi extension composition root, hooks, host client, and tools
+src/cli/                 # CLI gateway and feature command routers
+src/memory-domain/       # Declarative memory feature module
+src/workflow-memory/     # Procedural workflow-memory feature module
+src/code-index/          # Code indexing and source retrieval feature module
+src/code-analysis/       # Code intelligence and analysis feature module
+src/doc-index/           # Documentation indexing and doc intelligence feature module
+src/trust-sync/          # Memory/code trust integration feature module
+src/platform/            # Shared storage/protocol/platform adapters
+data-access/             # Repository-style SQL access modules used by legacy/runtime code
+test/                    # Vitest unit/integration tests and CLI smoke tests
+crosshash/               # Rust code-intelligence workspace
+```
+
+## Dependency boundaries
+
+LaPis is a modular monolith: one package, many independently testable feature modules. The target dependency flow is:
+
+```text
+Pi extension adapters
+  -> CLI/API command gateway
+  -> feature services
+  -> platform storage/protocol helpers
+```
+
+Follow these rules when adding or moving code:
+
+1. `extensions/*` may depend on backend clients and formatting adapters, but not raw SQL or parser internals.
+2. `memory-domain` may depend on storage, config, and ranking constants, but not code/doc parsers.
+3. `workflow-memory` may depend on storage and project identity only.
+4. `code-index` may depend on parser, filesystem, hashing, and storage helpers, but not memory observation ranking.
+5. `code-analysis` may depend on code-index read repositories and git metrics, but not Pi extension state.
+6. `doc-index` may depend on Markdown/doc storage; documentation coverage may depend only on a narrow code-symbol lookup.
+7. `trust-sync` is the only module that should coordinate memory observations with code symbol tables.
+8. `platform/protocol` owns `_meta`, compact/auto output, and LLM-facing transformations.
+9. Crosshash should stay behind a command/API boundary until it fully replaces the JavaScript code-intelligence path.
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the concise architecture overview and [`docs/ARCHITECTURE_MODULARIZATION.md`](docs/ARCHITECTURE_MODULARIZATION.md) for the detailed extraction rationale.
+
+## Adding or changing modules
+
+When a PR adds, removes, renames, or changes the dependency boundary of a module:
+
+1. Update [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md).
+2. Add or update the module-boundary comment in the module entry point.
+3. Add unit tests that exercise the feature module without starting the Pi extension when practical.
+4. Add integration tests against a temporary SQLite database for storage behavior.
+5. Add or update CLI/router tests only for argument mapping and command delegation.
+6. Keep user-facing formatting at extension or protocol boundaries instead of feature services.
+
+## Extraction/refactor PR requirements
+
+PRs labeled `architecture` or `refactor`, or PRs that touch modularization code, have additional requirements:
+
+1. **Full test suite must pass** — no exceptions.
+2. **Smoke CLI tests must pass** — every command that moved to a new router must still work.
+3. **Lint and format checks must pass** — run `npm run check`.
+4. **Legitimate test behavior changes must be documented** — if an extraction changes expected behavior, update the test in the same PR and explain why in the PR description.
+5. **Module map must stay current** — update `docs/MODULE_MAP.md` when module ownership or boundaries change.
+
+## Test commands reference
+
+| Command                  | What it checks                                          | When to run                  |
+| ------------------------ | ------------------------------------------------------- | ---------------------------- |
+| `npm test`               | Full Vitest suite, including unit and integration tests | Every PR                     |
+| `node test/smoke-cli.js` | Every CLI subcommand via subprocess                     | Every extraction/refactor PR |
+| `npm run lint`           | oxlint static analysis                                  | Every PR                     |
+| `npm run format:check`   | oxfmt formatting check                                  | Every PR                     |
+| `npm run check`          | Lint + format combined                                  | Every PR                     |
+
+## CI
+
+GitHub Actions runs on pushes and PRs to `main`:
+
+- `test.yml` installs dependencies, runs lint/format checks, runs the full test suite, and runs smoke CLI tests.
+- `crosshash-ci.yml` runs Rust lint/test coverage for the `crosshash/` workspace.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LaPis 💎
 
-> 🇵🇭 *lapis* — pencil, to write
-> 🪨 *lapis* — stone, precious gem
+> 🇵🇭 _lapis_ — pencil, to write
+> 🪨 _lapis_ — stone, precious gem
 > 🧠 La**Pi**s — memory for Pi
 
 Persistent memory for the [Pi coding agent](https://github.com/earendil-works/pi-coding-agent). One SQLite database, zero cloud dependencies, zero API keys.
@@ -9,6 +9,34 @@ Persistent memory for the [Pi coding agent](https://github.com/earendil-works/pi
 ## Architecture
 
 ![PiMemory Architecture](memory-layer-architecture.png)
+
+## Development
+
+Start with the contributor guide when changing the codebase: [`CONTRIBUTING.md`](CONTRIBUTING.md). The concise architecture overview is in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), and the authoritative module ownership table is in [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md).
+
+Current development entry points:
+
+| Path                       | Purpose                                                                                                          |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `memory-store.js`          | CLI entry point that delegates runtime dispatch.                                                                 |
+| `cli.js`                   | Runtime command dispatch setup.                                                                                  |
+| `src/cli/gateway.js`       | Feature command gateway and router composition.                                                                  |
+| `src/memory-domain/`       | Declarative memory features such as observations, search, context, sessions, dedupe, compaction, and workspaces. |
+| `src/workflow-memory/`     | Procedural workflow memory, steps, outcomes, and scoring.                                                        |
+| `src/code-index/`          | Code repository indexing, parsing, symbol extraction, edges, incremental indexing, and source retrieval.         |
+| `src/code-analysis/`       | Code intelligence queries such as graphs, blast radius, complexity, coupling, risk, and dead-code analysis.      |
+| `src/doc-index/`           | Markdown documentation indexing, links, glossary, examples, and doc analytics.                                   |
+| `src/trust-sync/`          | Integration boundary for memory/code symbol trust updates.                                                       |
+| `src/platform/`            | Shared storage composition and protocol/output formatting.                                                       |
+| `extensions/memory-layer/` | Pi extension hooks, host adapters, tool adapters, and result formatting.                                         |
+
+Before opening a PR, run:
+
+```bash
+npm test
+node test/smoke-cli.js
+npm run check
+```
 
 ## One-command install
 
@@ -35,98 +63,98 @@ Restart Pi and memory auto-wires on session start. Use `pi update --extensions` 
 
 ### Observations & Search
 
-| Command                                | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `save`                                 | Save an observation (decision, bugfix, pattern, etc.) |
-| `update --id`                          | Update an existing observation in-place by ID          |
-| `delete --id`                          | Soft-delete an observation by ID (recoverable)        |
-| `search`                               | FTS5 full-text search with hybrid ranking             |
-| `search --include-code`                | Search both memories AND indexed code symbols         |
-| `context`                               | Load session context by project                       |
-| `get`                                  | Retrieve a single observation by ID                   |
+| Command                 | Purpose                                               |
+| ----------------------- | ----------------------------------------------------- |
+| `save`                  | Save an observation (decision, bugfix, pattern, etc.) |
+| `update --id`           | Update an existing observation in-place by ID         |
+| `delete --id`           | Soft-delete an observation by ID (recoverable)        |
+| `search`                | FTS5 full-text search with hybrid ranking             |
+| `search --include-code` | Search both memories AND indexed code symbols         |
+| `context`               | Load session context by project                       |
+| `get`                   | Retrieve a single observation by ID                   |
 
 ### Code Indexing (v3 — WASM tree-sitter)
 
-| Command                                | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `index-repo --path`                    | Index a local folder with tree-sitter                 |
-| `reindex-repo --repo`                  | Incremental reindex via mtime                         |
-| `search-code --query`                  | FTS5 BM25 search over code symbols                   |
-| `get-code-source --repo --file --name` | Byte-accurate source retrieval                       |
-| `list-code-repos`                      | List indexed code repos                               |
-| `remove-code-repo --repo`              | Remove an indexed code repo                           |
+| Command                                | Purpose                               |
+| -------------------------------------- | ------------------------------------- |
+| `index-repo --path`                    | Index a local folder with tree-sitter |
+| `reindex-repo --repo`                  | Incremental reindex via mtime         |
+| `search-code --query`                  | FTS5 BM25 search over code symbols    |
+| `get-code-source --repo --file --name` | Byte-accurate source retrieval        |
+| `list-code-repos`                      | List indexed code repos               |
+| `remove-code-repo --repo`              | Remove an indexed code repo           |
 
 ### Code Analysis (v5 — import graph, call graph, complexity, dead code)
 
-| Command                                | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `import-graph --repo`                  | Import dependency graph with recursive traversal      |
-| `call-hierarchy --symbol --repo`       | Call graph hierarchy (callers/callees)                |
-| `blast-radius --symbol --repo`         | What breaks if a symbol changes                       |
-| `dead-code --repo`                     | Find unused code                                      |
-| `complexity --repo`                    | Cyclomatic complexity per function                    |
-| `outline --repo --file`                | File symbol outline (classes, methods, standalone)    |
-| `churn --repo`                         | Git commit frequency metrics                          |
+| Command                          | Purpose                                            |
+| -------------------------------- | -------------------------------------------------- |
+| `import-graph --repo`            | Import dependency graph with recursive traversal   |
+| `call-hierarchy --symbol --repo` | Call graph hierarchy (callers/callees)             |
+| `blast-radius --symbol --repo`   | What breaks if a symbol changes                    |
+| `dead-code --repo`               | Find unused code                                   |
+| `complexity --repo`              | Cyclomatic complexity per function                 |
+| `outline --repo --file`          | File symbol outline (classes, methods, standalone) |
+| `churn --repo`                   | Git commit frequency metrics                       |
 
 ### Code Analytics (v5.2–v5.3 — hotspots, cycles, importance, coupling, signal chains)
 
-| Command                                | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `hotspots --repo`                      | Top symbols by complexity × churn (bug risk)          |
-| `cycles --repo`                        | Dependency cycles via Tarjan SCC                      |
-| `importance --repo`                    | Symbol PageRank on call graph                         |
-| `coupling --repo`                      | Afferent/efferent/instability per file                 |
-| `extractable --repo`                   | Refactoring candidates                                 |
-| `hierarchy --symbol --repo`            | Class hierarchy from parent_name                       |
-| `signal-chains --repo`                 | Detect HTTP/CLI gateways and trace call chains         |
-| `layer-violations --repo`              | Check import rules against declared architecture layers |
+| Command                     | Purpose                                                 |
+| --------------------------- | ------------------------------------------------------- |
+| `hotspots --repo`           | Top symbols by complexity × churn (bug risk)            |
+| `cycles --repo`             | Dependency cycles via Tarjan SCC                        |
+| `importance --repo`         | Symbol PageRank on call graph                           |
+| `coupling --repo`           | Afferent/efferent/instability per file                  |
+| `extractable --repo`        | Refactoring candidates                                  |
+| `hierarchy --symbol --repo` | Class hierarchy from parent_name                        |
+| `signal-chains --repo`      | Detect HTTP/CLI gateways and trace call chains          |
+| `layer-violations --repo`   | Check import rules against declared architecture layers |
 
 ### Doc Indexing (v5 — markdown sections, links, glossary, code examples)
 
-| Command                                | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `index-docs --path --name`             | Index a markdown doc tree                              |
-| `reindex-docs --repo`                 | Re-index a doc repo                                    |
-| `doc-search --query --repo`            | Full-text search across doc sections                   |
-| `doc-outline --repo --file`            | Section hierarchy outline                              |
-| `backlinks --repo --path`              | Find all docs that link TO a given doc                 |
-| `broken-links --repo`                  | Find broken internal doc links                         |
-| `glossary --repo --term`               | Look up glossary terms                                 |
-| `tutorial-path --section --repo`       | Reconstruct ordered tutorial chain                    |
-| `code-examples --query --repo`         | Search fenced code blocks by content                   |
-| `doc-orphans --repo`                   | Find sections with zero inbound links                  |
-| `doc-coverage --repo`                  | Which code symbols have documentation coverage         |
-| `stale-pages --repo`                  | Find docs modified since last index                     |
-| `doc-duplicates --repo`                | Find duplicate sections by content hash                |
+| Command                          | Purpose                                        |
+| -------------------------------- | ---------------------------------------------- |
+| `index-docs --path --name`       | Index a markdown doc tree                      |
+| `reindex-docs --repo`            | Re-index a doc repo                            |
+| `doc-search --query --repo`      | Full-text search across doc sections           |
+| `doc-outline --repo --file`      | Section hierarchy outline                      |
+| `backlinks --repo --path`        | Find all docs that link TO a given doc         |
+| `broken-links --repo`            | Find broken internal doc links                 |
+| `glossary --repo --term`         | Look up glossary terms                         |
+| `tutorial-path --section --repo` | Reconstruct ordered tutorial chain             |
+| `code-examples --query --repo`   | Search fenced code blocks by content           |
+| `doc-orphans --repo`             | Find sections with zero inbound links          |
+| `doc-coverage --repo`            | Which code symbols have documentation coverage |
+| `stale-pages --repo`             | Find docs modified since last index            |
+| `doc-duplicates --repo`          | Find duplicate sections by content hash        |
 
 ### Workspace Management
 
-| Command                                | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `list-workspaces`                      | List all workspaces                                   |
-| `create-workspace --name`              | Create a workspace                                    |
-| `archive-workspace --name`             | Archive a workspace (soft, data preserved)            |
+| Command                    | Purpose                                    |
+| -------------------------- | ------------------------------------------ |
+| `list-workspaces`          | List all workspaces                        |
+| `create-workspace --name`  | Create a workspace                         |
+| `archive-workspace --name` | Archive a workspace (soft, data preserved) |
 
 ### Maintenance
 
-| Command                                | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `compact`                              | Prune dead links, decay trust, VACUUM, optimize FTS5  |
-| `dream`                                | Dream Cycle — clean **stale** memories (not just old). Auto-runs every 10 sessions |
-| `stats`                                | Database statistics                                    |
-| `list-projects`                        | List all known project names                           |
+| Command         | Purpose                                                                            |
+| --------------- | ---------------------------------------------------------------------------------- |
+| `compact`       | Prune dead links, decay trust, VACUUM, optimize FTS5                               |
+| `dream`         | Dream Cycle — clean **stale** memories (not just old). Auto-runs every 10 sessions |
+| `stats`         | Database statistics                                                                |
+| `list-projects` | List all known project names                                                       |
 
 #### Dream Cycle
 
 Unlike `compact` (housekeeping: vacuum, FTS optimize), the Dream Cycle targets **staleness** — information that is no longer accurate or useful:
 
-| Phase | What it cleans | Why it's stale |
-| ----- | -------------- | ----------------- |
-| Superseded | Memories with `duplicate`/`supersedes` relations | A newer memory replaces it |
-| Stale auto-progress | `progress` & `accomplished` types with zero recall | Never useful, just noise |
-| Stale auto-detected | Auto-detected decisions with zero recall + low trust | Pattern-matched junk never acted on |
-| Stale corrections | Titles starting with "CORRECTION:" | Should've used `update` instead |
-| Replaced configs | Superseded configs (e.g. "using frpc" → "switched to CF Tunnel") | Superseded setup info |
+| Phase               | What it cleans                                                   | Why it's stale                      |
+| ------------------- | ---------------------------------------------------------------- | ----------------------------------- |
+| Superseded          | Memories with `duplicate`/`supersedes` relations                 | A newer memory replaces it          |
+| Stale auto-progress | `progress` & `accomplished` types with zero recall               | Never useful, just noise            |
+| Stale auto-detected | Auto-detected decisions with zero recall + low trust             | Pattern-matched junk never acted on |
+| Stale corrections   | Titles starting with "CORRECTION:"                               | Should've used `update` instead     |
+| Replaced configs    | Superseded configs (e.g. "using frpc" → "switched to CF Tunnel") | Superseded setup info               |
 
 **Age alone is NOT a signal.** A 6-month-old valid decision stays. A 1-day-old superseded one goes.
 
@@ -150,7 +178,7 @@ Create `~/.pi/memory/config.jsonc` to override defaults. The file supports JSONC
     "fts_relevance": 0.4,
     "recency": 0.3,
     "trust": 0.15,
-    "recall": 0.15
+    "recall": 0.15,
   },
 
   // Deduplication thresholds (0.0 - 1.0)
@@ -158,14 +186,14 @@ Create `~/.pi/memory/config.jsonc` to override defaults. The file supports JSONC
     // Auto-merge duplicates at or above this similarity
     "auto_merge_threshold": 0.85,
     // Flag potential duplicates at or above this similarity
-    "warning_threshold": 0.60
+    "warning_threshold": 0.6,
   },
 
   // Run compaction every N sessions for a project (default: 5)
   "compact_every_n_sessions": 5,
 
   // Path to tier config file (default: ~/.pi/memory/tier.jsonc)
-  "tier_config_path": "~/.pi/memory/tier.jsonc"
+  "tier_config_path": "~/.pi/memory/tier.jsonc",
 }
 ```
 
@@ -189,28 +217,29 @@ Measured via `bench/bench-tokens.js` — runs real CLI commands against indexed 
 
 ### Results: Percentage Saved per Tool
 
-| Tool | [PiMemoryExtension](https://github.com/GeneGulanesJr/PiMemoryExtension) | [Aether (PCBuilder)](https://github.com/GeneGulanesJr/Aether) |
-| :--- | :---: | :---: |
-| importance | 27% | 26% |
-| hotspots | 48% | 0% |
-| dead-code | 42% | **47%** |
-| coupling | 33% | **39%** |
-| extraction | 33% | 24% |
-| cycles | 0% | 0% |
-| import-graph | 24% | 20% |
-| **OVERALL** | **36%** | **37%** |
+| Tool         | [PiMemoryExtension](https://github.com/GeneGulanesJr/PiMemoryExtension) | [Aether (PCBuilder)](https://github.com/GeneGulanesJr/Aether) |
+| :----------- | :---------------------------------------------------------------------: | :-----------------------------------------------------------: |
+| importance   |                                   27%                                   |                              26%                              |
+| hotspots     |                                   48%                                   |                              0%                               |
+| dead-code    |                                   42%                                   |                            **47%**                            |
+| coupling     |                                   33%                                   |                            **39%**                            |
+| extraction   |                                   33%                                   |                              24%                              |
+| cycles       |                                   0%                                    |                              0%                               |
+| import-graph |                                   24%                                   |                              20%                              |
+| **OVERALL**  |                                 **36%**                                 |                            **37%**                            |
 
 ### Total Savings
 
-| | PiMemoryExtension | Aether (PCBuilder) |
-| :--- | :---: | :---: |
-| Repo size | 38 files · 210 symbols | 154 files · 1,359 symbols |
-| Raw JSON | 42.6 KB | 181.7 KB |
-| Compact format | 27.1 KB | 114.3 KB |
-| Bytes saved | 15.5 KB | 67.4 KB |
-| Tokens saved | ~4,445 tokens | ~19,242 tokens |
+|                |   PiMemoryExtension    |    Aether (PCBuilder)     |
+| :------------- | :--------------------: | :-----------------------: |
+| Repo size      | 38 files · 210 symbols | 154 files · 1,359 symbols |
+| Raw JSON       |        42.6 KB         |         181.7 KB          |
+| Compact format |        27.1 KB         |         114.3 KB          |
+| Bytes saved    |        15.5 KB         |          67.4 KB          |
+| Tokens saved   |     ~4,445 tokens      |      ~19,242 tokens       |
 
 **Key findings:**
+
 - Dead-code sees the biggest gains (42–47%) — the `signals` and `confidence` fields are uniform across rows and get hoisted, while `symbol_id` is stripped
 - Coupling benefits from prefix interning on shared file paths (33–39%)
 - Larger repos trend higher — Aether (154 files, 1,359 symbols) edged out PiMemoryExtension (38 files) at 37% vs 36%
@@ -219,6 +248,7 @@ Measured via `bench/bench-tokens.js` — runs real CLI commands against indexed 
 All transforms are **lossless round-trip** — verified by 217 tests in `test/wire-format.test.js`.
 
 Run it yourself:
+
 ```bash
 node bench/bench-tokens.js
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,64 @@
+# LaPis Architecture
+
+LaPis is a modular monolith: it ships as one Node.js package and Pi extension, but each feature area has a defined owner, dependency boundary, and test surface.
+
+For the detailed extraction assessment and rationale, see [`ARCHITECTURE_MODULARIZATION.md`](ARCHITECTURE_MODULARIZATION.md). For a directory-by-directory ownership table, see [`MODULE_MAP.md`](MODULE_MAP.md).
+
+## Runtime layers
+
+```text
+Pi Agent
+  -> extensions/memory-layer/        # Pi hooks, tools, host adapters, formatting adapters
+  -> memory-store.js / cli.js        # CLI entry points and command dispatch setup
+  -> src/cli/                        # command gateway and feature routers
+  -> src/{feature}/                  # independently testable feature services
+  -> src/platform/ + data-access/    # storage, repositories, protocol formatting
+```
+
+## Layer responsibilities
+
+### Pi extension adapters
+
+`extensions/memory-layer/` registers Pi hooks and tools, performs project detection and native dependency health checks, and adapts backend results for LLM/tool responses. It should degrade gracefully when a feature adapter fails and should not contain raw SQL, parser internals, or feature business logic.
+
+### CLI command gateway
+
+`src/cli/gateway.js` composes feature routers from `src/cli/commands/`. Routers map CLI arguments to feature services and preserve command behavior for `memory-store.js`; they should not become a second implementation of feature logic.
+
+### Feature services
+
+Feature services live under `src/` and own one feature family each:
+
+- `src/memory-domain/` — declarative memory: observations, search, context, sessions, recall, dedupe, compaction, and workspaces.
+- `src/workflow-memory/` — procedural workflow memory and step outcomes.
+- `src/code-index/` — repository scanning, parsing, symbol extraction, edge extraction, incremental indexing, and source retrieval.
+- `src/code-analysis/` — graph, impact, quality, git-aware, and risk analysis over the code-index read model.
+- `src/doc-index/` — Markdown documentation indexing and documentation intelligence.
+- `src/trust-sync/` — explicit integration between memory observations and code symbols.
+
+### Platform helpers
+
+`src/platform/` owns shared platform concerns such as storage composition and protocol/output formatting. Feature modules should receive repositories or typed helpers rather than importing unrelated feature internals.
+
+## Dependency rules
+
+1. `extensions/*` may depend on backend clients and formatting adapters, but not raw SQL or parser internals.
+2. `memory-domain` may depend on storage, config, and ranking constants, but not code/doc parsers.
+3. `workflow-memory` may depend on storage and project identity only.
+4. `code-index` may depend on parser, filesystem, hashing, and storage helpers, but not memory observation ranking.
+5. `code-analysis` may depend on code-index read repositories and git metrics, but not Pi extension state.
+6. `doc-index` may depend on Markdown/doc storage; documentation coverage may depend only on a narrow code-symbol lookup.
+7. `trust-sync` is the only feature module that should coordinate memory observations with code symbol tables.
+8. `platform/protocol` owns `_meta`, compact/auto output, and LLM-facing transformations.
+9. Crosshash remains behind a command/API boundary until it fully replaces the JavaScript code-intelligence path.
+
+## Testability expectations
+
+Each feature module should have:
+
+- A public service interface with typed or well-documented inputs and outputs.
+- Repository interfaces or fixtures for tests.
+- Unit tests that do not start the Pi extension.
+- Integration tests against a temporary SQLite database for storage behavior.
+- CLI/router tests that verify argument mapping and delegation only.
+- Failure-mode tests proving a module failure returns a scoped error and does not break unrelated features.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,65 +1,9 @@
 # Contributing to LaPis
 
-## Baseline Verification Commands
+The canonical contributor guide lives at [`../CONTRIBUTING.md`](../CONTRIBUTING.md). It explains where to add features, the module dependency boundaries, and the required verification commands.
 
-Run these from a clean checkout to verify the codebase is healthy:
+Useful companion docs:
 
-```bash
-# 1. Run the full test suite (vitest)
-npm test
-
-# 2. Run smoke CLI tests (every CLI command as subprocess)
-node test/smoke-cli.js
-
-# 3. Lint and format checks
-npm run check
-```
-
-All three must pass before any PR is merged.
-
-## Extraction PRs
-
-PRs labeled `architecture` or `refactor` that touch modularization code (issues #75–#84) have additional requirements:
-
-1. **Full test suite must pass** — no exceptions.
-2. **Smoke CLI tests must pass** — every command that moved to a new router must still work.
-3. **Legitimate test changes must be documented** — if an extraction causes a test's expected behavior to change, update the test in the same PR and explain in the PR description.
-
-## Test Commands Reference
-
-| Command | What it checks | When to run |
-|---|---|---|
-| `npm test` | Full vitest suite (unit + integration) | Every PR |
-| `node test/smoke-cli.js` | Every CLI subcommand via subprocess | Every extraction PR |
-| `npm run lint` | oxlint static analysis | Every PR |
-| `npm run format:check` | oxfmt formatting check | Every PR |
-| `npm run check` | Lint + format combined | Every PR |
-
-## CI
-
-GitHub Actions runs on every push and PR to `main`:
-
-- **test.yml** — install, lint, full test suite, smoke CLI tests
-- **crosshash-ci.yml** — Rust lint/test for `crosshash/` submodule
-
-## Project Structure
-
-```
-memory-store.js          — CLI entry point (delegates to cli.js)
-extensions/
-  memory-layer/          — Pi extension (composition root)
-    host/                — Memory client, project detector, repo cache
-    hooks/               — Session lifecycle, context injection, passive capture
-    tools/               — Memory tools, code tools, doc tools
-src/                     — (Post-extraction) Feature domains
-  memory-domain/
-  workflow-memory/
-  code-index/
-  code-analysis/
-  doc-index/
-  trust-sync/
-  platform/protocol/
-  cli/commands/
-test/                    — Vitest unit/integration tests
-  smoke-cli.js           — CLI subprocess smoke tests
-```
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — concise architecture overview.
+- [`MODULE_MAP.md`](MODULE_MAP.md) — authoritative module ownership and dependency table.
+- [`ARCHITECTURE_MODULARIZATION.md`](ARCHITECTURE_MODULARIZATION.md) — detailed modularization assessment and extraction rationale.

--- a/docs/MODULE_MAP.md
+++ b/docs/MODULE_MAP.md
@@ -1,0 +1,37 @@
+# Module Map
+
+This document is the source of truth for LaPis module ownership. Update it whenever a PR adds, removes, renames, or changes the dependency boundary of a module.
+
+## Source modules
+
+| Feature area | Module directory | Entry point | Owns | Allowed dependencies | Must not depend on |
+| --- | --- | --- | --- | --- | --- |
+| CLI command gateway | `src/cli/` | `src/cli/gateway.js` | Command map composition and feature router registration. | Feature command routers and feature service modules. | Raw feature implementation details beyond router delegation; Pi extension state. |
+| Declarative memory domain | `src/memory-domain/` | `src/memory-domain/index.js` | Observations, memory search, context loading, sessions, recall logging, dedupe, compaction, and workspaces. | Storage/repository helpers, configuration, ranking constants, project identity. | Code/doc parsers, code-analysis internals, Pi extension state. |
+| Procedural workflow memory | `src/workflow-memory/` | `src/workflow-memory/index.js` | Saved workflows, ordered steps, step outcomes, and workflow scoring. | Storage/repository helpers and project identity. | Observation ranking internals, code/doc parsers, Pi extension state. |
+| Code indexing and retrieval | `src/code-index/` | `src/code-index/index.js` | Repository registration, scanning, language/parser selection, symbol extraction, import/call edge extraction, incremental indexing, and source retrieval. | Filesystem utilities, parser registry, hashing, code-index storage repositories. | Memory observation ranking, doc-index internals, Pi extension state. |
+| Code analysis and intelligence | `src/code-analysis/` | `src/code-analysis/index.js` | Import/call graph queries, blast radius, dead code, complexity, hotspots, cycles, importance, coupling, hierarchy, signal chains, layer violations, query winnowing, and risk analysis. | Code-index read model/repositories, git metrics, analysis formatters. | Pi extension state, memory observation CRUD, parser write-path internals. |
+| Documentation indexing and intelligence | `src/doc-index/` | `src/doc-index/index.js` | Markdown parsing, doc repository indexing, section search, backlinks, broken links, glossary terms, tutorial paths, code examples, stale/duplicate/orphan analytics, and doc coverage reports. | Markdown/doc storage repositories; a narrow code-symbol lookup for coverage only. | Memory-domain internals, code-analysis internals, Pi extension state. |
+| Trust synchronization | `src/trust-sync/` | `src/trust-sync/index.js` | Memory-to-code-symbol links, related memory lookup, trust policy, and code-change detection for trust updates. | Memory repositories, code-symbol repositories, git/code change metadata. | Unrelated feature internals; direct doc-index behavior. |
+| Platform services | `src/platform/` | `src/platform/storage/index.js`, `src/platform/protocol/envelope.js` | Shared storage composition, repository construction, protocol envelopes, compact output, and LLM-facing transformations. | Database adapters, repository factories, typed feature results, constants. | Feature business logic, Pi extension state, command parsing. |
+
+## Extension and support modules
+
+| Area | Directory | Owns | Boundary |
+| --- | --- | --- | --- |
+| Pi extension integration | `extensions/memory-layer/` | Pi hook registration, tool schemas, context injection, passive capture, trust-sync hooks, project detection, native dependency health checks, and tool result formatting. | Adapter layer only; do not add raw SQL, parser internals, or backend feature business logic here. |
+| Legacy/runtime CLI entry | `memory-store.js`, `cli.js`, `commands/` | Backwards-compatible command entry points and legacy command modules while extraction continues. | Prefer moving new feature behavior into `src/` modules and routing through `src/cli/`. |
+| Data access helpers | `data-access/` | Repository-style SQL helpers used by current runtime code. | Keep SQL ownership clear; do not mix presentation formatting into repositories. |
+| Crosshash Rust engine | `crosshash/` | Rust code-intelligence engine experiments and future backend work. | Keep behind a command/API boundary until it replaces the JavaScript code-intelligence path. |
+
+## When to update this file
+
+Update this module map when a change:
+
+- Adds or removes a top-level `src/` feature module.
+- Renames a module, entry point, or feature router.
+- Moves ownership of a command, table, repository, parser, formatter, or analysis routine.
+- Changes which modules are allowed to depend on each other.
+- Adds a new integration boundary between two feature modules.
+
+Also update the matching module-boundary comment in the relevant entry point so the code and docs stay aligned.

--- a/src/cli/gateway.js
+++ b/src/cli/gateway.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns CLI command-map composition and feature router registration. Routers map
+// Command arguments to feature services; business logic belongs in feature
+// Modules, and Pi extension state must stay outside this gateway.
+
 const memoryRouter = require('./commands/memory');
 const workflowRouter = require('./commands/workflow');
 const codeIndexRouter = require('./commands/code-index');
@@ -32,4 +37,9 @@ function getAllUsage() {
   };
 }
 
-module.exports = { buildCommandMap, getAllUsage, ANALYSIS_TOOLS: codeAnalysisRouter.ANALYSIS_TOOLS, _wrapAnalysis: codeAnalysisRouter._wrapAnalysis };
+module.exports = {
+  buildCommandMap,
+  getAllUsage,
+  ANALYSIS_TOOLS: codeAnalysisRouter.ANALYSIS_TOOLS,
+  _wrapAnalysis: codeAnalysisRouter._wrapAnalysis,
+};

--- a/src/code-analysis/index.js
+++ b/src/code-analysis/index.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns code intelligence queries over the code-index read model: graph, impact,
+// Quality, git-aware, and risk analysis. Depends on code-index repositories and
+// Git metrics; must not depend on Pi extension state or memory CRUD internals.
+
 const graph = require('./graph');
 const impact = require('./impact');
 const quality = require('./quality');

--- a/src/code-index/index.js
+++ b/src/code-index/index.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns code indexing and retrieval: repository discovery, scanning, parser
+// Selection, symbol/edge extraction, incremental indexing, and source lookup.
+// Must not depend on memory observation ranking or Pi extension state.
+
 module.exports = {
   ...require('./edge-extractor'),
   ...require('./incremental-indexer'),

--- a/src/doc-index/index.js
+++ b/src/doc-index/index.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns documentation indexing and intelligence: Markdown sections, links,
+// Glossary terms, examples, and doc analytics. Coverage may use a narrow code
+// Symbol lookup, but this module must not depend on memory/code-analysis internals.
+
 const { withDb } = require('../../utils');
 const repos = require('./repos');
 const markdownParser = require('./markdown-parser');

--- a/src/memory-domain/index.js
+++ b/src/memory-domain/index.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns declarative memory: observations, search, context, sessions, recall,
+// Dedupe, compaction, and workspaces. Depends on storage/config/ranking
+// Helpers only; must not depend on code or documentation parser internals.
+
 module.exports = {
   observations: require('./observations'),
   search: require('./search'),

--- a/src/platform/protocol/envelope.js
+++ b/src/platform/protocol/envelope.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns response envelopes, freshness/confidence metadata, and protocol-level
+// Result shaping. Feature business logic should return data for this boundary
+// To wrap rather than formatting LLM-facing responses itself.
+
 /**
  * Response-meta.js — Metadata envelope for every analysis response
  *

--- a/src/platform/storage/index.js
+++ b/src/platform/storage/index.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns shared storage context creation and repository composition. Feature
+// Modules should receive repositories/helpers from here instead of importing
+// Unrelated SQL or presentation concerns directly.
+
 const db = require('../../../db');
 const { createRepositories } = require('./repositories');
 

--- a/src/trust-sync/index.js
+++ b/src/trust-sync/index.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns the integration between declarative memories and indexed code symbols:
+// Symbol links, related-memory lookup, trust policy, and change detection. This
+// Is the only feature module that should coordinate memory and code tables.
+
 module.exports = {
   ...require('./symbol-links'),
   ...require('./related-memory'),

--- a/src/workflow-memory/index.js
+++ b/src/workflow-memory/index.js
@@ -1,3 +1,8 @@
+// Module boundary:
+// Owns procedural workflow memory: saved workflows, ordered steps, step
+// Outcomes, and scoring. Depends on storage/project identity only; must not
+// Depend on declarative-memory ranking or code/doc parser internals.
+
 const workflows = require('./workflows');
 const steps = require('./steps');
 const scoring = require('./scoring');


### PR DESCRIPTION
### Motivation

- Provide an authoritative contributor guide and concise architecture docs to standardize where to add features and which verification steps are required.  
- Make module ownership and dependency boundaries explicit to reduce incorrect cross-module imports during ongoing extractions/refactors.  
- Capture required PR checklist items and surface the `docs/MODULE_MAP.md` update requirement in the PR template.  

### Description

- Add `CONTRIBUTING.md` with baseline verification commands, module ownership table, dependency boundaries, and extraction/refactor requirements.  
- Add `docs/ARCHITECTURE.md` and `docs/MODULE_MAP.md` as the canonical architecture overview and module ownership reference.  
- Update `README.md` with a Development section, command/table formatting fixes, and small config examples/formatting tweaks.  
- Update `.github/pull_request_template.md` to include a checklist item requiring updates to `docs/MODULE_MAP.md` when modules change.  
- Annotate multiple module entry points with module-boundary comments and reorganize exports where appropriate, including `src/cli/gateway.js`, `src/code-index/index.js`, `src/code-analysis/index.js`, `src/doc-index/index.js`, `src/memory-domain/index.js`, `src/platform/protocol/envelope.js`, `src/platform/storage/index.js`, `src/trust-sync/index.js`, and `src/workflow-memory/index.js`.  

### Testing

- No automated tests were executed as part of this change; CI will run the repository test workflow.  
- Recommended verification before merge: run `npm test`, `node test/smoke-cli.js`, and `npm run check` as documented in `CONTRIBUTING.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0733928098832fa13631045d56da6e)