### PR TITLE
Normalize memory tool outputs, add validation/help and safety tests for memory-code/doc

### DIFF
--- a/extensions/memory-layer/tools/code-tools.ts
+++ b/extensions/memory-layer/tools/code-tools.ts
@@ -1,8 +1,9 @@
+import { mem, memStreaming } from '../host/memory-client';
+import { normalizeToolResult, stringifyToolError, toolTextResult } from './tool-result';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
-import { mem, memStreaming } from '../host/memory-client';
-import { getKnownRepos } from '../host/project-detector';
 import { formatCodeResult } from './format-code-result';
+import { getKnownRepos } from '../host/project-detector';
 
 interface CodeDeps {
   mem: typeof mem;
@@ -21,30 +22,32 @@ export function registerCodeTools(pi: ExtensionAPI, deps: CodeDeps) {
       'Requires the repo to be indexed first (use mode `index-repo`). ' +
       'Modes: callers, callees, blast-radius, dead-code, complexity, deps, outline, churn, hotspots, cycles, importance, coupling, extractable, hierarchy, signal-chains, layer-violations, index-repo, reindex-repo.',
     parameters: Type.Object({
-      mode: Type.String({
-        description:
-          'Analysis mode: callers|callees|blast-radius|dead-code|complexity|deps|outline|churn|hotspots|cycles|importance|coupling|extractable|hierarchy|signal-chains|layer-violations|index-repo|reindex-repo',
-        enum: [
-          'callers',
-          'callees',
-          'blast-radius',
-          'dead-code',
-          'complexity',
-          'deps',
-          'outline',
-          'churn',
-          'hotspots',
-          'cycles',
-          'importance',
-          'coupling',
-          'extractable',
-          'hierarchy',
-          'signal-chains',
-          'layer-violations',
-          'index-repo',
-          'reindex-repo',
-        ],
-      }),
+      mode: Type.Optional(
+        Type.String({
+          description:
+            'Analysis mode: callers|callees|blast-radius|dead-code|complexity|deps|outline|churn|hotspots|cycles|importance|coupling|extractable|hierarchy|signal-chains|layer-violations|index-repo|reindex-repo',
+          enum: [
+            'callers',
+            'callees',
+            'blast-radius',
+            'dead-code',
+            'complexity',
+            'deps',
+            'outline',
+            'churn',
+            'hotspots',
+            'cycles',
+            'importance',
+            'coupling',
+            'extractable',
+            'hierarchy',
+            'signal-chains',
+            'layer-violations',
+            'index-repo',
+            'reindex-repo',
+          ],
+        }),
+      ),
       repo: Type.Optional(
         Type.String({ description: 'Indexed repo name (required for analysis modes, optional for index-repo)' }),
       ),
@@ -86,167 +89,219 @@ export function registerCodeTools(pi: ExtensionAPI, deps: CodeDeps) {
       ),
     }),
     async execute(_id, params, _signal, onUpdate, _ctx) {
+      params = params ?? {};
       try {
-      const cmdMap: Record<string, string> = {
-        callers: 'call-hierarchy',
-        callees: 'call-hierarchy',
-        'blast-radius': 'blast-radius',
-        'dead-code': 'dead-code',
-        complexity: 'complexity',
-        deps: 'import-graph',
-        outline: 'outline',
-        churn: 'churn',
-        hotspots: 'hotspots',
-        cycles: 'cycles',
-        importance: 'importance',
-        coupling: 'coupling',
-        extractable: 'extractable',
-        hierarchy: 'hierarchy',
-        'signal-chains': 'signal-chains',
-        'layer-violations': 'layer-violations',
-        'index-repo': 'index-repo',
-        'reindex-repo': 'reindex-repo',
-      };
-      const cmd = cmdMap[params.mode];
-      if (!cmd) {
-        return { content: [{ type: 'text', text: `Unknown mode: ${params.mode}` }], details: {}, isError: true };
-      }
-
-      const args: Record<string, string> = {};
-      if (params.repo) {
-        args.repo = params.repo;
-      }
-      if (params.symbol) {
-        args.symbol = params.symbol;
-      }
-      if (params.file) {
-        args.file = params.file;
-      }
-      if (params.depth) {
-        args.depth = String(params.depth);
-      }
-      if (params.direction) {
-        args.direction = params.direction;
-      }
-      if (cmd === 'call-hierarchy') {
-        args.direction = params.mode === 'callers' ? 'callers' : 'callees';
-      }
-      if (params.min_confidence) {
-        args['min-confidence'] = String(params.min_confidence);
-      }
-      if (params.days) {
-        args.days = String(params.days);
-      }
-      if (params.refresh) {
-        args.refresh = 'true';
-      }
-      if (params.top) {
-        args.top = String(params.top);
-      }
-      if (params.scope) {
-        args.scope = params.scope;
-      }
-      if (params.sort_by) {
-        args['sort-by'] = params.sort_by;
-      }
-      if (params.min_complexity) {
-        args['min-complexity'] = String(params.min_complexity);
-      }
-      if (params.min_callers) {
-        args['min-callers'] = String(params.min_callers);
-      }
-      if (params.direction_hier) {
-        args.direction = params.direction_hier;
-      }
-      if (params.kind) {
-        args.kind = params.kind;
-      }
-      if (params.symbol_chain) {
-        args.symbol = String(params.symbol_chain);
-      }
-      if (params.path) {
-        args.path = params.path;
-      }
-      if (params.name) {
-        args.name = params.name;
-      }
-      if (params.rules) {
-        args.rules = typeof params.rules === 'string' ? params.rules : JSON.stringify(params.rules);
-      }
-
-      if (params.mode === 'index-repo' || params.mode === 'reindex-repo') {
-        const result = await deps.memStreaming(cmd, args, (msg: string) => {
-          try {
-            onUpdate({ type: 'progress', message: msg });
-          } catch {
-            /* Ignore if onUpdate not supported */
-          }
-        });
-        if (!result) {
-          return { content: [{ type: 'text', text: 'Indexing failed or timed out.' }], details: {}, isError: true };
-        }
-        if (result.error) {
-          return { content: [{ type: 'text', text: `Error: ${result.error}` }], details: result ?? {}, isError: true };
-        }
-        let fmt: string | undefined | null;
-        try { fmt = deps.formatCodeResult(params.mode, result); } catch { fmt = ''; }
-        return { content: [{ type: 'text', text: fmt ?? '' }], details: result ?? {} };
-      }
-
-      const codeRepos = await deps.getKnownRepos();
-      const repoMatch = codeRepos.find((r) => r.name.toLowerCase() === params.repo?.toLowerCase());
-      if (!repoMatch) {
-        const available = codeRepos.map((r) => r.name).join(', ') || 'none';
-        const cwd = process.cwd();
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `❌ Repo \"${params.repo}\" is not indexed. Available repos: ${available}\n\nTo index this repo, run:\n\`memory-code index-repo --path ${cwd} --name ${params.repo}\``,
-            },
-          ],
-          details: {},
-          isError: true,
+        const cmdMap: Record<string, string> = {
+          callers: 'call-hierarchy',
+          callees: 'call-hierarchy',
+          'blast-radius': 'blast-radius',
+          'dead-code': 'dead-code',
+          complexity: 'complexity',
+          deps: 'import-graph',
+          outline: 'outline',
+          churn: 'churn',
+          hotspots: 'hotspots',
+          cycles: 'cycles',
+          importance: 'importance',
+          coupling: 'coupling',
+          extractable: 'extractable',
+          hierarchy: 'hierarchy',
+          'signal-chains': 'signal-chains',
+          'layer-violations': 'layer-violations',
+          'index-repo': 'index-repo',
+          'reindex-repo': 'reindex-repo',
         };
-      }
+        const mode = typeof params.mode === 'string' ? params.mode : '';
+        if (!mode) {
+          return toolTextResult(codeHelpText());
+        }
 
-      const result = await deps.mem(cmd, args);
-      if (!result) {
-        if (
-          cmd === 'dead-code' ||
-          cmd === 'cycles' ||
-          cmd === 'importance' ||
-          cmd === 'coupling' ||
-          cmd === 'signal-chains' ||
-          cmd === 'import-graph'
-        ) {
-          return {
+        const cmd = cmdMap[mode];
+        if (!cmd) {
+          return toolTextResult(`Unknown memory-code mode: ${mode}\n\n${codeHelpText()}`, {}, true);
+        }
+
+        const validationError = validateCodeParams(mode, params);
+        if (validationError) {
+          return toolTextResult(validationError, {}, true);
+        }
+
+        const args: Record<string, string> = {};
+        if (params.repo) {
+          args.repo = params.repo;
+        }
+        if (params.symbol) {
+          args.symbol = params.symbol;
+        }
+        if (params.file) {
+          args.file = params.file;
+        }
+        if (params.depth) {
+          args.depth = String(params.depth);
+        }
+        if (params.direction) {
+          args.direction = params.direction;
+        }
+        if (cmd === 'call-hierarchy') {
+          args.direction = mode === 'callers' ? 'callers' : 'callees';
+        }
+        if (params.min_confidence) {
+          args['min-confidence'] = String(params.min_confidence);
+        }
+        if (params.days) {
+          args.days = String(params.days);
+        }
+        if (params.refresh) {
+          args.refresh = 'true';
+        }
+        if (params.top) {
+          args.top = String(params.top);
+        }
+        if (params.scope) {
+          args.scope = params.scope;
+        }
+        if (params.sort_by) {
+          args['sort-by'] = params.sort_by;
+        }
+        if (params.min_complexity) {
+          args['min-complexity'] = String(params.min_complexity);
+        }
+        if (params.min_callers) {
+          args['min-callers'] = String(params.min_callers);
+        }
+        if (params.direction_hier) {
+          args.direction = params.direction_hier;
+        }
+        if (params.kind) {
+          args.kind = params.kind;
+        }
+        if (params.symbol_chain) {
+          args.symbol = String(params.symbol_chain);
+        }
+        if (params.path) {
+          args.path = params.path;
+        }
+        if (params.name) {
+          args.name = params.name;
+        }
+        if (params.rules) {
+          args.rules = typeof params.rules === 'string' ? params.rules : JSON.stringify(params.rules);
+        }
+
+        if (mode === 'index-repo' || mode === 'reindex-repo') {
+          const result = await deps.memStreaming(cmd, args, (msg: string) => {
+            try {
+              onUpdate({ type: 'progress', message: msg });
+            } catch {
+              /* Ignore if onUpdate not supported */
+            }
+          });
+          if (!result) {
+            return toolTextResult('Indexing failed or timed out.', {}, true);
+          }
+          if (result.error) {
+            return toolTextResult(`Error: ${result.error}`, result ?? {}, true);
+          }
+          let fmt: string | undefined | null;
+          try {
+            fmt = deps.formatCodeResult(mode, result);
+          } catch {
+            fmt = '';
+          }
+          return toolTextResult(fmt || 'Indexing completed.', result ?? {});
+        }
+
+        const codeRepos = await deps.getKnownRepos();
+        const repoMatch = codeRepos.find((r) => r.name.toLowerCase() === params.repo?.toLowerCase());
+        if (!repoMatch) {
+          const available = codeRepos.map((r) => r.name).join(', ') || 'none';
+          const cwd = process.cwd();
+          return normalizeToolResult({
             content: [
               {
                 type: 'text',
-                text: `Analysis timed out or failed for \"${params.mode}\". Try reducing scope or depth, or re-index the repo.\nCommand: ${cmd} on repo \"${params.repo}\"`,
+                text: `❌ Repo \"${params.repo}\" is not indexed. Available repos: ${available}\n\nTo index this repo, run:\n\`memory-code index-repo --path ${cwd} --name ${params.repo}\``,
               },
             ],
             details: {},
             isError: true,
-          };
+          });
         }
-        return { content: [{ type: 'text', text: 'Analysis failed.' }], details: {}, isError: true };
-      }
-      if (result.error) {
-        return { content: [{ type: 'text', text: `Error: ${result.error}` }], details: result ?? {}, isError: true };
-      }
 
-      let fmt: string | undefined | null;
-      try { fmt = deps.formatCodeResult(params.mode, result); } catch { fmt = ''; }
-      return { content: [{ type: 'text', text: fmt ?? '' }], details: result ?? {} };
+        const result = await deps.mem(cmd, args);
+        if (!result) {
+          if (
+            cmd === 'dead-code' ||
+            cmd === 'cycles' ||
+            cmd === 'importance' ||
+            cmd === 'coupling' ||
+            cmd === 'signal-chains' ||
+            cmd === 'import-graph'
+          ) {
+            return normalizeToolResult({
+              content: [
+                {
+                  type: 'text',
+                  text: `Analysis timed out or failed for \"${mode}\". Try reducing scope or depth, or re-index the repo.\nCommand: ${cmd} on repo \"${params.repo}\"`,
+                },
+              ],
+              details: {},
+              isError: true,
+            });
+          }
+          return toolTextResult('Analysis failed.', {}, true);
+        }
+        if (result.error) {
+          return toolTextResult(`Error: ${result.error}`, result ?? {}, true);
+        }
+
+        let fmt: string | undefined | null;
+        try {
+          fmt = deps.formatCodeResult(mode, result);
+        } catch {
+          fmt = '';
+        }
+        return toolTextResult(fmt || `No ${mode} results found.`, result ?? {});
       } catch (err) {
-        return {
-          content: [{ type: 'text', text: `Unexpected error: ${err instanceof Error ? err.message : String(err)}` }],
-          details: {},
-          isError: true,
-        };
+        return toolTextResult(`Unexpected error: ${stringifyToolError(err)}`, {}, true);
       }
     },
   });
