### PR TITLE
Improve code indexer performance and add discovery / per-file progress reporting

### DIFF
--- a/db.js
+++ b/db.js
@@ -121,6 +121,8 @@ function tryLibsql() {
     const Database = require('libsql');
     const d = new Database(cfg.db_path);
     d.exec('PRAGMA journal_mode=WAL;');
+    d.exec('PRAGMA synchronous=NORMAL;');
+    d.exec('PRAGMA temp_store=MEMORY;');
     d.exec(`PRAGMA busy_timeout=${safeInt(cfg.busy_timeout_ms, 5000)};`);
     d.exec(`PRAGMA wal_autocheckpoint=${safeInt(cfg.wal_autocheckpoint, 1000)};`);
     d.exec('PRAGMA foreign_keys=ON;');

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -22,6 +22,24 @@ function emitProgress(args, phase, detail, stats) {
   process.stderr.write(`${JSON.stringify(payload)}\n`);
 }
 
+function progressPath(filePath, repoRoot) {
+  if (!repoRoot) {
+    return filePath;
+  }
+  const relative = path.relative(repoRoot, filePath);
+  return relative && !relative.startsWith('..') ? relative : filePath;
+}
+
+function shouldEmitFileProgress(done, total) {
+  if (done <= 5 || done === total) {
+    return true;
+  }
+  if (total <= 100) {
+    return done % 10 === 0;
+  }
+  return done % 25 === 0;
+}
+
 function getHeadCommit(repoPath) {
   try {
     return require('child_process')
@@ -118,7 +136,10 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
 
 function formatSkipReport(report) {
   const lines = [];
-  const topN = (obj, n = 5) => Object.entries(obj).sort((a, b) => b[1] - a[1]).slice(0, n);
+  const topN = (obj, n = 5) =>
+    Object.entries(obj)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, n);
   if (Object.keys(report.builtIn).length > 0) {
     const top = topN(report.builtIn);
     lines.push(`  Built-in skip: ${top.map(([d]) => d).join(', ')}...`);
@@ -151,6 +172,13 @@ async function scanPhase(repoPath, options, args) {
         emitProgress(args, 'discovery', { message: `Skipping [${reason}]: ${relativePath}` });
       }
     },
+    onScanProgress: (stats) => {
+      const suffix = stats.done ? 'complete' : 'in progress';
+      emitProgress(args, 'discovery', {
+        message: `Discovery ${suffix}: ${stats.codeFiles} code files, ${stats.entriesSeen} entries, ${stats.dirsVisited} dirs`,
+        files_done: stats.codeFiles,
+      });
+    },
   });
   return { files: scanResult.files, absPath, skipReport: scanResult.skipReport };
 }
