### PR TITLE
Resolve PR #108 merge conflicts; preserve progress reporting and fix scanner test compat

### DIFF
--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -45,7 +45,7 @@ function getHeadCommit(repoPath) {
     return require('child_process')
       .execSync('git rev-parse HEAD', { cwd: repoPath, encoding: 'utf-8', timeout: 5000 })
       .trim();
-  } catch (_) {
+  } catch {
     return null;
   }
 }
@@ -96,7 +96,7 @@ function insertSymbols(repository, repoId, fileId, filePath, symbols) {
 
 function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCount) {
   const stats = { files_total: totalFiles, files_done: fileCount, symbols: symbolCount };
-  emitProgress(args, 'analysis', { message: 'Building import graph...' }, stats);
+  emitProgress(args, 'analysis', { step: 'build-import-graph', message: 'Step 5/5: building import graph...' }, stats);
 
   let importEdges = 0;
   let callEdges = 0;
@@ -106,15 +106,18 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     if (ig.success) {
       importEdges = ig.edges;
     }
-  } catch (_) {}
-  emitProgress(args, 'analysis', { message: 'Building call graph...' }, stats);
+  } catch {}
+  emitProgress(args, 'analysis', { step: 'build-call-graph', message: 'Step 5/5: building call graph...' }, stats);
   try {
     const cg = buildCallEdges(db, repoId, {
       onProgress: (p) => {
         emitProgress(
           args,
           'analysis',
-          { message: `Building call graph... ${p.filesProcessed}/${p.totalFiles} files, ${p.callsFound} calls` },
+          {
+            step: 'build-call-graph',
+            message: `Step 5/5: building call graph... ${p.filesProcessed}/${p.totalFiles} files, ${p.callsFound} calls`,
+          },
           stats,
         );
       },
@@ -122,14 +125,19 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     if (cg.success) {
       callEdges = cg.calls;
     }
-  } catch (_) {}
-  emitProgress(args, 'analysis', { message: 'Computing complexity...' }, stats);
+  } catch {}
+  emitProgress(
+    args,
+    'analysis',
+    { step: 'compute-complexity', message: 'Step 5/5: computing complexity metrics...' },
+    stats,
+  );
   try {
     const cc = buildComplexityMetrics(db, repoId);
     if (cc.success) {
       complexityCount = cc.symbols;
     }
-  } catch (_) {}
+  } catch {}
 
   return { importEdges, callEdges, complexityCount };
 }