+}
+
+function codeHelpText(): string {
+  return [
+    'memory-code requires a mode.',
+    '',
+    'Examples:',
+    '- memory-code outline --repo <repo> --file src/foo.ts',
+    '- memory-code callers --repo <repo> --symbol MyClass.method',
+    '- memory-code reindex-repo --path . --name <repo>',
+    '',
+    'Modes: callers, callees, blast-radius, dead-code, complexity, deps, outline, churn, hotspots, cycles, importance, coupling, extractable, hierarchy, signal-chains, layer-violations, index-repo, reindex-repo.',
+  ].join('\n');
+}
+
+function validateCodeParams(mode: string, params: Record<string, any>): string | null {
+  if (mode === 'index-repo' && !params.path) {
+    return 'index-repo requires --path.\n\nExample:\nmemory-code index-repo --path . --name <repo>';
+  }
+
+  if (mode === 'reindex-repo' && !params.path && !params.repo) {
+    return 'reindex-repo requires --path or --repo.\n\nExamples:\nmemory-code reindex-repo --path . --name <repo>\nmemory-code reindex-repo --repo <repo>';
+  }
+
+  if (mode !== 'index-repo' && mode !== 'reindex-repo' && !params.repo) {
+    return `${mode} requires --repo.\n\nExample:\nmemory-code ${mode} --repo <repo>`;
+  }
+
+  if (['callers', 'callees', 'blast-radius', 'complexity'].includes(mode) && !params.symbol) {
+    return `${mode} requires --symbol.\n\nExample:\nmemory-code ${mode} --repo ${params.repo || '<repo>'} --symbol <symbol>`;
+  }
+
+  if (['outline', 'churn'].includes(mode) && !params.file) {
+    return `${mode} requires --file.\n\nExample:\nmemory-code ${mode} --repo ${params.repo || '<repo>'} --file src/foo.ts`;
+  }
+
+  return null;
 }

