### PR TITLE
Fix code index reset progress for large reindexes

### DIFF
--- a/extensions/memory-layer/host/memory-client.ts
+++ b/extensions/memory-layer/host/memory-client.ts
@@ -99,14 +99,27 @@ export async function memStreaming(
       });
 
       let stdout = '';
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const resetTimer = () => {
+        if (timer) {
+          clearTimeout(timer);
+        }
+        timer = setTimeout(() => {
+          child.kill();
+          reject(new Error(`${cmd} timed out after ${timeout}ms without output`));
+        }, timeout + 5000);
+      };
+      resetTimer();
 
       child.stdout.on('data', (chunk: Buffer) => {
         stdout += chunk.toString('utf8');
+        resetTimer();
       });
 
       if (onProgress) {
         const rl = createInterface({ input: child.stderr! });
         rl.on('line', (line: string) => {
+          resetTimer();
           try {
             const parsed = JSON.parse(line);
             if (parsed.progress) {
@@ -125,13 +138,10 @@ export async function memStreaming(
         });
       }
 
-      const timer = setTimeout(() => {
-        child.kill();
-        reject(new Error(`${cmd} timed out after ${timeout}ms`));
-      }, timeout + 5000);
-
       child.on('close', (code) => {
-        clearTimeout(timer);
+        if (timer) {
+          clearTimeout(timer);
+        }
         if (code !== 0 && !stdout.trim()) {
           reject(new Error(`${cmd} exited with code ${code}`));
           return;
@@ -145,7 +155,9 @@ export async function memStreaming(
       });
 
       child.on('error', (err) => {
-        clearTimeout(timer);
+        if (timer) {
+          clearTimeout(timer);
+        }
         reject(err);
       });
     });

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -442,7 +442,21 @@ async function indexRepository(deps, repoPath, repoName) {
     step: 'clear-index',
     message: `Step 3/5: clearing existing index rows for ${repoName}...`,
   });
-  repository.clearRepoIndex(repoId);
+  const clearT0 = Date.now();
+  const clearTotals = repository.clearRepoIndex(repoId, {
+    onProgress: (progress) => {
+      emitProgress(args, 'reset-index', {
+        step: 'clear-index',
+        message: `Step 3/5: ${progress.message}`,
+        rows_deleted: progress.deleted,
+      });
+    },
+  });
+  emitProgress(args, 'reset-index', {
+    step: 'clear-index',
+    message: `Step 3/5: cleared existing index rows for ${repoName} (${Date.now() - clearT0}ms)`,
+    clear_totals: clearTotals,
+  });
 
   emitProgress(args, 'parsing', {
     step: 'parse-and-store',
@@ -509,7 +523,6 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
   }
 
   if (mode === 'full') {
-    repository.clearRepoIndex(existing.id);
     return indexRepository({ ...deps, repository, parserRegistry: registry }, existing.path, repo);
   }
 

--- a/src/code-index/repos.js
+++ b/src/code-index/repos.js
@@ -49,10 +49,69 @@ function createCodeIndexRepository(deps) {
       }
       return this.createRepo({ name, path });
     },
-    clearRepoIndex(repoId) {
-      sqlRun('DELETE FROM code_symbols WHERE repo_id = ?', [repoId]);
-      sqlRun('DELETE FROM code_files WHERE repo_id = ?', [repoId]);
-      sqlRun('DELETE FROM churn_metrics WHERE repo_id = ?', [repoId]);
+    clearRepoIndex(repoId, options = {}) {
+      const batchSize = Math.max(1, Number(options.batchSize) || 1000);
+      const onProgress = typeof options.onProgress === 'function' ? options.onProgress : null;
+      const emit = (message, extra = {}) => {
+        if (onProgress) {
+          onProgress({ message, ...extra });
+        }
+      };
+      const deleteByIdBatch = ({ label, selectSql, selectParams = [] }) => {
+        let deleted = 0;
+        emit(`Clearing ${label.name}...`, { deleted });
+        for (;;) {
+          const rows = sqlJson(selectSql, [...selectParams, batchSize]);
+          if (!rows.length) {
+            break;
+          }
+          const ids = rows.map((row) => row.id);
+          const placeholders = ids.map(() => '?').join(', ');
+          sqlRun(`DELETE FROM ${label.table} WHERE id IN (${placeholders})`, ids);
+          deleted += ids.length;
+          emit(`Cleared ${deleted} ${label.name}`, { deleted });
+          if (ids.length < batchSize) {
+            break;
+          }
+        }
+        return deleted;
+      };
+
+      const totals = {};
+      _withTransaction(() => {
+        totals.symbolComplexity = deleteByIdBatch({
+          label: { table: 'symbol_complexity', name: 'complexity rows' },
+          selectSql:
+            'SELECT sc.id FROM symbol_complexity sc JOIN code_symbols s ON s.id = sc.symbol_id WHERE s.repo_id = ? LIMIT ?',
+          selectParams: [repoId],
+        });
+        totals.calls = deleteByIdBatch({
+          label: { table: 'code_calls', name: 'call edges' },
+          selectSql: 'SELECT id FROM code_calls WHERE repo_id = ? LIMIT ?',
+          selectParams: [repoId],
+        });
+        totals.imports = deleteByIdBatch({
+          label: { table: 'code_imports', name: 'import edges' },
+          selectSql: 'SELECT id FROM code_imports WHERE repo_id = ? LIMIT ?',
+          selectParams: [repoId],
+        });
+        totals.churn = deleteByIdBatch({
+          label: { table: 'churn_metrics', name: 'churn rows' },
+          selectSql: 'SELECT id FROM churn_metrics WHERE repo_id = ? LIMIT ?',
+          selectParams: [repoId],
+        });
+        totals.symbols = deleteByIdBatch({
+          label: { table: 'code_symbols', name: 'symbols' },
+          selectSql: 'SELECT id FROM code_symbols WHERE repo_id = ? LIMIT ?',
+          selectParams: [repoId],
+        });
+        totals.files = deleteByIdBatch({
+          label: { table: 'code_files', name: 'files' },
+          selectSql: 'SELECT id FROM code_files WHERE repo_id = ? LIMIT ?',
+          selectParams: [repoId],
+        });
+      });
+      return totals;
     },
     listFiles(repoId) {
       return sqlJson('SELECT * FROM code_files WHERE repo_id = ?', [repoId]);

--- a/test/code-index-modules.test.js
+++ b/test/code-index-modules.test.js
@@ -6,6 +6,7 @@ const { normalizeSymbol, extractSymbolsFromFile } = require('../src/code-index/s
 const { sourceSliceFromRow } = require('../src/code-index/source-retrieval');
 const { parsePhase, reindexRepository } = require('../src/code-index/incremental-indexer');
 const { scanRepository } = require('../src/code-index/scanner');
+const { createCodeIndexRepository } = require('../src/code-index/repos');
 
 describe('code-index parser registry', () => {
   it('maps supported file extensions to parser languages', () => {
@@ -125,6 +126,65 @@ describe('code-index symbol extractor', () => {
 
     expect(extractSymbolsFromFile('/repo/app.js', registry)).toHaveLength(1);
     expect(extractSymbolsFromFile('/repo/app.js', registry)[0].name).toBe('answer');
+  });
+});
+
+describe('code-index repository clearing', () => {
+  it('clears derived index rows in batches before source rows and emits progress', () => {
+    const calls = [];
+    const progress = [];
+    const rowsBySql = new Map();
+    const key = (sql) => sql.replace(/\s+/g, ' ').trim();
+
+    function queueRows(sql, batches) {
+      rowsBySql.set(
+        key(sql),
+        batches.map((batch) => batch.map((id) => ({ id }))),
+      );
+    }
+
+    queueRows(
+      'SELECT sc.id FROM symbol_complexity sc JOIN code_symbols s ON s.id = sc.symbol_id WHERE s.repo_id = ? LIMIT ?',
+      [[1, 2], []],
+    );
+    queueRows('SELECT id FROM code_calls WHERE repo_id = ? LIMIT ?', [[3], []]);
+    queueRows('SELECT id FROM code_imports WHERE repo_id = ? LIMIT ?', [[]]);
+    queueRows('SELECT id FROM churn_metrics WHERE repo_id = ? LIMIT ?', [[]]);
+    queueRows('SELECT id FROM code_symbols WHERE repo_id = ? LIMIT ?', [[4], []]);
+    queueRows('SELECT id FROM code_files WHERE repo_id = ? LIMIT ?', [[5], []]);
+
+    const repository = createCodeIndexRepository({
+      sqlJson(sql) {
+        const batches = rowsBySql.get(key(sql));
+        if (!batches) {
+          throw new Error(`unexpected query: ${sql}`);
+        }
+        return batches.shift() || [];
+      },
+      sqlRun(sql, params) {
+        calls.push([sql, params]);
+      },
+      withTransaction(fn) {
+        calls.push(['BEGIN']);
+        const result = fn();
+        calls.push(['COMMIT']);
+        return result;
+      },
+    });
+
+    const totals = repository.clearRepoIndex(42, { batchSize: 2, onProgress: (p) => progress.push(p.message) });
+
+    expect(totals).toMatchObject({ symbolComplexity: 2, calls: 1, symbols: 1, files: 1 });
+    expect(calls.map((call) => (Array.isArray(call) ? call[0] : call))).toEqual([
+      'BEGIN',
+      'DELETE FROM symbol_complexity WHERE id IN (?, ?)',
+      'DELETE FROM code_calls WHERE id IN (?)',
+      'DELETE FROM code_symbols WHERE id IN (?)',
+      'DELETE FROM code_files WHERE id IN (?)',
+      'COMMIT',
+    ]);
+    expect(progress).toContain('Cleared 2 complexity rows');
+    expect(progress).toContain('Cleared 1 symbols');
   });
 });
 


### PR DESCRIPTION
### Motivation
- Large repository reindexes could appear to hang at “Step 3/5” because clearing the code index was done in one silent operation without intermediate progress updates.
- Full reindex duplicated a silent clear, which made visible progress inconsistent with the actual work being performed.
- Long-running streaming memory commands could be killed by a static wall-clock timeout even when they were actively producing progress, causing premature failures.

### Description
- Implement `clearRepoIndex(repoId, options = {})` in `src/code-index/repos.js` to delete derived tables in bounded batches inside the repository transaction, emit per-batch progress via an `onProgress` callback, and return totals.
- Wire repository clearing progress into `indexRepository` in `src/code-index/incremental-indexer.js` so `Step 3/5` reports incremental `reset-index` messages and a final `clear_totals`, and remove the duplicate silent clear during full reindex so the visible step owns the work.
- Change `memStreaming` in `extensions/memory-layer/host/memory-client.ts` to use an idle timer that is reset on `stdout`/`stderr` progress (instead of a single static timeout) so active long-running jobs are not killed while producing output.
- Add a unit test in `test/code-index-modules.test.js` covering batched clearing order, transaction wrapping, returned totals, and emitted progress messages for the batched `clearRepoIndex` behavior.

### Testing
- Ran the full test suite with `npm test` and observed all tests passing (the run completed with the suite reporting all tests passed, including the new `code-index repository clearing` test).
- Ran targeted tests `test/code-index-modules.test.js` and `test/state.test.js` which passed locally after changes.
- Verified formatting with `npx oxfmt --check` and fixed formatting on touched files, and ran targeted linting (`npx oxlint`) for the modified files; the modified files pass targeted format/lint checks.
- Performed a smoke run of indexing with `node memory-store.js index-repo --path <tmp> --name smoke-index --progress` and observed incremental `reset-index` progress lines and successful indexing; note that `npm run check` still returns non-zero for unrelated pre-existing repo-wide lint warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abbe2f9e8832fb2e43a492c7a5fda)