@@ -175,7 +183,9 @@ async function scanPhase(repoPath, options, args) {
     onScanProgress: (stats) => {
       const suffix = stats.done ? 'complete' : 'in progress';
       emitProgress(args, 'discovery', {
-        message: `Discovery ${suffix}: ${stats.codeFiles} code files, ${stats.entriesSeen} entries, ${stats.dirsVisited} dirs`,
+        message: `Step 2/5: discovery ${suffix}; currently scanning ${stats.currentKind || 'entry'} ${stats.currentPath || '.'} (${stats.codeFiles} code files found, ${stats.entriesSeen} entries seen, ${stats.dirsVisited} dirs visited)`,
+        step: 'discover-files',
+        current_file: stats.currentPath || '.',
         files_done: stats.codeFiles,
       });
     },
@@ -196,9 +206,15 @@ async function parsePhase(files, deps, repoId, args) {
   if (useWorkers) {
     try {
       pool = await createParsePool();
-      emitProgress(args, 'init', { message: `Using ${pool.numWorkers} worker threads for parallel parsing` });
+      emitProgress(args, 'init', {
+        step: 'prepare-workers',
+        message: `Preparing parser workers: using ${pool.numWorkers} worker threads for symbol extraction`,
+      });
     } catch (e) {
-      emitProgress(args, 'init', { message: `Worker pool failed (${e.message}), falling back to sequential parsing` });
+      emitProgress(args, 'init', {
+        step: 'prepare-workers',
+        message: `Preparing parser workers failed (${e.message}); continuing with sequential symbol extraction`,
+      });
       pool = null;
       useWorkers = false;
     }
@@ -208,15 +224,34 @@ async function parsePhase(files, deps, repoId, args) {
   let fileCount = 0;
   const skipped = [];
 
+  function validateSymbols(record, symbols) {
+    if (symbols.length === 0 && record.content.trim().length > 0) {
+      const hasExports = /\bexport\s/.test(record.content);
+      const hasFunction = /\bfunction\b|\b=>\s|\bdef\s|\bfunc\s|\bfn\s/.test(record.content);
+      if (hasExports || hasFunction) {
+        skipped.push({
+          file: record.filePath,
+          error: 'Parse returned 0 symbols despite containing exports/functions',
+          zeroSymbolFile: true,
+        });
+      }
+    }
+  }
+
   try {
     for (let i = 0; i < files.length; i += batchSize) {
       const batch = files.slice(i, i + batchSize);
       const batchNum = Math.floor(i / batchSize) + 1;
       const totalBatches = Math.ceil(totalFiles / batchSize);
+      const firstBatchPath = batch[0] ? progressPath(batch[0], repoRoot) : '(empty batch)';
       emitProgress(
         args,
         'parsing',
-        { message: `Parsing files batch ${batchNum}/${totalBatches}${useWorkers ? ' (parallel)' : ''}...` },
+        {
+          step: 'read-files',
+          current_file: firstBatchPath,
+          message: `Reading source files for batch ${batchNum}/${totalBatches}: ${batch.length} files starting at ${firstBatchPath}`,
+        },
         { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
       );
 
@@ -232,43 +267,76 @@ async function parsePhase(files, deps, repoId, args) {
       );
 
       const validReads = reads.filter((r) => r !== null);
+      emitProgress(
+        args,
+        'parsing',
+        {
+          step: 'extract-symbols',
+          current_file: validReads[0] ? progressPath(validReads[0].filePath, repoRoot) : firstBatchPath,
+          message: `Extracting symbols for batch ${batchNum}/${totalBatches}: ${validReads.length} readable files${useWorkers ? ' with workers' : ' sequentially'}`,
+        },
+        { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
+      );
 
-      let symbolMap;
+      const parsedRecords = [];
       if (useWorkers && pool) {
         try {
           const workerInputs = validReads.map((r) => ({ filePath: r.filePath, content: r.content }));
           const workerResults = await pool.parseAll(workerInputs);
-          symbolMap = new Map(workerResults.map((r) => [r.filePath, r.symbols]));
+          const symbolMap = new Map(workerResults.map((r) => [r.filePath, r.symbols]));
+          for (const record of validReads) {
+            const symbols = symbolMap.get(record.filePath) || [];
+            validateSymbols(record, symbols);
+            parsedRecords.push({ record, symbols });
+          }
         } catch (e) {
-          emitProgress(args, 'parsing', { message: `Worker error (${e.message}), falling back to sequential` });
-          symbolMap = null;
+          emitProgress(args, 'parsing', {
+            step: 'extract-symbols',
+            message: `Worker symbol extraction failed (${e.message}); retrying this batch sequentially`,
+          });
+          useWorkers = false;
         }
       }
 
+      if (!useWorkers || parsedRecords.length === 0) {
+        let parsedInBatch = 0;
+        for (const record of validReads) {
+          const symbols = extractSymbolsFromFile(record.filePath, registry, record.content);
+          validateSymbols(record, symbols);
+          parsedRecords.push({ record, symbols });
+          parsedInBatch++;
+          const absoluteDone = i + parsedInBatch;
+          if (shouldEmitFileProgress(absoluteDone, totalFiles)) {
+            emitProgress(
+              args,
+              'parsing',
+              {
+                step: 'extract-symbols',
+                current_file: progressPath(record.filePath, repoRoot),
+                message: `Extracted symbols ${absoluteDone}/${totalFiles}: ${progressPath(record.filePath, repoRoot)} (${symbols.length} symbols)`,
+              },
+              { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
+            );
+          }
+        }
+      }
+
+      emitProgress(
+        args,
+        'parsing',
+        {
+          step: 'store-index',
+          current_file: parsedRecords[0] ? progressPath(parsedRecords[0].record.filePath, repoRoot) : firstBatchPath,
+          message: `Storing index records for batch ${batchNum}/${totalBatches}: ${parsedRecords.length} files`,
+        },
+        { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
+      );
+
       const batchSymbols = [];
       const writeRecords = (insideTransaction = false) => {
-        for (const record of validReads) {
+        for (const { record, symbols } of parsedRecords) {
           try {
             const fileId = repository.insertFile(fileRecordToParams(repoId, record));
-            let symbols;
-            if (symbolMap) {
-              symbols = symbolMap.get(record.filePath) || [];
-            } else {
-              symbols = extractSymbolsFromFile(record.filePath, registry, record.content);
-            }
-
-            if (symbols.length === 0 && record.content.trim().length > 0) {
-              const hasExports = /\bexport\s/.test(record.content);
-              const hasFunction = /\bfunction\b|\b=>\s|\bdef\s|\bfunc\s|\bfn\s/.test(record.content);
-              if (hasExports || hasFunction) {
-                skipped.push({
-                  file: record.filePath,
-                  error: 'Parse returned 0 symbols despite containing exports/functions',
-                  zeroSymbolFile: true,
-                });
-              }
-            }
-
             for (const sym of symbols) {
               batchSymbols.push({
                 repoId,
@@ -294,7 +362,11 @@ async function parsePhase(files, deps, repoId, args) {
               emitProgress(
                 args,
                 'parsing',
-                { message: `Indexed ${fileCount}/${totalFiles}: ${progressPath(record.filePath, repoRoot)}` },
+                {
+                  step: 'store-index',
+                  current_file: progressPath(record.filePath, repoRoot),
+                  message: `Stored index ${fileCount}/${totalFiles}: ${progressPath(record.filePath, repoRoot)} (${symbols.length} symbols)`,
+                },
                 { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
               );
             }
@@ -346,7 +418,8 @@ async function indexRepository(deps, repoPath, repoName) {
     };
   }
 
-  emitProgress(args, 'init', { message: 'Scanning files...' });
+  emitProgress(args, 'init', { step: 'prepare-parser', message: 'Step 1/5: preparing tree-sitter parsers...' });
+  emitProgress(args, 'discovery', { step: 'discover-files', message: 'Step 2/5: discovering code files to index...' });
   const scanResult = await scanPhase(repoPath, {}, args);
   if (scanResult.error) {
     return { error: scanResult.error };
@@ -365,9 +438,17 @@ async function indexRepository(deps, repoPath, repoName) {
   }
 
   const repoId = repository.upsertRepo({ name: repoName, path: absPath });
+  emitProgress(args, 'reset-index', {
+    step: 'clear-index',
+    message: `Step 3/5: clearing existing index rows for ${repoName}...`,
+  });
   repository.clearRepoIndex(repoId);
 
-  emitProgress(args, 'parsing', { message: 'Parsing files...', files_total: files.length });
+  emitProgress(args, 'parsing', {
+    step: 'parse-and-store',
+    message: `Step 4/5: reading files, extracting symbols, and storing index rows for ${files.length} files...`,
+    files_total: files.length,
+  });
   const parseT0 = Date.now();
   const parseResult = await parsePhase(files, { parserRegistry: registry, repository }, repoId, {
     ...args,
@@ -375,7 +456,10 @@ async function indexRepository(deps, repoPath, repoName) {
   });
   const parseMs = Date.now() - parseT0;
 
-  emitProgress(args, 'analysis', { message: 'Building derived indexes...' });
+  emitProgress(args, 'analysis', {
+    step: 'derived-indexes',
+    message: 'Step 5/5: building derived indexes (imports, calls, complexity)...',
+  });
   const derivedT0 = Date.now();
   const headCommit = getHeadCommit(absPath);
   repository.updateRepoStats({ repoId, headCommit });
@@ -433,7 +517,11 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
     return { error: 'WASM tree-sitter parser not available' };
   }
 
-  emitProgress(args, 'init', { message: `Reindexing "${repo}" (incremental)...` });
+  emitProgress(args, 'init', {
+    step: 'prepare-parser',
+    message: `Step 1/5: preparing tree-sitter parsers for incremental reindex of "${repo}"...`,
+  });
+  emitProgress(args, 'discovery', { step: 'discover-files', message: 'Step 2/5: discovering code files to check...' });
 
   const scanResult = fs.existsSync(existing.path)
     ? await scanPhase(existing.path, {}, args)
@@ -462,7 +550,11 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
       emitProgress(
         args,
         'parsing',
-        { message: `Checking file ${i + 1}/${totalFiles}...` },
+        {
+          step: 'check-file',
+          current_file: progressPath(filePath, existing.path),
+          message: `Step 3/5: checking file ${i + 1}/${totalFiles}: ${progressPath(filePath, existing.path)}`,
+        },
         { files_total: totalFiles, files_done: i, symbols: symbolCount },
       );
     }
@@ -485,7 +577,17 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
             fileId = repository.insertFile(fileRecordToParams(existing.id, record));
           }
 
+          emitProgress(args, 'parsing', {
+            step: 'extract-symbols',
+            current_file: progressPath(filePath, existing.path),
+            message: `Step 3/5: extracting symbols from changed file ${progressPath(filePath, existing.path)}`,
+          });
           const symbols = extractSymbolsFromFile(filePath, registry, content);
+          emitProgress(args, 'parsing', {
+            step: 'store-index',
+            current_file: progressPath(filePath, existing.path),
+            message: `Step 3/5: storing updated index rows for ${progressPath(filePath, existing.path)} (${symbols.length} symbols)`,
+          });
           symbolCount += insertSymbols(repository, existing.id, fileId, filePath, symbols);
           reindexed++;
         };
@@ -495,7 +597,7 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
           writeChangedFile();
         }
       }
-    } catch (_) {}
+    } catch {}
 
     const done = i + 1;
     if (shouldEmitFileProgress(done, totalFiles)) {
@@ -503,7 +605,9 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
         args,
         'parsing',
         {
-          message: `Checked ${done}/${totalFiles}: ${progressPath(filePath, existing.path)} (${reindexed} changed, ${unchanged} unchanged)`,
+          step: 'check-file',
+          current_file: progressPath(filePath, existing.path),
+          message: `Step 3/5: checked ${done}/${totalFiles}: ${progressPath(filePath, existing.path)} (${reindexed} changed, ${unchanged} unchanged)`,
         },
         { files_total: totalFiles, files_done: done, symbols: symbolCount },
       );
@@ -516,7 +620,15 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
     repository.deleteFile(fileInfo.id);
   }
 
-  emitProgress(args, 'analysis', { message: 'Building derived indexes...' });
+  emitProgress(args, 'cleanup', {
+    step: 'remove-stale-files',
+    message: `Step 4/5: removing ${staleFiles.length} stale files from the index...`,
+  });
+
+  emitProgress(args, 'analysis', {
+    step: 'derived-indexes',
+    message: 'Step 5/5: rebuilding derived indexes (imports, calls, complexity)...',
+  });
   repository.updateRepoStats({ repoId: existing.id, headCommit: null });
   const derived = rebuildDerivedIndexes(db, existing.id, args, totalFiles, totalFiles, symbolCount);
 

--- a/src/code-index/scanner.js
+++ b/src/code-index/scanner.js
@@ -65,13 +65,14 @@ function scanRepository(repoPath, options = {}) {
   const skipReport = { builtIn: {}, gitignore: {}, memorycodeignore: {}, unsupportedExt: 0 };
   const ignoreFiles = options.onProgress || null;
   const reportScanProgress = options.onScanProgress || null;
-  const scanStats = { dirsVisited: 0, entriesSeen: 0, codeFiles: 0 };
+  const scanStats = { dirsVisited: 0, entriesSeen: 0, codeFiles: 0, currentPath: '.', currentKind: 'directory' };
 
-  function maybeReportScanProgress() {
+  function maybeReportScanProgress(force = false) {
     if (!reportScanProgress) {
       return;
     }
     if (
+      force ||
       scanStats.entriesSeen <= 10 ||
       scanStats.entriesSeen % 500 === 0 ||
       (scanStats.codeFiles > 0 && scanStats.codeFiles % 100 === 0)
@@ -82,6 +83,11 @@ function scanRepository(repoPath, options = {}) {
 
   function walk(dir) {
     scanStats.dirsVisited++;
+    scanStats.currentPath = path.relative(repoPath, dir) || '.';
+    scanStats.currentKind = 'directory';
+    if (scanStats.dirsVisited <= 5 || scanStats.dirsVisited % 50 === 0) {
+      maybeReportScanProgress(true);
+    }
     let entries;
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -93,6 +99,8 @@ function scanRepository(repoPath, options = {}) {
       scanStats.entriesSeen++;
       const fullPath = path.join(dir, entry.name);
       const relativePath = path.relative(repoPath, fullPath);
+      scanStats.currentPath = relativePath;
+      scanStats.currentKind = entry.isDirectory() ? 'directory' : 'file';
       if (entry.isDirectory()) {
         if (shouldSkipDir(entry.name, extraIgnoreDirs)) {
           skipReport.builtIn[entry.name] = (skipReport.builtIn[entry.name] || 0) + 1;

--- a/test/code-index-modules.test.js
+++ b/test/code-index-modules.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { getLanguageForFile, canParseFile } = require('../src/code-index/parser-registry');
 const { normalizeSymbol, extractSymbolsFromFile } = require('../src/code-index/symbol-extractor');
 const { sourceSliceFromRow } = require('../src/code-index/source-retrieval');
-const { reindexRepository } = require('../src/code-index/incremental-indexer');
+const { parsePhase, reindexRepository } = require('../src/code-index/incremental-indexer');
 const { scanRepository } = require('../src/code-index/scanner');
 
 describe('code-index parser registry', () => {
@@ -20,6 +20,61 @@ describe('code-index parser registry', () => {
   it('only reports bundled code extensions as parseable', () => {
     expect(canParseFile('/repo/app.cjs')).toBe(true);
     expect(canParseFile('/repo/notes.txt')).toBe(false);
+  });
+});
+
+describe('code-index parse progress', () => {
+  it('reports what parsing sub-step is currently running', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-parse-progress-'));
+    const filePath = path.join(tmp, 'app.js');
+    fs.writeFileSync(filePath, 'function app() { return 1; }');
+    const progress = [];
+    const originalWrite = process.stderr.write;
+    process.stderr.write = (chunk, encoding, cb) => {
+      progress.push(JSON.parse(String(chunk)));
+      if (typeof cb === 'function') {
+        cb();
+      }
+      return true;
+    };
+
+    try {
+      await parsePhase(
+        [filePath],
+        {
+          parserRegistry: {
+            canParseFile: () => true,
+            parseContent: () => [
+              {
+                name: 'app',
+                kind: 'function',
+                signature: 'function app()',
+                qualified_name: 'app',
+                start_line: 1,
+                end_line: 1,
+                start_byte: 0,
+                end_byte: 28,
+                language: 'javascript',
+              },
+            ],
+          },
+          repository: {
+            withTransaction: (fn) => fn(),
+            insertFile: () => 123,
+            insertSymbol: () => {},
+          },
+        },
+        7,
+        { progress: true, repoRoot: tmp, noWorkers: true },
+      );
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    expect(progress.map((p) => p.step)).toEqual(
+      expect.arrayContaining(['read-files', 'extract-symbols', 'store-index']),
+    );
+    expect(progress.some((p) => p.current_file === 'app.js')).toBe(true);
   });
 });
 
@@ -115,6 +170,7 @@ describe('code-index scanner', () => {
 
     expect(result.files).toEqual([path.join(tmp, 'app.js')]);
     expect(result.skipReport.unsupportedExt).toBe(1);
-    expect(progress.at(-1)).toMatchObject({ done: true, codeFiles: 1 });
+    expect(progress[progress.length - 1]).toMatchObject({ done: true, codeFiles: 1 });
+    expect(progress.some((p) => p.currentPath === 'app.js' && p.currentKind === 'file')).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- Bring the PR branch up-to-date with `main` and resolve merge conflicts so the enhanced indexer/scanner progress work can be landed cleanly.
- Preserve the richer progress telemetry and transactional writes introduced in the PR while ensuring tests remain compatible with older Node.js runtimes.

### Description
- Resolved merge conflicts in `src/code-index/incremental-indexer.js`, `src/code-index/scanner.js`, and `test/code-index-modules.test.js` and committed the resolution.
- Kept and unified enhanced progress emission (new `step`, `current_file`, throttled per-file updates via `shouldEmitFileProgress`, and `progressPath`) and worker/sequential parsing improvements in `parsePhase` within `src/code-index/incremental-indexer.js`.
- Restored scanner-side progress fields (`currentPath`, `currentKind`) and added an `onScanProgress` reporting path in `src/code-index/scanner.js` so discovery progress is reported continuously.
- Fixed test compatibility by replacing `progress.at(-1)` with `progress[progress.length - 1]` and updated `test/code-index-modules.test.js` to exercise parsing progress via the newly exported `parsePhase`.

### Testing
- Ran dependency install with `npm ci` which completed successfully.
- Ran the test suite with `npm test` and all tests passed (`710` tests across `45` test files reported in the run).
- Ran lint/format checks with `npm run check` which failed due to pre-existing repository-wide lint warnings (1 lint error plus multiple warnings) unrelated to the merge conflict resolution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab83449c8832fa3edf3f2791695eb)