--- a/extensions/memory-layer/tools/doc-tools.ts
+++ b/extensions/memory-layer/tools/doc-tools.ts
@@ -1,8 +1,9 @@
+import { normalizeToolResult, stringifyToolError, toolTextResult } from './tool-result';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
-import { mem } from '../host/memory-client';
-import { getKnownRepos } from '../host/project-detector';
 import { formatDocResult } from './format-doc-result';
+import { getKnownRepos } from '../host/project-detector';
+import { mem } from '../host/memory-client';
 
 interface DocDeps {
   mem: typeof mem;
@@ -19,25 +20,27 @@ export function registerDocTools(pi: ExtensionAPI, deps: DocDeps) {
       'Requires docs to be indexed first (use mode `index-docs`). ' +
       'Modes: search, outline, backlinks, broken-links, glossary, tutorial-path, code-examples, orphans, coverage, stale-pages, duplicates, index-docs, reindex-docs.',
     parameters: Type.Object({
-      mode: Type.String({
-        description:
-          'Query mode: search|outline|backlinks|broken-links|glossary|tutorial-path|code-examples|orphans|coverage|stale-pages|duplicates|index-docs|reindex-docs',
-        enum: [
-          'search',
-          'outline',
-          'backlinks',
-          'broken-links',
-          'glossary',
-          'tutorial-path',
-          'code-examples',
-          'orphans',
-          'coverage',
-          'stale-pages',
-          'duplicates',
-          'index-docs',
-          'reindex-docs',
-        ],
-      }),
+      mode: Type.Optional(
+        Type.String({
+          description:
+            'Query mode: search|outline|backlinks|broken-links|glossary|tutorial-path|code-examples|orphans|coverage|stale-pages|duplicates|index-docs|reindex-docs',
+          enum: [
+            'search',
+            'outline',
+            'backlinks',
+            'broken-links',
+            'glossary',
+            'tutorial-path',
+            'code-examples',
+            'orphans',
+            'coverage',
+            'stale-pages',
+            'duplicates',
+            'index-docs',
+            'reindex-docs',
+          ],
+        }),
+      ),
       repo: Type.Optional(
         Type.String({ description: 'Indexed doc repo name (required for query modes, optional for index-docs)' }),
       ),
@@ -62,119 +65,171 @@ export function registerDocTools(pi: ExtensionAPI, deps: DocDeps) {
       ignore: Type.Optional(Type.String({ description: 'Glob pattern to ignore during doc indexing' })),
     }),
     async execute(_id, params, _signal, _onUpdate, _ctx) {
+      params = params ?? {};
       try {
-      const cmdMap: Record<string, string> = {
-        search: 'doc-search',
-        outline: 'doc-outline',
-        backlinks: 'backlinks',
-        'broken-links': 'broken-links',
-        glossary: 'glossary',
-        'tutorial-path': 'tutorial-path',
-        'code-examples': 'code-examples',
-        orphans: 'doc-orphans',
-        coverage: 'doc-coverage',
-        'stale-pages': 'stale-pages',
-        duplicates: 'doc-duplicates',
-        'index-docs': 'index-docs',
-        'reindex-docs': 'reindex-docs',
-      };
-      const cmd = cmdMap[params.mode];
-      if (!cmd) {
-        return { content: [{ type: 'text', text: `Unknown mode: ${params.mode}` }], details: {}, isError: true };
-      }
+        const cmdMap: Record<string, string> = {
+          search: 'doc-search',
+          outline: 'doc-outline',
+          backlinks: 'backlinks',
+          'broken-links': 'broken-links',
+          glossary: 'glossary',
+          'tutorial-path': 'tutorial-path',
+          'code-examples': 'code-examples',
+          orphans: 'doc-orphans',
+          coverage: 'doc-coverage',
+          'stale-pages': 'stale-pages',
+          duplicates: 'doc-duplicates',
+          'index-docs': 'index-docs',
+          'reindex-docs': 'reindex-docs',
+        };
+        const mode = typeof params.mode === 'string' ? params.mode : '';
+        if (!mode) {
+          return toolTextResult(docHelpText());
+        }
 
-      const args: Record<string, string> = {};
-      if (params.repo) {
-        args.repo = params.repo;
-      }
-      if (params.query) {
-        args.query = params.query;
-      }
-      if (params.file) {
-        args.file = params.file;
-      }
-      if (params.doc_path) {
-        args.path = params.doc_path;
-      }
-      if (params.term) {
-        args.term = params.term;
-      }
-      if (params.section) {
-        args.section = String(params.section);
-      }
-      if (params.level) {
-        args.level = String(params.level);
-      }
-      if (params.role) {
-        args.role = params.role;
-      }
-      if (params.lang) {
-        args.lang = params.lang;
-      }
-      if (params.include_same_doc) {
-        args['include-same-doc'] = 'true';
-      }
-      if (params.doc_repo) {
-        args['doc-repo'] = params.doc_repo;
-      }
-      if (params.path) {
-        args.path = params.path;
-      }
-      if (params.name) {
-        args.name = params.name;
-      }
-      if (params.ignore) {
-        args.ignore = params.ignore;
-      }
+        const cmd = cmdMap[mode];
+        if (!cmd) {
+          return toolTextResult(`Unknown memory-doc mode: ${mode}\n\n${docHelpText()}`, {}, true);
+        }
 
-      if (params.mode === 'index-docs' || params.mode === 'reindex-docs') {
+        const validationError = validateDocParams(mode, params);
+        if (validationError) {
+          return toolTextResult(validationError, {}, true);
+        }
+
+        const args: Record<string, string> = {};
+        if (params.repo) {
+          args.repo = params.repo;
+        }
+        if (params.query) {
+          args.query = params.query;
+        }
+        if (params.file) {
+          args.file = params.file;
+        }
+        if (params.doc_path) {
+          args.path = params.doc_path;
+        }
+        if (params.term) {
+          args.term = params.term;
+        }
+        if (params.section) {
+          args.section = String(params.section);
+        }
+        if (params.level) {
+          args.level = String(params.level);
+        }
+        if (params.role) {
+          args.role = params.role;
+        }
+        if (params.lang) {
+          args.lang = params.lang;
+        }
+        if (params.include_same_doc) {
+          args['include-same-doc'] = 'true';
+        }
+        if (params.doc_repo) {
+          args['doc-repo'] = params.doc_repo;
+        }
+        if (params.path) {
+          args.path = params.path;
+        }
+        if (params.name) {
+          args.name = params.name;
+        }
+        if (params.ignore) {
+          args.ignore = params.ignore;
+        }
+
+        if (mode === 'index-docs' || mode === 'reindex-docs') {
+          const result = await deps.mem(cmd, args);
+          if (!result) {
+            return toolTextResult('Doc indexing failed or timed out.', {}, true);
+          }
+          if (result.error) {
+            return toolTextResult(`Error: ${result.error}`, result ?? {}, true);
+          }
+          let fmt: string | undefined | null;
+          try {
+            fmt = deps.formatDocResult(mode, result);
+          } catch {
+            fmt = '';
+          }
+          return toolTextResult(fmt || 'Doc indexing completed.', result ?? {});
+        }
+
+        const docRepos = await deps.getKnownRepos();
+        const docRepoMatch = docRepos.find((r) => r.name.toLowerCase() === params.repo?.toLowerCase());
+        if (!docRepoMatch) {
+          const available = docRepos.map((r) => r.name).join(', ') || 'none';
+          const cwd = process.cwd();
+          return normalizeToolResult({
+            content: [
+              {
+                type: 'text',
+                text: `❌ Doc repo \"${params.repo}\" is not indexed. Available repos: ${available}\n\nTo index these docs, run:\n\`memory-doc index-docs --path ${cwd} --name ${params.repo}\``,
+              },
+            ],
+            details: {},
+            isError: true,
+          });
+        }
+
         const result = await deps.mem(cmd, args);
         if (!result) {
-          return { content: [{ type: 'text', text: 'Doc indexing failed or timed out.' }], details: {}, isError: true };
+          return toolTextResult('Doc query failed.', {}, true);
         }
         if (result.error) {
-          return { content: [{ type: 'text', text: `Error: ${result.error}` }], details: result ?? {}, isError: true };
+          return toolTextResult(`Error: ${result.error}`, result ?? {}, true);
         }
+
         let fmt: string | undefined | null;
-        try { fmt = deps.formatDocResult(params.mode, result); } catch { fmt = ''; }
-        return { content: [{ type: 'text', text: fmt ?? '' }], details: result ?? {} };
-      }
-
-      const docRepos = await deps.getKnownRepos();
-      const docRepoMatch = docRepos.find((r) => r.name.toLowerCase() === params.repo?.toLowerCase());
-      if (!docRepoMatch) {
-        const available = docRepos.map((r) => r.name).join(', ') || 'none';
-        const cwd = process.cwd();
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `❌ Doc repo \"${params.repo}\" is not indexed. Available repos: ${available}\n\nTo index these docs, run:\n\`memory-doc index-docs --path ${cwd} --name ${params.repo}\``,
-            },
-          ],
-          details: {},
-          isError: true,
-        };
-      }
-
-      const result = await deps.mem(cmd, args);
-      if (!result) {
-        return { content: [{ type: 'text', text: 'Doc query failed.' }], details: {}, isError: true };
-      }
-      if (result.error) {
-        return { content: [{ type: 'text', text: `Error: ${result.error}` }], details: result ?? {}, isError: true };
-      }
-
-      let fmt: string | undefined | null;
-      try { fmt = deps.formatDocResult(params.mode, result); } catch { fmt = ''; }
-      return { content: [{ type: 'text', text: fmt ?? '' }], details: result ?? {} };
+        try {
+          fmt = deps.formatDocResult(mode, result);
+        } catch {
+          fmt = '';
+        }
+        return toolTextResult(fmt || `No ${mode} results found.`, result ?? {});
       } catch (err) {
-        return {
-          content: [{ type: 'text', text: `Unexpected error: ${err instanceof Error ? err.message : String(err)}` }],
-          details: {},
-          isError: true,
-        };
+        return toolTextResult(`Unexpected error: ${stringifyToolError(err)}`, {}, true);
       }
     },
   });