@@ -160,6 +188,7 @@ async function parsePhase(files, deps, repoId, args) {
   const repository = deps.repository || createCodeIndexRepository(require('../../db'));
   const batchSize = RESULT_LIMITS.INDEX_BATCH_SIZE;
   const totalFiles = files.length;
+  const repoRoot = args.repoRoot || args.repoPath || null;
 
   let useWorkers = totalFiles >= WORKER_POOL.MIN_FILES_FOR_PARALLEL && !args.noWorkers;
   let pool = null;
@@ -217,56 +246,78 @@ async function parsePhase(files, deps, repoId, args) {
       }
 
       const batchSymbols = [];
-      for (const record of validReads) {
-        try {
-          const fileId = repository.insertFile(fileRecordToParams(repoId, record));
-          let symbols;
-          if (symbolMap) {
-            symbols = symbolMap.get(record.filePath) || [];
-          } else {
-            symbols = extractSymbolsFromFile(record.filePath, registry, record.content);
-          }
+      const writeRecords = (insideTransaction = false) => {
+        for (const record of validReads) {
+          try {
+            const fileId = repository.insertFile(fileRecordToParams(repoId, record));
+            let symbols;
+            if (symbolMap) {
+              symbols = symbolMap.get(record.filePath) || [];
+            } else {
+              symbols = extractSymbolsFromFile(record.filePath, registry, record.content);
+            }
 
-          if (symbols.length === 0 && record.content.trim().length > 0) {
-            const hasExports = /\bexport\s/.test(record.content);
-            const hasFunction = /\bfunction\b|\b=>\s|\bdef\s|\bfunc\s|\bfn\s/.test(record.content);
-            if (hasExports || hasFunction) {
-              skipped.push({
-                file: record.filePath,
-                error: 'Parse returned 0 symbols despite containing exports/functions',
-                zeroSymbolFile: true,
+            if (symbols.length === 0 && record.content.trim().length > 0) {
+              const hasExports = /\bexport\s/.test(record.content);
+              const hasFunction = /\bfunction\b|\b=>\s|\bdef\s|\bfunc\s|\bfn\s/.test(record.content);
+              if (hasExports || hasFunction) {
+                skipped.push({
+                  file: record.filePath,
+                  error: 'Parse returned 0 symbols despite containing exports/functions',
+                  zeroSymbolFile: true,
+                });
+              }
+            }
+
+            for (const sym of symbols) {
+              batchSymbols.push({
+                repoId,
+                fileId,
+                filePath: record.filePath,
+                name: sym.name,
+                kind: sym.kind,
+                signature: sym.signature,
+                qualifiedName: sym.qualified_name,
+                startLine: sym.start_line,
+                endLine: sym.end_line,
+                startByte: sym.start_byte,
+                endByte: sym.end_byte,
+                docstring: sym.docstring || '',
+                bodyPreview: sym.body_preview || '',
+                language: sym.language,
+                parentName: sym.parent_name || '',
               });
             }
+            symbolCount += symbols.length;
+            fileCount++;
+            if (shouldEmitFileProgress(fileCount, totalFiles)) {
+              emitProgress(
+                args,
+                'parsing',
+                { message: `Indexed ${fileCount}/${totalFiles}: ${progressPath(record.filePath, repoRoot)}` },
+                { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
+              );
+            }
+          } catch (e) {
+            skipped.push({ file: record.filePath, error: e.message });
           }
-
-          for (const sym of symbols) {
-            batchSymbols.push({
-              repoId,
-              fileId,
-              filePath: record.filePath,
-              name: sym.name,
-              kind: sym.kind,
-              signature: sym.signature,
-              qualifiedName: sym.qualified_name,
-              startLine: sym.start_line,
-              endLine: sym.end_line,
-              startByte: sym.start_byte,
-              endByte: sym.end_byte,
-              docstring: sym.docstring || '',
-              bodyPreview: sym.body_preview || '',
-              language: sym.language,
-              parentName: sym.parent_name || '',
-            });
-          }
-          symbolCount += symbols.length;
-          fileCount++;
-        } catch (e) {
-          skipped.push({ file: record.filePath, error: e.message });
         }
-      }
 
-      if (batchSymbols.length > 0) {
-        repository.insertSymbolBatch(batchSymbols);
+        if (batchSymbols.length > 0) {
+          if (insideTransaction) {
+            for (const sym of batchSymbols) {
+              repository.insertSymbol(sym);
+            }
+          } else {
+            repository.insertSymbolBatch(batchSymbols);
+          }
+        }
+      };
+
+      if (typeof repository.withTransaction === 'function') {
+        repository.withTransaction(() => writeRecords(true));
+      } else {
+        writeRecords(false);
       }
     }
   } finally {
@@ -318,7 +369,10 @@ async function indexRepository(deps, repoPath, repoName) {
 
   emitProgress(args, 'parsing', { message: 'Parsing files...', files_total: files.length });
   const parseT0 = Date.now();
-  const parseResult = await parsePhase(files, { parserRegistry: registry, repository }, repoId, args);
+  const parseResult = await parsePhase(files, { parserRegistry: registry, repository }, repoId, {
+    ...args,
+    repoRoot: absPath,
+  });
   const parseMs = Date.now() - parseT0;
 
   emitProgress(args, 'analysis', { message: 'Building derived indexes...' });
@@ -350,7 +404,9 @@ async function indexRepository(deps, repoPath, repoName) {
   emitProgress(
     args,
     'done',
-    { message: `Done: ${parseResult.fileCount} files, ${parseResult.symbolCount} symbols (${(totalMs / 1000).toFixed(1)}s)` },
+    {
+      message: `Done: ${parseResult.fileCount} files, ${parseResult.symbolCount} symbols (${(totalMs / 1000).toFixed(1)}s)`,
+    },
     { files_total: files.length, files_done: parseResult.fileCount, symbols: parseResult.symbolCount },
   );
   return result;
@@ -379,7 +435,9 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
 
   emitProgress(args, 'init', { message: `Reindexing "${repo}" (incremental)...` });
 
-  const scanResult = scanRepository(existing.path);
+  const scanResult = fs.existsSync(existing.path)
+    ? await scanPhase(existing.path, {}, args)
+    : { files: [], skipReport: { builtIn: {}, gitignore: {}, memorycodeignore: {}, unsupportedExt: 0 } };
   const files = scanResult.files;
   const skipReport = scanResult.skipReport;
   const skipSummary = formatSkipReport(skipReport);
@@ -414,24 +472,42 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
       const prev = existingFiles.get(filePath);
       if (prev && prev.mtime === stats.mtimeMs) {
         unchanged++;
-        continue;
-      }
-
-      const content = fs.readFileSync(filePath, 'utf-8');
-      const record = { filePath, content, stats };
-      let fileId;
-      if (prev) {
-        repository.clearFileSymbols(prev.id);
-        repository.updateFile(prev.id, fileRecordToParams(existing.id, record));
-        fileId = prev.id;
       } else {
-        fileId = repository.insertFile(fileRecordToParams(existing.id, record));
-      }
+        const content = fs.readFileSync(filePath, 'utf-8');
+        const record = { filePath, content, stats };
+        const writeChangedFile = () => {
+          let fileId;
+          if (prev) {
+            repository.clearFileSymbols(prev.id);
+            repository.updateFile(prev.id, fileRecordToParams(existing.id, record));
+            fileId = prev.id;
+          } else {
+            fileId = repository.insertFile(fileRecordToParams(existing.id, record));
+          }
 
-      const symbols = extractSymbolsFromFile(filePath, registry, content);
-      symbolCount += insertSymbols(repository, existing.id, fileId, filePath, symbols);
-      reindexed++;
+          const symbols = extractSymbolsFromFile(filePath, registry, content);
+          symbolCount += insertSymbols(repository, existing.id, fileId, filePath, symbols);
+          reindexed++;
+        };
+        if (typeof repository.withTransaction === 'function') {
+          repository.withTransaction(writeChangedFile);
+        } else {
+          writeChangedFile();
+        }
+      }
     } catch (_) {}
+
+    const done = i + 1;
+    if (shouldEmitFileProgress(done, totalFiles)) {
+      emitProgress(
+        args,
+        'parsing',
+        {
+          message: `Checked ${done}/${totalFiles}: ${progressPath(filePath, existing.path)} (${reindexed} changed, ${unchanged} unchanged)`,
+        },
+        { files_total: totalFiles, files_done: done, symbols: symbolCount },
+      );
+    }
   }
 
   const currentFilesSet = new Set(files);

--- a/src/code-index/repos.js
+++ b/src/code-index/repos.js
@@ -17,6 +17,9 @@ function createCodeIndexRepository(deps) {
   }
 
   return Object.freeze({
+    withTransaction(fn) {
+      return _withTransaction(fn);
+    },
     findRepoByName(name) {
       return first(sqlJson('SELECT * FROM code_repos WHERE name = ? LIMIT 1', [name]));
     },
@@ -55,18 +58,31 @@ function createCodeIndexRepository(deps) {
       return sqlJson('SELECT * FROM code_files WHERE repo_id = ?', [repoId]);
     },
     insertFile(params) {
+      const values = [
+        params.repoId,
+        params.path,
+        params.language,
+        params.content,
+        params.contentHash,
+        params.mtime,
+        params.sizeBytes,
+        params.lineCount,
+      ];
+      try {
+        const rows = sqlJson(
+          'INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id',
+          values,
+        );
+        if (rows && rows[0] && rows[0].id) {
+          return rows[0].id;
+        }
+      } catch {
+        // Older SQLite-compatible engines may not support RETURNING.
+        // The fallback insert-then-lookup path keeps indexing portable.
+      }
       sqlRun(
         'INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-        [
-          params.repoId,
-          params.path,
-          params.language,
-          params.content,
-          params.contentHash,
-          params.mtime,
-          params.sizeBytes,
-          params.lineCount,
-        ],
+        values,
       );
       return sqlJson('SELECT id FROM code_files WHERE repo_id = ? AND path = ?', [params.repoId, params.path])[0].id;
     },

--- a/src/code-index/scanner.js
+++ b/src/code-index/scanner.js
@@ -64,8 +64,24 @@ function scanRepository(repoPath, options = {}) {
   const memorycodeignoreIg = loadMemorycodeignoreRules(repoPath);
   const skipReport = { builtIn: {}, gitignore: {}, memorycodeignore: {}, unsupportedExt: 0 };
   const ignoreFiles = options.onProgress || null;
+  const reportScanProgress = options.onScanProgress || null;
+  const scanStats = { dirsVisited: 0, entriesSeen: 0, codeFiles: 0 };
+
+  function maybeReportScanProgress() {
+    if (!reportScanProgress) {
+      return;
+    }
+    if (
+      scanStats.entriesSeen <= 10 ||
+      scanStats.entriesSeen % 500 === 0 ||
+      (scanStats.codeFiles > 0 && scanStats.codeFiles % 100 === 0)
+    ) {
+      reportScanProgress({ ...scanStats });
+    }
+  }
 
   function walk(dir) {
+    scanStats.dirsVisited++;
     let entries;
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -74,36 +90,50 @@ function scanRepository(repoPath, options = {}) {
     }
 
     for (const entry of entries) {
+      scanStats.entriesSeen++;
       const fullPath = path.join(dir, entry.name);
       const relativePath = path.relative(repoPath, fullPath);
       if (entry.isDirectory()) {
         if (shouldSkipDir(entry.name, extraIgnoreDirs)) {
           skipReport.builtIn[entry.name] = (skipReport.builtIn[entry.name] || 0) + 1;
-          if (ignoreFiles) ignoreFiles(relativePath, 'built-in');
+          if (ignoreFiles) {
+            ignoreFiles(relativePath, 'built-in');
+          }
         } else if (gitignoreIg && gitignoreIg.ignores(relativePath)) {
           skipReport.gitignore[entry.name] = (skipReport.gitignore[entry.name] || 0) + 1;
-          if (ignoreFiles) ignoreFiles(relativePath, '.gitignore');
+          if (ignoreFiles) {
+            ignoreFiles(relativePath, '.gitignore');
+          }
         } else if (memorycodeignoreIg && memorycodeignoreIg.ignores(relativePath)) {
           skipReport.memorycodeignore[entry.name] = (skipReport.memorycodeignore[entry.name] || 0) + 1;
-          if (ignoreFiles) ignoreFiles(relativePath, '.memorycodeignore');
+          if (ignoreFiles) {
+            ignoreFiles(relativePath, '.memorycodeignore');
+          }
         } else {
           walk(fullPath);
         }
       } else if (entry.isFile()) {
         if (!isCodeFile(fullPath)) {
           skipReport.unsupportedExt++;
-          return;
-        }
-        const shouldSkip = (gitignoreIg && gitignoreIg.ignores(relativePath)) || 
-                           (memorycodeignoreIg && memorycodeignoreIg.ignores(relativePath));
-        if (!shouldSkip) {
-          results.push(fullPath);
+          maybeReportScanProgress();
+        } else {
+          const shouldSkip =
+            (gitignoreIg && gitignoreIg.ignores(relativePath)) ||
+            (memorycodeignoreIg && memorycodeignoreIg.ignores(relativePath));
+          if (!shouldSkip) {
+            results.push(fullPath);
+            scanStats.codeFiles++;
+            maybeReportScanProgress();
+          }
         }
       }
     }
   }
 
   walk(repoPath);
+  if (reportScanProgress) {
+    reportScanProgress({ ...scanStats, done: true });
+  }
   return { files: results, skipReport };
 }
 

--- a/test/code-index-modules.test.js
+++ b/test/code-index-modules.test.js
@@ -1,7 +1,11 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { getLanguageForFile, canParseFile } = require('../src/code-index/parser-registry');
 const { normalizeSymbol, extractSymbolsFromFile } = require('../src/code-index/symbol-extractor');
 const { sourceSliceFromRow } = require('../src/code-index/source-retrieval');
 const { reindexRepository } = require('../src/code-index/incremental-indexer');
+const { scanRepository } = require('../src/code-index/scanner');
 
 describe('code-index parser registry', () => {
   it('maps supported file extensions to parser languages', () => {
@@ -97,5 +101,20 @@ describe('code-index incremental reindexer', () => {
     expect(result.files_removed).toBe(1);
     expect(calls).toContainEqual(['deleteFile', 10]);
     expect(calls).toContainEqual(['updateRepoStats', 7]);
+  });
+});
+
+describe('code-index scanner', () => {
+  it('continues scanning after unsupported files and reports discovery progress', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-scan-'));
+    fs.writeFileSync(path.join(tmp, 'README.md'), '# docs');
+    fs.writeFileSync(path.join(tmp, 'app.js'), 'function app() { return 1; }');
+    const progress = [];
+
+    const result = scanRepository(tmp, { onScanProgress: (stats) => progress.push(stats) });
+
+    expect(result.files).toEqual([path.join(tmp, 'app.js')]);
+    expect(result.skipReport.unsupportedExt).toBe(1);
+    expect(progress.at(-1)).toMatchObject({ done: true, codeFiles: 1 });
   });
 });


### PR DESCRIPTION
### Motivation

- Indexing large repositories was slow and provided little feedback while scanning or parsing, making long runs feel stalled. 
- Database writes were a bottleneck due to many individual inserts and lack of transactional batching. 
- Scanning could abort early on unsupported files and lacked periodic discovery progress events.

### Description

- Added discovery progress from the scanner so callers receive periodic `onScanProgress` callbacks (dirs visited, entries seen, code files) and the indexer emits discovery events via `emitProgress`.
- Added per-file parsing/index progress in `parsePhase` that reports `Indexed X/Y: <relative-path>` with throttling logic and a helper `progressPath` to show repo-relative file paths. 
- Improved DB write performance by exposing a repository `withTransaction` helper, batching symbol writes inside transactions, and using `INSERT ... RETURNING id` for `insertFile` with a portable fallback for engines that don’t support RETURNING. 
- Tuned SQLite connection pragmas for indexing workloads by setting `synchronous=NORMAL` and `temp_store=MEMORY` alongside WAL mode to improve bulk-insert throughput. 
- Fixed scanner traversal so unsupported (non-code) files increment skip counts and continue scanning the rest of the directory, and added final `done: true` scan progress emission. 
- Adjusted reindex flow to reuse the new scanPhase and to emit progress while checking files; updated tests to cover scanner progress behavior.

### Testing

- Ran unit/integration tests: `npm test -- test/code-index-modules.test.js` passed (7 tests) and `npm test -- test/code-index-modules.test.js test/index-repo.test.js` passed (18 tests total). 
- Ran formatting and lint tools: `npm exec -- oxfmt --check ...` passed and `npm exec -- oxlint ...` completed with warnings only for repo-wide lint debt unrelated to this change. 
- `npm run check` remains failing due to existing repository-wide lint issues outside the scope of this PR. 
- Verified targeted formatting and tests after changes; scan/progress behavior covered by the new test `code-index scanner continues scanning after unsupported files and reports discovery progress` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab0ff0220832fa1d0524258df574f)