### PR TITLE
Support JSX files in code indexing

### DIFF
--- a/parse-code.js
+++ b/parse-code.js
@@ -10,7 +10,7 @@
  *   await codeParser.init();
  *   const symbols = codeParser.parseFile('/path/to/file.js');
  *
- * Supported: .js/.mjs/.cjs, .ts/.mts/.cts, .tsx, .sql
+ * Supported: .js/.jsx/.mjs/.cjs, .ts/.mts/.cts, .tsx, .sql
  */
 
 const path = require('path');
@@ -23,6 +23,7 @@ const GRAMMAR_DIR = path.resolve(__dirname, 'grammars');
 // Language map: file extension → { grammarFile, languageName, parserKey }
 const LANGUAGE_MAP = {
   '.js': { grammarFile: 'javascript.wasm', languageName: 'javascript', parserKey: 'javascript' },
+  '.jsx': { grammarFile: 'javascript.wasm', languageName: 'javascript', parserKey: 'javascript' },
   '.mjs': { grammarFile: 'javascript.wasm', languageName: 'javascript', parserKey: 'javascript' },
   '.cjs': { grammarFile: 'javascript.wasm', languageName: 'javascript', parserKey: 'javascript' },
   '.ts': { grammarFile: 'typescript.wasm', languageName: 'typescript', parserKey: 'typescript' },
@@ -182,6 +183,36 @@ function _getLineFromOffset(content, offset) {
   return content.substring(0, offset).split('\n').length;
 }
 
+function _fallbackLanguageFromExtension(ext) {
+  if (ext === '.tsx') {
+    return 'typescript';
+  }
+  if (ext === '.jsx') {
+    return 'javascript';
+  }
+  return ext.slice(1);
+}
+
+function _fallbackJsTsKind(content, match) {
+  if (match[1]) {
+    return 'function';
+  }
+  if (!match[2]) {
+    return 'constant';
+  }
+  const declaration = content.substring(match.index, match.index + 20);
+  if (declaration.includes('class ')) {
+    return 'class';
+  }
+  if (declaration.includes('interface ')) {
+    return 'interface';
+  }
+  if (declaration.includes('enum ')) {
+    return 'enum';
+  }
+  return 'type';
+}
+
 function _fallbackExtractSymbols(filePath, content) {
   const ext = path.extname(filePath).toLowerCase();
   const symbols = [];
@@ -194,7 +225,7 @@ function _fallbackExtractSymbols(filePath, content) {
     symbols.push({
       name,
       kind,
-      language: ext === '.tsx' ? 'typescript' : ext.slice(1),
+      language: _fallbackLanguageFromExtension(ext),
       file: filePath,
       signature: signature.length > 200 ? `${signature.slice(0, 197)}...` : signature,
       qualified_name: name,
@@ -208,21 +239,19 @@ function _fallbackExtractSymbols(filePath, content) {
     });
   }
 
-  const jsTsExts = new Set(['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.tsx']);
+  const jsTsExts = new Set(['.js', '.jsx', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.tsx']);
   if (jsTsExts.has(ext)) {
-    const re = /(?:^|\n)\s*(?:export\s+(?:default\s+)?)?(?:async\s+)?(?:function\s+(\w+)|(?:class|interface|type|enum)\s+(\w+)|(?:const|let|var)\s+(\w+)\s*=[^;\n]*)/g;
+    const re =
+      /(?:^|\n)\s*(?:export\s+(?:default\s+)?)?(?:async\s+)?(?:function\s+(\w+)|(?:class|interface|type|enum)\s+(\w+)|(?:const|let|var)\s+(\w+)\s*=[^;\n]*)/g;
     let match;
     while ((match = re.exec(content)) !== null) {
       const name = match[1] || match[2] || match[3];
-      if (!name) continue;
-      const kind = match[1] ? 'function' : match[2] ? (
-        content.substring(match.index, match.index + 20).includes('class ') ? 'class' :
-        content.substring(match.index, match.index + 20).includes('interface ') ? 'interface' :
-        content.substring(match.index, match.index + 20).includes('enum ') ? 'enum' : 'type'
-      ) : 'constant';
-      const line = _getLineFromOffset(content, match.index);
-      const sig = match[0].trim().split('\n')[0];
-      add(name, kind, line, sig, match.index);
+      if (name) {
+        const kind = _fallbackJsTsKind(content, match);
+        const line = _getLineFromOffset(content, match.index);
+        const sig = match[0].trim().split('\n')[0];
+        add(name, kind, line, sig, match.index);
+      }
     }
   } else if (ext === '.py' || ext === '.pyw') {
     const re = /^(?:async\s+)?(?:def|class)\s+(\w+)/gm;
@@ -251,7 +280,12 @@ function _fallbackExtractSymbols(filePath, content) {
     const enumRe = /(?:^|\n)\s*(?:pub\s+)?enum\s+(\w+)/g;
     const traitRe = /(?:^|\n)\s*(?:pub\s+)?trait\s+(\w+)/g;
     let match;
-    for (const [regex, kind] of [[fnRe, 'function'], [structRe, 'class'], [enumRe, 'enum'], [traitRe, 'interface']]) {
+    for (const [regex, kind] of [
+      [fnRe, 'function'],
+      [structRe, 'class'],
+      [enumRe, 'enum'],
+      [traitRe, 'interface'],
+    ]) {
       while ((match = regex.exec(content)) !== null) {
         const line = _getLineFromOffset(content, match.index);
         add(match[1], kind, line, match[0].trim(), match.index);

--- a/src/code-index/parser-registry.js
+++ b/src/code-index/parser-registry.js
@@ -4,6 +4,7 @@ const { CODE_EXTENSIONS } = require('../../utils');
 
 const LANGUAGE_BY_EXTENSION = Object.freeze({
   '.js': 'javascript',
+  '.jsx': 'javascript',
   '.mjs': 'javascript',
   '.cjs': 'javascript',
   '.ts': 'typescript',

--- a/test/code-index-modules.test.js
+++ b/test/code-index-modules.test.js
@@ -11,6 +11,7 @@ const { createCodeIndexRepository } = require('../src/code-index/repos');
 describe('code-index parser registry', () => {
   it('maps supported file extensions to parser languages', () => {
     expect(getLanguageForFile('/repo/app.js')).toBe('javascript');
+    expect(getLanguageForFile('/repo/app.jsx')).toBe('javascript');
     expect(getLanguageForFile('/repo/app.tsx')).toBe('typescript');
     expect(getLanguageForFile('/repo/main.py')).toBe('python');
     expect(getLanguageForFile('/repo/main.go')).toBe('go');
@@ -224,13 +225,14 @@ describe('code-index scanner', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-scan-'));
     fs.writeFileSync(path.join(tmp, 'README.md'), '# docs');
     fs.writeFileSync(path.join(tmp, 'app.js'), 'function app() { return 1; }');
+    fs.writeFileSync(path.join(tmp, 'Component.jsx'), 'export function Component() { return <div />; }');
     const progress = [];
 
     const result = scanRepository(tmp, { onScanProgress: (stats) => progress.push(stats) });
 
-    expect(result.files).toEqual([path.join(tmp, 'app.js')]);
+    expect(result.files.sort()).toEqual([path.join(tmp, 'Component.jsx'), path.join(tmp, 'app.js')].sort());
     expect(result.skipReport.unsupportedExt).toBe(1);
-    expect(progress[progress.length - 1]).toMatchObject({ done: true, codeFiles: 1 });
+    expect(progress[progress.length - 1]).toMatchObject({ done: true, codeFiles: 2 });
     expect(progress.some((p) => p.currentPath === 'app.js' && p.currentKind === 'file')).toBe(true);
   });
 });

--- a/test/parse-code.test.js
+++ b/test/parse-code.test.js
@@ -74,6 +74,17 @@ describe('parse-code (WASM tree-sitter)', () => {
       expect(fn.docstring).toContain('greeter');
     });
 
+    it('should extract JSX components from .jsx files', () => {
+      const tmpFile = path.join('/tmp', 'test-comp.jsx');
+      fs.writeFileSync(tmpFile, 'export function Card({ title }) {\n  return <section>{title}</section>;\n}');
+      const symbols = codeParser.parseFile(tmpFile);
+      fs.unlinkSync(tmpFile);
+
+      const fn = symbols.find((sym) => sym.name === 'Card');
+      expect(fn).toBeDefined();
+      expect(fn.language).toBe('javascript');
+    });
+
     it('should return output with all required fields', () => {
       const tmpFile = path.join('/tmp', 'test-schema.js');
       fs.writeFileSync(tmpFile, 'function myFunc(x) { return x; }');

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -171,6 +171,7 @@ describe('utils.js', () => {
   describe('CODE_EXTENSIONS', () => {
     it('should include common code extensions', () => {
       expect(utils.CODE_EXTENSIONS.has('.js')).toBe(true);
+      expect(utils.CODE_EXTENSIONS.has('.jsx')).toBe(true);
       expect(utils.CODE_EXTENSIONS.has('.ts')).toBe(true);
       expect(utils.CODE_EXTENSIONS.has('.py')).toBe(true);
       expect(utils.CODE_EXTENSIONS.has('.go')).toBe(true);

--- a/utils.js
+++ b/utils.js
@@ -43,7 +43,20 @@ const IGNORE_DIRS_DOCS = new Set([...IGNORE_DIRS_COMMON, '.svn', '.hg', '__pycac
 
 /* ── file extension sets ────────────────────────────────────── */
 
-const CODE_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.tsx', '.go', '.rs', '.py', '.pyw']);
+const CODE_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.ts',
+  '.mts',
+  '.cts',
+  '.tsx',
+  '.go',
+  '.rs',
+  '.py',
+  '.pyw',
+]);
 
 const MD_EXTENSIONS = new Set(['.md', '.mdx']);
 


### PR DESCRIPTION
### Motivation
- Scanner and parser were treating `.jsx` files as unsupported, causing JSX sources to be skipped and outlines to miss symbols.
- The change ensures JSX files are discovered, parsed with the JavaScript grammar, and receive the same fallback extraction as other JS/TS files.

### Description
- Add `.jsx` to the global `CODE_EXTENSIONS` allowlist in `utils.js` so the scanner treats JSX files as code files.
- Map `.jsx` to the JavaScript parser in `parse-code.js` (`LANGUAGE_MAP`) and `src/code-index/parser-registry.js` so `.jsx` resolves to the bundled JS grammar.
- Extend the fallback extractor in `parse-code.js` to recognize `.jsx` in the JS/TS fallback set and to label fallback symbols from `.jsx` as `javascript`, plus small helper functions to clean up fallback logic.
- Add regression tests updating `test/utils.test.js`, `test/code-index-modules.test.js`, and `test/parse-code.test.js` to cover `.jsx` extension membership, parser mapping, scanner discovery, and JSX symbol extraction.

### Testing
- Ran unit tests with `npm test -- --run test/utils.test.js test/code-index-modules.test.js test/parse-code.test.js` and all tests passed.
- Performed an end-to-end repro by running `node memory-store.js index-repo` on a temporary repo with `App.jsx` and `util.js`, which reported `files_indexed: 2` and `symbols_extracted: 2`, and `memory-store.js outline` returned the `App` symbol as expected.
- Verified formatting with `npx oxfmt --check` on modified files and the formatter check passed for the changed files.
- Ran `npm run check` which still fails due to pre-existing lint issues elsewhere in the repo (unrelated to this focused change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abe5e8da0832fb2111540dd3b8f76)