+}
+
+function docHelpText(): string {
+  return [
+    'memory-doc requires a mode.',
+    '',
+    'Examples:',
+    '- memory-doc search --repo <repo> --query "getting started"',
+    '- memory-doc outline --repo <repo> --file docs/guide.md',
+    '- memory-doc reindex-docs --path docs --name <repo>',
+    '',
+    'Modes: search, outline, backlinks, broken-links, glossary, tutorial-path, code-examples, orphans, coverage, stale-pages, duplicates, index-docs, reindex-docs.',
+  ].join('\n');
+}
+
+function validateDocParams(mode: string, params: Record<string, any>): string | null {
+  if (mode === 'index-docs' && !params.path) {
+    return 'index-docs requires --path.\n\nExample:\nmemory-doc index-docs --path docs --name <repo>';
+  }
+
+  if (mode === 'reindex-docs' && !params.path && !params.repo) {
+    return 'reindex-docs requires --path or --repo.\n\nExamples:\nmemory-doc reindex-docs --path docs --name <repo>\nmemory-doc reindex-docs --repo <repo>';
+  }
+
+  if (mode !== 'index-docs' && mode !== 'reindex-docs' && !params.repo) {
+    return `${mode} requires --repo.\n\nExample:\nmemory-doc ${mode} --repo <repo>`;
+  }
+
+  if (['search', 'code-examples'].includes(mode) && !params.query) {
+    return `${mode} requires --query.\n\nExample:\nmemory-doc ${mode} --repo ${params.repo || '<repo>'} --query "getting started"`;
+  }
+
+  if (mode === 'backlinks' && !params.doc_path) {
+    return 'backlinks requires --doc-path.\n\nExample:\nmemory-doc backlinks --repo <repo> --doc-path docs/guide.md';
+  }
+
+  return null;
 }

--- a/extensions/memory-layer/tools/tool-result.ts
+++ b/extensions/memory-layer/tools/tool-result.ts
@@ -1,0 +1,61 @@
+export interface ToolTextResult {
+  content: Array<{ type: 'text'; text: string } | Record<string, unknown>>;
+  details: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export function toolTextResult(text: unknown, details: unknown = {}, isError = false): ToolTextResult {
+  return normalizeToolResult({
+    content: [{ type: 'text', text: stringifyToolText(text) }],
+    details,
+    isError,
+  });
+}
+
+export function normalizeToolResult(result: unknown, fallbackText = 'No output.'): ToolTextResult {
+  if (!result || typeof result !== 'object') {
+    return {
+      content: [{ type: 'text', text: stringifyToolText(result) || fallbackText }],
+      details: {},
+      isError: true,
+    };
+  }
+
+  const candidate = result as Record<string, unknown>;
+  const content = Array.isArray(candidate.content) ? candidate.content : [];
+  const normalizedContent = content
+    .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+    .map((item) => {
+      if (item.type === 'text') {
+        return { ...item, text: stringifyToolText(item.text) };
+      }
+      return item;
+    });
+
+  if (normalizedContent.length === 0) {
+    normalizedContent.push({ type: 'text', text: fallbackText });
+  }
+
+  const details = candidate.details && typeof candidate.details === 'object' ? candidate.details : {};
+
+  return {
+    ...candidate,
+    content: normalizedContent,
+    details: details as Record<string, unknown>,
+    ...(candidate.isError === undefined ? {} : { isError: Boolean(candidate.isError) }),
+  } as ToolTextResult;
+}
+
+export function stringifyToolError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function stringifyToolText(text: unknown): string {
+  if (typeof text === 'string') {
+    return text;
+  }
+  if (text == null) {
+    return '';
+  }
+  return String(text);
+}

--- a/test/memory-layer-tool-safety.test.js
+++ b/test/memory-layer-tool-safety.test.js
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest';
+import { normalizeToolResult, toolTextResult } from '../extensions/memory-layer/tools/tool-result.ts';
+import { registerCodeTools } from '../extensions/memory-layer/tools/code-tools.ts';
+import { registerDocTools } from '../extensions/memory-layer/tools/doc-tools.ts';
+
+function captureTool(register, deps) {
+  let registered;
+  register(
+    {
+      registerTool(tool) {
+        registered = tool;
+      },
+    },
+    deps,
+  );
+  if (!registered) {
+    throw new Error('tool was not registered');
+  }
+  return registered;
+}
+
+function expectRenderable(result) {
+  expect(result).toBeTruthy();
+  expect(Array.isArray(result.content)).toBe(true);
+  expect(result.content.length).toBeGreaterThan(0);
+  expect(result.content.every((item) => item && typeof item === 'object')).toBe(true);
+  expect(result.content.filter((item) => item.type === 'text').every((item) => typeof item.text === 'string')).toBe(
+    true,
+  );
+  expect(result.details).toBeTruthy();
+  expect(typeof result.details).toBe('object');
+}
+
+describe('memory tool renderer safety', () => {
+  it('normalizes malformed results into Pi-renderable text results', () => {
+    expectRenderable(normalizeToolResult(undefined));
+    expectRenderable(normalizeToolResult({}));
+    expectRenderable(normalizeToolResult({ content: undefined, details: undefined }));
+    expectRenderable(toolTextResult(null));
+  });
+
+  it.each([
+    ['bare command', {}],
+    ['unknown mode', { mode: 'wat' }],
+    ['missing repo', { mode: 'outline' }],
+    ['missing symbol', { mode: 'callers', repo: 'app' }],
+    ['missing file', { mode: 'outline', repo: 'app' }],
+    ['missing index path', { mode: 'index-repo' }],
+  ])('keeps memory-code renderable for %s', async (_name, params) => {
+    const tool = captureTool(registerCodeTools, {
+      mem: vi.fn(),
+      memStreaming: vi.fn(),
+      getKnownRepos: vi.fn().mockResolvedValue([]),
+      formatCodeResult: vi.fn(),
+    });
+
+    const result = await tool.execute('id', params, undefined, vi.fn(), {});
+    expectRenderable(result);
+  });
+
+  it('keeps memory-code renderable for unindexed repos, empty backend output, backend errors, formatter failures, and thrown exceptions', async () => {
+    const cases = [
+      {
+        name: 'unindexed repo',
+        deps: {
+          mem: vi.fn(),
+          memStreaming: vi.fn(),
+          getKnownRepos: vi.fn().mockResolvedValue([]),
+          formatCodeResult: vi.fn(),
+        },
+        params: { mode: 'deps', repo: 'app' },
+      },
+      {
+        name: 'empty backend output',
+        deps: {
+          mem: vi.fn().mockResolvedValue(undefined),
+          memStreaming: vi.fn(),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'app' }]),
+          formatCodeResult: vi.fn(),
+        },
+        params: { mode: 'deps', repo: 'app' },
+      },
+      {
+        name: 'backend error',
+        deps: {
+          mem: vi.fn().mockResolvedValue({ error: 'boom' }),
+          memStreaming: vi.fn(),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'app' }]),
+          formatCodeResult: vi.fn(),
+        },
+        params: { mode: 'deps', repo: 'app' },
+      },
+      {
+        name: 'formatter failure',
+        deps: {
+          mem: vi.fn().mockResolvedValue({ edges: [] }),
+          memStreaming: vi.fn(),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'app' }]),
+          formatCodeResult: vi.fn(() => {
+            throw new Error('format failed');
+          }),
+        },
+        params: { mode: 'deps', repo: 'app' },
+      },
+      {
+        name: 'backend throw',
+        deps: {
+          mem: vi.fn(() => {
+            throw new Error('db locked');
+          }),
+          memStreaming: vi.fn(),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'app' }]),
+          formatCodeResult: vi.fn(),
+        },
+        params: { mode: 'deps', repo: 'app' },
+      },
+      {
+        name: 'indexing empty output',
+        deps: {
+          mem: vi.fn(),
+          memStreaming: vi.fn().mockResolvedValue(undefined),
+          getKnownRepos: vi.fn(),
+          formatCodeResult: vi.fn(),
+        },
+        params: { mode: 'reindex-repo', path: '.', name: 'app' },
+      },
+    ];
+
+    const results = await Promise.all(
+      cases.map((testCase) => {
+        const tool = captureTool(registerCodeTools, testCase.deps);
+        return tool.execute('id', testCase.params, undefined, vi.fn(), {});
+      }),
+    );
+
+    results.forEach(expectRenderable);
+  });
+
+  it.each([
+    ['bare command', {}],
+    ['unknown mode', { mode: 'wat' }],
+    ['missing repo', { mode: 'search' }],
+    ['missing query', { mode: 'search', repo: 'docs' }],
+    ['missing backlinks path', { mode: 'backlinks', repo: 'docs' }],
+    ['missing index path', { mode: 'index-docs' }],
+  ])('keeps memory-doc renderable for %s', async (_name, params) => {
+    const tool = captureTool(registerDocTools, {
+      mem: vi.fn(),
+      getKnownRepos: vi.fn().mockResolvedValue([]),
+      formatDocResult: vi.fn(),
+    });
+
+    const result = await tool.execute('id', params, undefined, vi.fn(), {});
+    expectRenderable(result);
+  });
+
+  it('keeps memory-doc renderable for unindexed repos, empty backend output, backend errors, formatter failures, and thrown exceptions', async () => {
+    const cases = [
+      {
+        deps: {
+          mem: vi.fn(),
+          getKnownRepos: vi.fn().mockResolvedValue([]),
+          formatDocResult: vi.fn(),
+        },
+        params: { mode: 'outline', repo: 'docs' },
+      },
+      {
+        deps: {
+          mem: vi.fn().mockResolvedValue(undefined),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'docs' }]),
+          formatDocResult: vi.fn(),
+        },
+        params: { mode: 'outline', repo: 'docs' },
+      },
+      {
+        deps: {
+          mem: vi.fn().mockResolvedValue({ error: 'boom' }),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'docs' }]),
+          formatDocResult: vi.fn(),
+        },
+        params: { mode: 'outline', repo: 'docs' },
+      },
+      {
+        deps: {
+          mem: vi.fn().mockResolvedValue({ headings: [] }),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'docs' }]),
+          formatDocResult: vi.fn(() => {
+            throw new Error('format failed');
+          }),
+        },
+        params: { mode: 'outline', repo: 'docs' },
+      },
+      {
+        deps: {
+          mem: vi.fn(() => {
+            throw new Error('db locked');
+          }),
+          getKnownRepos: vi.fn().mockResolvedValue([{ name: 'docs' }]),
+          formatDocResult: vi.fn(),
+        },
+        params: { mode: 'outline', repo: 'docs' },
+      },
+      {
+        deps: {
+          mem: vi.fn().mockResolvedValue(undefined),
+          getKnownRepos: vi.fn(),
+          formatDocResult: vi.fn(),
+        },
+        params: { mode: 'reindex-docs', path: 'docs', name: 'docs' },
+      },
+    ];
+
+    const results = await Promise.all(
+      cases.map((testCase) => {
+        const tool = captureTool(registerDocTools, testCase.deps);
+        return tool.execute('id', testCase.params, undefined, vi.fn(), {});
+      }),
+    );
+
+    results.forEach(expectRenderable);
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve robustness of the memory tools so malformed or missing backend responses never produce unrenderable UI payloads.  
- Provide clearer user guidance and parameter validation for `memory-code` and `memory-doc` modes and indexing commands.  

### Description

- Add a new helper module `tools/tool-result.ts` exporting `toolTextResult`, `normalizeToolResult`, and `stringifyToolError` to normalize tool outputs and stringify errors.  
- Update `extensions/memory-layer/tools/code-tools.ts` to use the new helpers, make `mode` optional in the schema, return help text when `mode` is omitted, validate params via `validateCodeParams`, and improve streaming/indexing and error handling (including safe `onUpdate` usage).  
- Update `extensions/memory-layer/tools/doc-tools.ts` similarly to use the new helpers, make `mode` optional, add `validateDocParams`, help text, and safer indexing/query handling.  
- Add `codeHelpText`/`docHelpText` and validation functions to centralize guidance for `index-repo`/`index-docs` and other required args.  
- Add unit tests `test/memory-layer-tool-safety.test.js` that exercise normalization and ensure the tools always return Pi-renderable results across malformed backend outputs, missing params, formatter failures, and thrown exceptions.  

### Testing

- Added and ran the new Vitest unit test file `test/memory-layer-tool-safety.test.js` which exercises normalization and safety scenarios for `memory-code` and `memory-doc`; the tests passed when run with `vitest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6c29bbd0832fa4141c040ddc6dc6)