### PR TITLE
Add ranked code-context search, schema v9, scanner hardening, and enriched symbol metadata

### DIFF
--- a/commands/code-impl.js
+++ b/commands/code-impl.js
@@ -48,6 +48,19 @@ function searchCode(args) {
   );
 }
 
+function rankedContext(args) {
+  const query = args.query;
+  if (!query) {
+    const { jsonErrNoExit } = require('../db');
+    return jsonErrNoExit('Usage: ranked-code-context --query <text> [--repo NAME] [--token-budget N]');
+  }
+  return codeSearchService.rankedContext(query, args.repo || null, {
+    tokenBudget: parseInt(args['token-budget'] || args.tokenBudget || '4000', 10),
+    maxResults: parseInt(args['max-results'] || '20', 10),
+    kind: args.kind || null,
+  });
+}
+
 function getCodeSource(args) {
   const repo = args.repo;
   const file = args.file;
@@ -72,4 +85,13 @@ function removeCodeRepo(args) {
   return codeSearchService.removeCodeRepoInternal(repo);
 }
 
-module.exports = { indexRepo, reindexRepo, codeRepoHealth, searchCode, getCodeSource, listCodeRepos, removeCodeRepo };
+module.exports = {
+  indexRepo,
+  reindexRepo,
+  codeRepoHealth,
+  searchCode,
+  rankedContext,
+  getCodeSource,
+  listCodeRepos,
+  removeCodeRepo,
+};

--- a/db.js
+++ b/db.js
@@ -92,7 +92,9 @@ function findLapisRoot() {
       }
     } catch {}
     const parent = path.dirname(dir);
-    if (parent === dir) {break;}
+    if (parent === dir) {
+      break;
+    }
     dir = parent;
   }
   return __dirname;
@@ -235,11 +237,11 @@ const _CRITICAL_TABLES = [
   // V3: code indexing
   [
     'code_repos',
-    "CREATE TABLE IF NOT EXISTS code_repos (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE, path TEXT NOT NULL UNIQUE, file_count INTEGER DEFAULT 0, symbol_count INTEGER DEFAULT 0, indexed_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')), head_commit TEXT)",
+    "CREATE TABLE IF NOT EXISTS code_repos (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE, path TEXT NOT NULL UNIQUE, file_count INTEGER DEFAULT 0, symbol_count INTEGER DEFAULT 0, indexed_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')), head_commit TEXT, current_branch TEXT, base_head TEXT)",
   ],
   [
     'code_files',
-    'CREATE TABLE IF NOT EXISTS code_files (id INTEGER PRIMARY KEY AUTOINCREMENT, repo_id INTEGER NOT NULL REFERENCES code_repos(id) ON DELETE CASCADE, path TEXT NOT NULL, language TEXT NOT NULL, content TEXT NOT NULL, content_hash TEXT NOT NULL, mtime REAL, size_bytes INTEGER DEFAULT 0, line_count INTEGER DEFAULT 0, UNIQUE(repo_id, path))',
+    'CREATE TABLE IF NOT EXISTS code_files (id INTEGER PRIMARY KEY AUTOINCREMENT, repo_id INTEGER NOT NULL REFERENCES code_repos(id) ON DELETE CASCADE, path TEXT NOT NULL, language TEXT NOT NULL, content TEXT NOT NULL, content_hash TEXT NOT NULL, mtime REAL, size_bytes INTEGER DEFAULT 0, line_count INTEGER DEFAULT 0, mtime_ns INTEGER, UNIQUE(repo_id, path))',
   ],
   [
     'code_file_diagnostics',
@@ -247,7 +249,7 @@ const _CRITICAL_TABLES = [
   ],
   [
     'code_symbols',
-    "CREATE TABLE IF NOT EXISTS code_symbols (id INTEGER PRIMARY KEY AUTOINCREMENT, repo_id INTEGER NOT NULL REFERENCES code_repos(id) ON DELETE CASCADE, file_id INTEGER NOT NULL REFERENCES code_files(id) ON DELETE CASCADE, name TEXT NOT NULL, kind TEXT NOT NULL, signature TEXT, file_path TEXT NOT NULL, start_line INTEGER NOT NULL, end_line INTEGER NOT NULL, start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL, docstring TEXT DEFAULT '', body_preview TEXT DEFAULT '', language TEXT NOT NULL, parent_name TEXT DEFAULT '', qualified_name TEXT NOT NULL, indexed_at TEXT NOT NULL DEFAULT (datetime('now')))",
+    "CREATE TABLE IF NOT EXISTS code_symbols (id INTEGER PRIMARY KEY AUTOINCREMENT, repo_id INTEGER NOT NULL REFERENCES code_repos(id) ON DELETE CASCADE, file_id INTEGER NOT NULL REFERENCES code_files(id) ON DELETE CASCADE, name TEXT NOT NULL, kind TEXT NOT NULL, signature TEXT, file_path TEXT NOT NULL, start_line INTEGER NOT NULL, end_line INTEGER NOT NULL, start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL, docstring TEXT DEFAULT '', body_preview TEXT DEFAULT '', language TEXT NOT NULL, parent_name TEXT DEFAULT '', qualified_name TEXT NOT NULL, stable_symbol_id TEXT DEFAULT '', content_hash TEXT DEFAULT '', summary TEXT DEFAULT '', decorators_json TEXT DEFAULT '[]', keywords_json TEXT DEFAULT '[]', call_references_json TEXT DEFAULT '[]', ecosystem_context TEXT DEFAULT '', indexed_at TEXT NOT NULL DEFAULT (datetime('now')))",
   ],
   // V5: code analysis
   [
@@ -310,8 +312,11 @@ function ensureCriticalTables() {
 
 function _createTableIndexes(name, db) {
   const indexMap = {
-    code_repos: [],
-    code_files: ['CREATE INDEX IF NOT EXISTS idx_cf_repo ON code_files(repo_id)'],
+    code_repos: ['CREATE INDEX IF NOT EXISTS idx_cr_branch ON code_repos(current_branch)'],
+    code_files: [
+      'CREATE INDEX IF NOT EXISTS idx_cf_repo ON code_files(repo_id)',
+      'CREATE INDEX IF NOT EXISTS idx_cf_hash ON code_files(repo_id, content_hash)',
+    ],
     code_file_diagnostics: [
       'CREATE INDEX IF NOT EXISTS idx_cfd_repo ON code_file_diagnostics(repo_id)',
       'CREATE INDEX IF NOT EXISTS idx_cfd_status ON code_file_diagnostics(repo_id, status)',
@@ -320,6 +325,7 @@ function _createTableIndexes(name, db) {
       'CREATE INDEX IF NOT EXISTS idx_cs_repo ON code_symbols(repo_id)',
       'CREATE INDEX IF NOT EXISTS idx_cs_name ON code_symbols(name)',
       'CREATE INDEX IF NOT EXISTS idx_cs_file ON code_symbols(file_id)',
+      'CREATE INDEX IF NOT EXISTS idx_cs_stable ON code_symbols(repo_id, stable_symbol_id)',
     ],
     code_imports: [
       'CREATE INDEX IF NOT EXISTS idx_ci_source ON code_imports(source_file_id)',
@@ -371,7 +377,7 @@ function runMigrations() {
     console.error('[db] Failed to read user_version:', e.message);
   }
 
-  if (version >= 8) {
+  if (version >= 9) {
     return { migrated: false, version };
   }
 
@@ -383,6 +389,7 @@ function runMigrations() {
     { to: 6, run: runMigrationV6 },
     { to: 7, run: runMigrationV7 },
     { to: 8, run: runMigrationV8 },
+    { to: 9, run: runMigrationV9 },
   ];
 
   const fromVersion = version;
@@ -525,6 +532,28 @@ function runMigrationV5() {
   const errors = [];
   try {
     const schema = fs.readFileSync(SCHEMA_PATH, 'utf8');
+    // Newer schema indexes may reference columns added after V5. Add them first
+    // When migrating an older database so the schema replay remains idempotent.
+    for (const [table, column, definition] of [
+      ['code_repos', 'current_branch', 'TEXT'],
+      ['code_repos', 'base_head', 'TEXT'],
+      ['code_files', 'mtime_ns', 'INTEGER'],
+      ['code_symbols', 'stable_symbol_id', "TEXT DEFAULT ''"],
+      ['code_symbols', 'content_hash', "TEXT DEFAULT ''"],
+      ['code_symbols', 'summary', "TEXT DEFAULT ''"],
+      ['code_symbols', 'decorators_json', "TEXT DEFAULT '[]'"],
+      ['code_symbols', 'keywords_json', "TEXT DEFAULT '[]'"],
+      ['code_symbols', 'call_references_json', "TEXT DEFAULT '[]'"],
+      ['code_symbols', 'ecosystem_context', "TEXT DEFAULT ''"],
+    ]) {
+      try {
+        sqlRaw(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+      } catch (err) {
+        if (!/duplicate column|no such table/i.test(err.message)) {
+          throw err;
+        }
+      }
+    }
     // _db.exec() correctly handles complex multi-statement SQL with triggers etc.
     // It cannot run inside a transaction because schema.sql contains PRAGMAs.
     try {
@@ -603,6 +632,40 @@ function runMigrationV7() {
     });
   } catch (e) {
     errors.push(`V7: ${e.message}`);
+  }
+  return errors;
+}
+
+function runMigrationV9() {
+  const errors = [];
+  const addColumn = (table, column, definition) => {
+    try {
+      sqlRaw(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+    } catch (e) {
+      if (!/duplicate column/i.test(e.message)) {
+        throw e;
+      }
+    }
+  };
+  try {
+    withTransaction(() => {
+      addColumn('code_repos', 'current_branch', 'TEXT');
+      addColumn('code_repos', 'base_head', 'TEXT');
+      addColumn('code_files', 'mtime_ns', 'INTEGER');
+      addColumn('code_symbols', 'stable_symbol_id', "TEXT DEFAULT ''");
+      addColumn('code_symbols', 'content_hash', "TEXT DEFAULT ''");
+      addColumn('code_symbols', 'summary', "TEXT DEFAULT ''");
+      addColumn('code_symbols', 'decorators_json', "TEXT DEFAULT '[]'");
+      addColumn('code_symbols', 'keywords_json', "TEXT DEFAULT '[]'");
+      addColumn('code_symbols', 'call_references_json', "TEXT DEFAULT '[]'");
+      addColumn('code_symbols', 'ecosystem_context', "TEXT DEFAULT ''");
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_cr_branch ON code_repos(current_branch)');
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_cf_hash ON code_files(repo_id, content_hash)');
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_cs_stable ON code_symbols(repo_id, stable_symbol_id)');
+      sqlRaw('PRAGMA user_version = 9');
+    });
+  } catch (e) {
+    errors.push(`V9: ${e.message}`);
   }
   return errors;
 }

--- a/schema.sql
+++ b/schema.sql
@@ -10,7 +10,7 @@
 --   doc-index repository: doc_repos, doc_files, doc_sections, doc FTS, links, terms, code blocks.
 --   trust-sync repository: symbol_links and trust_adjustments because they bridge memories and code symbols.
 --   analytics repository: read-only aggregate queries across feature-owned tables.
-PRAGMA user_version = 8;
+PRAGMA user_version = 9;
 
 -- ═══════════════════════════════════════════════════════════
 -- MEMORY REPOSITORY: WORKSPACES  (v4 — formal project isolation)
@@ -226,7 +226,9 @@ CREATE TABLE IF NOT EXISTS code_repos (
   symbol_count  INTEGER DEFAULT 0,
   indexed_at    TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
-  head_commit   TEXT
+  head_commit   TEXT,
+  current_branch TEXT,
+  base_head     TEXT
 );
 
 -- ═══════════════════════════════════════════════════════════
@@ -242,6 +244,7 @@ CREATE TABLE IF NOT EXISTS code_files (
   mtime         REAL,
   size_bytes    INTEGER DEFAULT 0,
   line_count    INTEGER DEFAULT 0,
+  mtime_ns      INTEGER,
   UNIQUE(repo_id, path)
 );
 
@@ -279,13 +282,22 @@ CREATE TABLE IF NOT EXISTS code_symbols (
   language        TEXT NOT NULL,
   parent_name     TEXT DEFAULT '',
   qualified_name  TEXT NOT NULL,
+  stable_symbol_id TEXT DEFAULT '',
+  content_hash    TEXT DEFAULT '',
+  summary         TEXT DEFAULT '',
+  decorators_json TEXT DEFAULT '[]',
+  keywords_json   TEXT DEFAULT '[]',
+  call_references_json TEXT DEFAULT '[]',
+  ecosystem_context TEXT DEFAULT '',
   indexed_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_cs_repo ON code_symbols(repo_id);
 CREATE INDEX IF NOT EXISTS idx_cs_name ON code_symbols(name);
 CREATE INDEX IF NOT EXISTS idx_cs_file ON code_symbols(file_id);
+CREATE INDEX IF NOT EXISTS idx_cs_stable ON code_symbols(repo_id, stable_symbol_id);
 CREATE INDEX IF NOT EXISTS idx_cf_repo ON code_files(repo_id);
+CREATE INDEX IF NOT EXISTS idx_cf_hash ON code_files(repo_id, content_hash);
 
 -- FTS5 for code symbol search
 CREATE VIRTUAL TABLE IF NOT EXISTS code_symbols_fts USING fts5(

--- a/services/code-search.js
+++ b/services/code-search.js
@@ -4,6 +4,7 @@ module.exports = {
   searchCodeLike: sourceRetrieval.searchCodeLike,
   searchCode: sourceRetrieval.searchCode,
   getCodeSource: sourceRetrieval.getCodeSource,
+  rankedContext: sourceRetrieval.rankedContext,
   listCodeReposInternal: sourceRetrieval.listCodeRepos,
   removeCodeRepoInternal: sourceRetrieval.removeCodeRepo,
 };

--- a/src/cli/commands/code-index.js
+++ b/src/cli/commands/code-index.js
@@ -5,6 +5,7 @@ const USAGE = {
   'reindex-repo': '--repo <repo-name> [--mode full|incremental]',
   'health-code-repo': '--repo <repo-name>',
   'search-code': '--query <text> [--repo NAME] [--kind TYPE] [--max-results N]',
+  'ranked-code-context': '--query <text> [--repo NAME] [--kind TYPE] [--token-budget N] [--max-results N]',
   'get-code-source': '--repo NAME --file PATH --name SYMBOL',
   'list-code-repos': '',
   'remove-code-repo': '--repo <repo-name>',
@@ -15,6 +16,7 @@ function register(commands) {
   commands['reindex-repo'] = (args) => codeCmd.reindexRepo(args);
   commands['health-code-repo'] = (args) => codeCmd.codeRepoHealth(args);
   commands['search-code'] = (args) => codeCmd.searchCode(args);
+  commands['ranked-code-context'] = (args) => codeCmd.rankedContext(args);
   commands['get-code-source'] = (args) => codeCmd.getCodeSource(args);
   commands['list-code-repos'] = () => codeCmd.listCodeRepos();
   commands['remove-code-repo'] = (args) => codeCmd.removeCodeRepo(args);

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -7,7 +7,14 @@ const { createCodeIndexRepository } = require('./repos');
 const { scanRepository } = require('./scanner');
 const { createParserRegistry, getLanguageForFile } = require('./parser-registry');
 const { extractSymbolsFromFile } = require('./symbol-extractor');
-const { buildImportEdges, buildImportEdgesForFiles, buildCallEdges, buildCallEdgesForFiles, buildComplexityMetrics, buildComplexityMetricsForFiles } = require('./edge-extractor');
+const {
+  buildImportEdges,
+  buildImportEdgesForFiles,
+  buildCallEdges,
+  buildCallEdgesForFiles,
+  buildComplexityMetrics,
+  buildComplexityMetricsForFiles,
+} = require('./edge-extractor');
 const { createParsePool } = require('./worker-pool');
 
 function emitProgress(args, phase, detail, stats) {
@@ -52,6 +59,69 @@ function getHeadCommit(repoPath) {
   } catch {
     return null;
   }
+}
+
+function getCurrentBranch(repoPath) {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function parseChangedPathsInput(input, repoPath) {
+  if (!input) {
+    return null;
+  }
+  let entries = input;
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return null;
+    }
+    try {
+      entries = JSON.parse(trimmed);
+    } catch {
+      entries = trimmed
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean);
+    }
+  }
+  if (!Array.isArray(entries)) {
+    return null;
+  }
+  const changed = new Set();
+  const deleted = new Set();
+  for (const entry of entries) {
+    let status = 'modified';
+    let filePath = entry;
+    if (entry && typeof entry === 'object') {
+      status = entry.status || entry.type || entry.change_type || entry.changeType || status;
+      filePath = entry.path || entry.file || entry.filePath || entry[1];
+    }
+    if (!filePath || typeof filePath !== 'string') {
+      continue;
+    }
+    const abs = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(repoPath, filePath);
+    if (/delete|remove|unlink/i.test(status) || !fs.existsSync(abs)) {
+      deleted.add(abs);
+    } else {
+      changed.add(abs);
+    }
+  }
+  return {
+    changed: [...changed],
+    deleted: [...deleted],
+    renamed: [],
+    currentHead: getHeadCommit(repoPath),
+    source: 'changed-paths',
+  };
 }
 
 function getGitDelta(repoPath, baseCommit) {
@@ -110,6 +180,8 @@ function fileRecordToParams(repoId, record) {
     content: record.content,
     contentHash: hashContent(record.content),
     mtime: record.stats.mtimeMs,
+    mtimeNs:
+      typeof record.stats.mtimeNs === 'bigint' ? Number(record.stats.mtimeNs) : Math.round(record.stats.mtimeMs * 1e6),
     sizeBytes: record.stats.size,
     lineCount: lines.length,
   };
@@ -148,6 +220,13 @@ function insertSymbols(repository, repoId, fileId, filePath, symbols) {
       bodyPreview: sym.body_preview || '',
       language: sym.language,
       parentName: sym.parent_name || '',
+      stableSymbolId: sym.stable_symbol_id || '',
+      contentHash: sym.content_hash || '',
+      summary: sym.summary || '',
+      decoratorsJson: sym.decorators_json || '[]',
+      keywordsJson: sym.keywords_json || '[]',
+      callReferencesJson: sym.call_references_json || '[]',
+      ecosystemContext: sym.ecosystem_context || '',
     });
     count++;
   }
@@ -209,10 +288,15 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
 }
 
 function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, deletedFileIds) {
-  emitProgress(args, 'analysis', {
-    step: 'build-import-graph',
-    message: `Step 5/5: incrementally rebuilding import graph for ${changedFileIds.length + deletedFileIds.length} affected files...`,
-  }, stats);
+  emitProgress(
+    args,
+    'analysis',
+    {
+      step: 'build-import-graph',
+      message: `Step 5/5: incrementally rebuilding import graph for ${changedFileIds.length + deletedFileIds.length} affected files...`,
+    },
+    stats,
+  );
 
   let importEdges = 0;
   let callEdges = 0;
@@ -224,26 +308,41 @@ function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, dele
     if (ig.success) importEdges = ig.edges;
   } catch {}
 
-  emitProgress(args, 'analysis', {
-    step: 'build-call-graph',
-    message: `Step 5/5: incrementally rebuilding call graph for affected files...`,
-  }, stats);
+  emitProgress(
+    args,
+    'analysis',
+    {
+      step: 'build-call-graph',
+      message: `Step 5/5: incrementally rebuilding call graph for affected files...`,
+    },
+    stats,
+  );
   try {
     const cg = buildCallEdgesForFiles(db, repoId, changedFileIds, deletedFileIds, {
       onProgress: (p) => {
-        emitProgress(args, 'analysis', {
-          step: 'build-call-graph',
-          message: `Step 5/5: rebuilding call graph... ${p.filesProcessed}/${p.totalFiles} files, ${p.callsFound} calls`,
-        }, stats);
+        emitProgress(
+          args,
+          'analysis',
+          {
+            step: 'build-call-graph',
+            message: `Step 5/5: rebuilding call graph... ${p.filesProcessed}/${p.totalFiles} files, ${p.callsFound} calls`,
+          },
+          stats,
+        );
       },
     });
     if (cg.success) callEdges = cg.calls;
   } catch {}
 
-  emitProgress(args, 'analysis', {
-    step: 'compute-complexity',
-    message: 'Step 5/5: incrementally computing complexity metrics...',
-  }, stats);
+  emitProgress(
+    args,
+    'analysis',
+    {
+      step: 'compute-complexity',
+      message: 'Step 5/5: incrementally computing complexity metrics...',
+    },
+    stats,
+  );
   try {
     const cc = buildComplexityMetricsForFiles(db, repoId, changedFileIds, deletedFileIds);
     if (cc.success) complexityCount = cc.symbols;
@@ -278,8 +377,25 @@ function formatSkipReport(report) {
     const top = topN(report.memorycodeignore);
     lines.push(`  .memorycodeignore: ${top.map(([d]) => d).join(', ')}...`);
   }
+  if (report.extraIgnore && Object.keys(report.extraIgnore).length > 0) {
+    const top = topN(report.extraIgnore);
+    lines.push(`  extra ignore: ${top.map(([d]) => d).join(', ')}...`);
+  }
   if (report.unsupportedExt > 0) {
     lines.push(`  Non-code files: ${report.unsupportedExt} skipped`);
+  }
+  for (const [key, label] of [
+    ['tooLarge', 'Oversize files'],
+    ['binary', 'Binary files'],
+    ['secret', 'Secret-like files'],
+    ['symlink', 'Symlinks'],
+    ['pathTraversal', 'Path escapes'],
+    ['unreadable', 'Unreadable entries'],
+    ['fileLimit', 'Files beyond cap'],
+  ]) {
+    if (report[key] > 0) {
+      lines.push(`  ${label}: ${report[key]} skipped`);
+    }
   }
   return lines.join('\n');
 }
@@ -411,7 +527,9 @@ async function parsePhase(files, deps, repoId, args) {
               repoId,
               record,
               symbols.length === 0 && record.content.trim().length > 0 ? 'zero_symbols' : 'ok',
-              symbols.length === 0 && record.content.trim().length > 0 ? 'No symbols extracted from non-empty file' : '',
+              symbols.length === 0 && record.content.trim().length > 0
+                ? 'No symbols extracted from non-empty file'
+                : '',
               symbols.length,
             );
             parsedRecords.push({ record, symbols });
@@ -489,6 +607,13 @@ async function parsePhase(files, deps, repoId, args) {
                 bodyPreview: sym.body_preview || '',
                 language: sym.language,
                 parentName: sym.parent_name || '',
+                stableSymbolId: sym.stable_symbol_id || '',
+                contentHash: sym.content_hash || '',
+                summary: sym.summary || '',
+                decoratorsJson: sym.decorators_json || '[]',
+                keywordsJson: sym.keywords_json || '[]',
+                callReferencesJson: sym.call_references_json || '[]',
+                ecosystemContext: sym.ecosystem_context || '',
               });
             }
             symbolCount += symbols.length;
@@ -612,7 +737,7 @@ async function indexRepository(deps, repoPath, repoName) {
   });
   const derivedT0 = Date.now();
   const headCommit = getHeadCommit(absPath);
-  repository.updateRepoStats({ repoId, headCommit });
+  repository.updateRepoStats({ repoId, headCommit, currentBranch: getCurrentBranch(absPath), baseHead: headCommit });
   const derived = await derivedPhase(db, repoId, args, files.length, parseResult.fileCount, parseResult.symbolCount);
   const derivedMs = Date.now() - derivedT0;
 
@@ -672,11 +797,16 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
   });
   emitProgress(args, 'discovery', { step: 'discover-files', message: 'Step 2/5: discovering code files to check...' });
 
-  const gitDelta = fs.existsSync(existing.path) ? getGitDelta(existing.path, existing.head_commit) : null;
+  const explicitDelta = fs.existsSync(existing.path)
+    ? parseChangedPathsInput(args.changedPaths || args['changed-paths'] || args.paths, existing.path)
+    : null;
+  const gitDelta =
+    explicitDelta || (fs.existsSync(existing.path) ? getGitDelta(existing.path, existing.head_commit) : null);
   const gitChangedFiles = gitDelta
     ? gitDelta.changed.filter((filePath) => fs.existsSync(filePath) && registry.canParseFile(filePath))
     : null;
   const gitDeletedFiles = gitDelta ? gitDelta.deleted : [];
+  const explicitChangedPathMode = gitDelta && gitDelta.source === 'changed-paths';
   const scanResult = gitDelta
     ? {
         files: gitChangedFiles,
@@ -793,9 +923,10 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
   }
 
   const currentFilesSet = new Set(files);
-  const staleFiles = gitDelta
-    ? [...existingFiles.entries()].filter(([filePath]) => gitDeletedFiles.includes(filePath))
-    : [...existingFiles.entries()].filter(([filePath]) => !currentFilesSet.has(filePath));
+  const staleFiles =
+    gitDelta || explicitChangedPathMode
+      ? [...existingFiles.entries()].filter(([filePath]) => gitDeletedFiles.includes(filePath))
+      : [...existingFiles.entries()].filter(([filePath]) => !currentFilesSet.has(filePath));
   for (const [, fileInfo] of staleFiles) {
     deletedFileIds.push(fileInfo.id);
     repository.deleteFile(fileInfo.id);
@@ -810,8 +941,22 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
     step: 'derived-indexes',
     message: 'Step 5/5: rebuilding derived indexes (imports, calls, complexity)...',
   });
-  repository.updateRepoStats({ repoId: existing.id, headCommit: gitDelta?.currentHead || getHeadCommit(existing.path) });
-  const derived = rebuildDerivedIndexes(db, existing.id, args, totalFiles, totalFiles, symbolCount, changedFileIds, deletedFileIds);
+  repository.updateRepoStats({
+    repoId: existing.id,
+    headCommit: gitDelta?.currentHead || getHeadCommit(existing.path),
+    currentBranch: getCurrentBranch(existing.path),
+    baseHead: existing.head_commit || null,
+  });
+  const derived = rebuildDerivedIndexes(
+    db,
+    existing.id,
+    args,
+    totalFiles,
+    totalFiles,
+    symbolCount,
+    changedFileIds,
+    deletedFileIds,
+  );
 
   const totalMs = Date.now() - t0;
   emitProgress(
@@ -927,6 +1072,8 @@ module.exports = {
   emitProgress,
   fileRecordToParams,
   getHeadCommit,
+  getCurrentBranch,
+  parseChangedPathsInput,
   getCodeRepoHealth,
   indexRepository,
   insertSymbols,

--- a/src/code-index/read-model.js
+++ b/src/code-index/read-model.js
@@ -6,8 +6,8 @@
  */
 
 /** @typedef {{ id: number, name: string, path: string, file_count?: number, symbol_count?: number, indexed_at?: string, updated_at?: string, head_commit?: string }} CodeRepository */
-/** @typedef {{ id: number, repo_id: number, path: string, language: string, content?: string, content_hash?: string, mtime?: number, size_bytes?: number, line_count?: number }} CodeFile */
-/** @typedef {{ id?: number, repo_id?: number, file_id?: number, file_path: string, name: string, kind: string, signature?: string, qualified_name?: string, start_line: number, end_line: number, start_byte: number, end_byte: number, docstring?: string, body_preview?: string, language: string, parent_name?: string }} CodeSymbol */
+/** @typedef {{ id: number, repo_id: number, path: string, language: string, content?: string, content_hash?: string, mtime?: number, size_bytes?: number, line_count?: number, mtime_ns?: number }} CodeFile */
+/** @typedef {{ id?: number, repo_id?: number, file_id?: number, file_path: string, name: string, kind: string, signature?: string, qualified_name?: string, start_line: number, end_line: number, start_byte: number, end_byte: number, docstring?: string, body_preview?: string, language: string, parent_name?: string, stable_symbol_id?: string, content_hash?: string, summary?: string, decorators_json?: string, keywords_json?: string, call_references_json?: string, ecosystem_context?: string }} CodeSymbol */
 /** @typedef {{ id?: number, repo_id: number, source_file_id: number, target_module: string, target_file_id?: number | null, import_type: string, line_number?: number }} ImportEdge */
 /** @typedef {{ id?: number, repo_id: number, caller_symbol_id: number, callee_name: string, callee_symbol_id?: number | null, confidence: number, line_number?: number }} CallEdge */
 /** @typedef {{ id?: number, symbol_id: number, cyclomatic: number, nesting_depth: number, param_count: number, lines_of_code: number, assessment: string }} ComplexityMetric */

--- a/src/code-index/repos.js
+++ b/src/code-index/repos.js
@@ -131,10 +131,11 @@ function createCodeIndexRepository(deps) {
         params.mtime,
         params.sizeBytes,
         params.lineCount,
+        params.mtimeNs || null,
       ];
       try {
         const rows = sqlJson(
-          'INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id',
+          'INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count, mtime_ns) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id',
           values,
         );
         if (rows && rows[0] && rows[0].id) {
@@ -145,7 +146,7 @@ function createCodeIndexRepository(deps) {
         // The fallback insert-then-lookup path keeps indexing portable.
       }
       sqlRun(
-        'INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count, mtime_ns) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
         values,
       );
       return sqlJson('SELECT id FROM code_files WHERE repo_id = ? AND path = ?', [params.repoId, params.path])[0].id;
@@ -163,15 +164,27 @@ function createCodeIndexRepository(deps) {
     },
     updateFile(fileId, params) {
       sqlRun(
-        'UPDATE code_files SET content = ?, content_hash = ?, mtime = ?, size_bytes = ?, line_count = ?, language = ? WHERE id = ?',
-        [params.content, params.contentHash, params.mtime, params.sizeBytes, params.lineCount, params.language, fileId],
+        'UPDATE code_files SET content = ?, content_hash = ?, mtime = ?, size_bytes = ?, line_count = ?, language = ?, mtime_ns = ? WHERE id = ?',
+        [
+          params.content,
+          params.contentHash,
+          params.mtime,
+          params.sizeBytes,
+          params.lineCount,
+          params.language,
+          params.mtimeNs || null,
+          fileId,
+        ],
       );
     },
     deleteFile(fileId) {
       const rows = sqlJson('SELECT repo_id, path FROM code_files WHERE id = ? LIMIT 1', [fileId]);
       sqlRun('DELETE FROM code_symbols WHERE file_id = ?', [fileId]);
       if (rows.length) {
-        sqlRun('DELETE FROM code_file_diagnostics WHERE repo_id = ? AND file_path = ?', [rows[0].repo_id, rows[0].path]);
+        sqlRun('DELETE FROM code_file_diagnostics WHERE repo_id = ? AND file_path = ?', [
+          rows[0].repo_id,
+          rows[0].path,
+        ]);
       }
       sqlRun('DELETE FROM code_files WHERE id = ?', [fileId]);
     },
@@ -225,8 +238,9 @@ function createCodeIndexRepository(deps) {
     insertSymbol(params) {
       sqlRun(
         `INSERT INTO code_symbols (repo_id, file_id, file_path, name, kind, signature, qualified_name,
-         start_line, end_line, start_byte, end_byte, docstring, body_preview, language, parent_name)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         start_line, end_line, start_byte, end_byte, docstring, body_preview, language, parent_name,
+         stable_symbol_id, content_hash, summary, decorators_json, keywords_json, call_references_json, ecosystem_context)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           params.repoId,
           params.fileId,
@@ -243,6 +257,13 @@ function createCodeIndexRepository(deps) {
           params.bodyPreview || '',
           params.language,
           params.parentName || '',
+          params.stableSymbolId || '',
+          params.contentHash || '',
+          params.summary || '',
+          params.decoratorsJson || '[]',
+          params.keywordsJson || '[]',
+          params.callReferencesJson || '[]',
+          params.ecosystemContext || '',
         ],
       );
     },
@@ -254,10 +275,10 @@ function createCodeIndexRepository(deps) {
         }
       });
     },
-    updateRepoStats({ repoId, headCommit }) {
+    updateRepoStats({ repoId, headCommit, currentBranch, baseHead }) {
       sqlRun(
-        "UPDATE code_repos SET file_count = (SELECT count(*) FROM code_files WHERE repo_id = ?), symbol_count = (SELECT count(*) FROM code_symbols WHERE repo_id = ?), head_commit = COALESCE(?, head_commit), updated_at = datetime('now') WHERE id = ?",
-        [repoId, repoId, headCommit || null, repoId],
+        "UPDATE code_repos SET file_count = (SELECT count(*) FROM code_files WHERE repo_id = ?), symbol_count = (SELECT count(*) FROM code_symbols WHERE repo_id = ?), head_commit = COALESCE(?, head_commit), current_branch = COALESCE(?, current_branch), base_head = COALESCE(?, base_head), updated_at = datetime('now') WHERE id = ?",
+        [repoId, repoId, headCommit || null, currentBranch || null, baseHead || null, repoId],
       );
     },
     listRepos() {

--- a/src/code-index/scanner.js
+++ b/src/code-index/scanner.js
@@ -2,6 +2,11 @@ const path = require('path');
 const fs = require('fs');
 const { CODE_EXTENSIONS, IGNORE_DIRS_CODE } = require('../../utils');
 
+const DEFAULT_MAX_FILE_SIZE = 1024 * 1024;
+const DEFAULT_MAX_FILES = 20000;
+const SECRET_FILE_RE = /(^|[/\\])(\.env($|\.)|id_rsa$|id_dsa$|id_ecdsa$|id_ed25519$|.*\.(pem|key|p12|pfx)$)/i;
+const PRIORITY_DIRS = ['src/', 'lib/', 'pkg/', 'cmd/', 'internal/', 'app/', 'packages/'];
+
 function shouldSkipDir(dirName, extraIgnoreDirs = []) {
   return dirName.startsWith('.') || IGNORE_DIRS_CODE.has(dirName) || extraIgnoreDirs.includes(dirName);
 }
@@ -57,15 +62,99 @@ function loadMemorycodeignoreRules(repoPath) {
   return loadIgnoreRules(repoPath, '.memorycodeignore');
 }
 
+function tryCreateIgnore(patterns) {
+  if (!patterns || patterns.length === 0) {
+    return null;
+  }
+  try {
+    return require('ignore')().add(patterns);
+  } catch {
+    return null;
+  }
+}
+
+function isBinaryFile(filePath, sampleSize = 8000) {
+  try {
+    const fd = fs.openSync(filePath, 'r');
+    try {
+      const buf = Buffer.alloc(sampleSize);
+      const bytesRead = fs.readSync(fd, buf, 0, sampleSize, 0);
+      if (bytesRead === 0) {
+        return false;
+      }
+      for (let i = 0; i < bytesRead; i++) {
+        if (buf[i] === 0) {
+          return true;
+        }
+      }
+      return false;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+}
+
+function pathIsInside(root, candidate) {
+  const rel = path.relative(root, candidate);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+function prioritySort(root) {
+  return (a, b) => {
+    const ar = path.relative(root, a).replace(/\\/g, '/');
+    const br = path.relative(root, b).replace(/\\/g, '/');
+    const ap = PRIORITY_DIRS.findIndex((prefix) => ar.startsWith(prefix));
+    const bp = PRIORITY_DIRS.findIndex((prefix) => br.startsWith(prefix));
+    const ai = ap === -1 ? PRIORITY_DIRS.length : ap;
+    const bi = bp === -1 ? PRIORITY_DIRS.length : bp;
+    if (ai !== bi) {
+      return ai - bi;
+    }
+    return ar.localeCompare(br);
+  };
+}
+
 function scanRepository(repoPath, options = {}) {
   const results = [];
+  const absRoot = path.resolve(repoPath);
   const extraIgnoreDirs = options.ignoreDirs || [];
-  const gitignoreIg = loadGitignoreRules(repoPath);
-  const memorycodeignoreIg = loadMemorycodeignoreRules(repoPath);
-  const skipReport = { builtIn: {}, gitignore: {}, memorycodeignore: {}, unsupportedExt: 0 };
+  const gitignoreIg = loadGitignoreRules(absRoot);
+  const nestedGitignoreRules = [];
+  const memorycodeignoreIg = loadMemorycodeignoreRules(absRoot);
+  const extraIgnoreIg = tryCreateIgnore(options.extraIgnorePatterns || []);
+  const maxFileSize = Number(options.maxFileSize || DEFAULT_MAX_FILE_SIZE);
+  const maxFiles = Number(options.maxFiles || DEFAULT_MAX_FILES);
+  const followSymlinks = options.followSymlinks === true;
+  const skipReport = {
+    builtIn: {},
+    gitignore: {},
+    memorycodeignore: {},
+    extraIgnore: {},
+    unsupportedExt: 0,
+    tooLarge: 0,
+    binary: 0,
+    secret: 0,
+    symlink: 0,
+    pathTraversal: 0,
+    unreadable: 0,
+    fileLimit: 0,
+  };
   const ignoreFiles = options.onProgress || null;
   const reportScanProgress = options.onScanProgress || null;
   const scanStats = { dirsVisited: 0, entriesSeen: 0, codeFiles: 0, currentPath: '.', currentKind: 'directory' };
+
+  function mark(reason, key, relativePath) {
+    if (typeof skipReport[reason] === 'number') {
+      skipReport[reason]++;
+    } else {
+      skipReport[reason][key] = (skipReport[reason][key] || 0) + 1;
+    }
+    if (ignoreFiles) {
+      ignoreFiles(relativePath, reason);
+    }
+  }
 
   function maybeReportScanProgress(force = false) {
     if (!reportScanProgress) {
@@ -81,9 +170,33 @@ function scanRepository(repoPath, options = {}) {
     }
   }
 
+  function ignoredBy(relativePath, isDir = false) {
+    const rel = relativePath.replace(/\\/g, '/') + (isDir && !relativePath.endsWith(path.sep) ? '/' : '');
+    if (gitignoreIg && (gitignoreIg.ignores(relativePath) || gitignoreIg.ignores(rel))) {
+      return 'gitignore';
+    }
+    for (const rule of nestedGitignoreRules) {
+      if (!relativePath.startsWith(rule.prefix)) {
+        continue;
+      }
+      const local = relativePath.slice(rule.prefix.length).replace(/\\/g, '/');
+      const localDir = local + (isDir && !local.endsWith('/') ? '/' : '');
+      if (local && (rule.ig.ignores(local) || rule.ig.ignores(localDir))) {
+        return 'gitignore';
+      }
+    }
+    if (memorycodeignoreIg && (memorycodeignoreIg.ignores(relativePath) || memorycodeignoreIg.ignores(rel))) {
+      return 'memorycodeignore';
+    }
+    if (extraIgnoreIg && (extraIgnoreIg.ignores(relativePath) || extraIgnoreIg.ignores(rel))) {
+      return 'extraIgnore';
+    }
+    return null;
+  }
+
   function walk(dir) {
     scanStats.dirsVisited++;
-    scanStats.currentPath = path.relative(repoPath, dir) || '.';
+    scanStats.currentPath = path.relative(absRoot, dir) || '.';
     scanStats.currentKind = 'directory';
     if (scanStats.dirsVisited <= 5 || scanStats.dirsVisited % 50 === 0) {
       maybeReportScanProgress(true);
@@ -92,57 +205,94 @@ function scanRepository(repoPath, options = {}) {
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
+      skipReport.unreadable++;
       return;
+    }
+
+    if (entries.some((entry) => entry.isFile() && entry.name === '.gitignore')) {
+      try {
+        const ig = require('ignore')().add(fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8'));
+        const dirRel = path.relative(absRoot, dir);
+        nestedGitignoreRules.push({ prefix: dirRel ? `${dirRel}${path.sep}` : '', ig });
+      } catch {}
     }
 
     for (const entry of entries) {
       scanStats.entriesSeen++;
       const fullPath = path.join(dir, entry.name);
-      const relativePath = path.relative(repoPath, fullPath);
+      const relativePath = path.relative(absRoot, fullPath);
       scanStats.currentPath = relativePath;
       scanStats.currentKind = entry.isDirectory() ? 'directory' : 'file';
+      if (entry.isSymbolicLink() && !followSymlinks) {
+        mark('symlink', entry.name, relativePath);
+        continue;
+      }
+      let resolved = fullPath;
+      try {
+        resolved = fs.realpathSync(fullPath);
+      } catch {}
+      if (!pathIsInside(absRoot, resolved)) {
+        mark('pathTraversal', entry.name, relativePath);
+        continue;
+      }
       if (entry.isDirectory()) {
         if (shouldSkipDir(entry.name, extraIgnoreDirs)) {
-          skipReport.builtIn[entry.name] = (skipReport.builtIn[entry.name] || 0) + 1;
-          if (ignoreFiles) {
-            ignoreFiles(relativePath, 'built-in');
-          }
-        } else if (gitignoreIg && gitignoreIg.ignores(relativePath)) {
-          skipReport.gitignore[entry.name] = (skipReport.gitignore[entry.name] || 0) + 1;
-          if (ignoreFiles) {
-            ignoreFiles(relativePath, '.gitignore');
-          }
-        } else if (memorycodeignoreIg && memorycodeignoreIg.ignores(relativePath)) {
-          skipReport.memorycodeignore[entry.name] = (skipReport.memorycodeignore[entry.name] || 0) + 1;
-          if (ignoreFiles) {
-            ignoreFiles(relativePath, '.memorycodeignore');
-          }
+          mark('builtIn', entry.name, relativePath);
         } else {
-          walk(fullPath);
+          const ignored = ignoredBy(relativePath, true);
+          if (ignored) {
+            mark(ignored, entry.name, relativePath);
+          } else {
+            walk(fullPath);
+          }
         }
       } else if (entry.isFile()) {
         if (!isCodeFile(fullPath)) {
           skipReport.unsupportedExt++;
           maybeReportScanProgress();
-        } else {
-          const shouldSkip =
-            (gitignoreIg && gitignoreIg.ignores(relativePath)) ||
-            (memorycodeignoreIg && memorycodeignoreIg.ignores(relativePath));
-          if (!shouldSkip) {
-            results.push(fullPath);
-            scanStats.codeFiles++;
-            maybeReportScanProgress();
-          }
+          continue;
         }
+        const ignored = ignoredBy(relativePath, false);
+        if (ignored) {
+          mark(ignored, path.extname(entry.name) || entry.name, relativePath);
+          continue;
+        }
+        if (SECRET_FILE_RE.test(relativePath.replace(/\\/g, '/'))) {
+          mark('secret', entry.name, relativePath);
+          continue;
+        }
+        let stats;
+        try {
+          stats = fs.statSync(fullPath);
+        } catch {
+          skipReport.unreadable++;
+          continue;
+        }
+        if (maxFileSize > 0 && stats.size > maxFileSize) {
+          mark('tooLarge', path.extname(entry.name) || entry.name, relativePath);
+          continue;
+        }
+        if (isBinaryFile(fullPath)) {
+          mark('binary', path.extname(entry.name) || entry.name, relativePath);
+          continue;
+        }
+        results.push(fullPath);
+        scanStats.codeFiles++;
+        maybeReportScanProgress();
       }
     }
   }
 
-  walk(repoPath);
+  walk(absRoot);
+  if (results.length > maxFiles) {
+    skipReport.fileLimit = results.length - maxFiles;
+    results.sort(prioritySort(absRoot));
+    results.length = maxFiles;
+  }
   if (reportScanProgress) {
     reportScanProgress({ ...scanStats, done: true });
   }
   return { files: results, skipReport };
 }
 
-module.exports = { isCodeFile, scanRepository, shouldSkipDir, loadGitignoreRules };
+module.exports = { isBinaryFile, isCodeFile, scanRepository, shouldSkipDir, loadGitignoreRules };

--- a/src/code-index/source-retrieval.js
+++ b/src/code-index/source-retrieval.js
@@ -1,4 +1,5 @@
 const { ensureDb, sqlJson, sqlRaw } = require('../../db');
+const { estimateTokens } = require('../../utils');
 const { createCodeIndexRepository } = require('./repos');
 
 function sourceSliceFromRow(row) {
@@ -26,6 +27,68 @@ function getCodeSource(repoName, filePath, symbolName, repository = null) {
   };
 }
 
+function tokenize(text) {
+  return (
+    (text || '')
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .toLowerCase()
+      .match(/[a-z_][a-z0-9_]{1,}/g) || []
+  );
+}
+
+function ensureCodeFts() {
+  const ftsCheck = sqlJson("SELECT name FROM sqlite_master WHERE type='table' AND name='code_symbols_fts'");
+  if (!ftsCheck.length) {
+    sqlRaw(`CREATE VIRTUAL TABLE IF NOT EXISTS code_symbols_fts USING fts5(
+      name, kind, signature, docstring, file_path, body_preview, content=code_symbols, content_rowid=id)`);
+  }
+}
+
+function centralityBySymbol(repoName) {
+  const rows = sqlJson(
+    `SELECT s.id,
+      COALESCE(in_calls.count, 0) AS inbound_calls,
+      COALESCE(out_calls.count, 0) AS outbound_calls,
+      COALESCE(importers.count, 0) AS importers
+     FROM code_symbols s
+     JOIN code_repos r ON r.id = s.repo_id
+     LEFT JOIN (SELECT callee_symbol_id AS id, COUNT(*) AS count FROM code_calls WHERE callee_symbol_id IS NOT NULL GROUP BY callee_symbol_id) in_calls ON in_calls.id = s.id
+     LEFT JOIN (SELECT caller_symbol_id AS id, COUNT(*) AS count FROM code_calls GROUP BY caller_symbol_id) out_calls ON out_calls.id = s.id
+     LEFT JOIN (SELECT cf.id AS file_id, COUNT(*) AS count FROM code_imports ci JOIN code_files cf ON cf.id = ci.target_file_id GROUP BY cf.id) importers ON importers.file_id = s.file_id
+     WHERE (? IS NULL OR r.name = ?)`,
+    [repoName, repoName],
+  );
+  const scores = new Map();
+  let max = 0;
+  for (const row of rows) {
+    const score = row.inbound_calls * 2 + row.importers * 1.5 + row.outbound_calls * 0.25;
+    scores.set(row.id, score);
+    if (score > max) {
+      max = score;
+    }
+  }
+  return { scores, max: max || 1 };
+}
+
+function mapSearchRow(row, i) {
+  return {
+    rank: i + 1,
+    score: row.score,
+    repo: row.repo,
+    file: row.file,
+    symbol: row.symbol_name,
+    kind: row.kind,
+    line: row.start_line,
+    end_line: row.end_line,
+    signature: row.signature,
+    docstring: row.docstring,
+    snippet: row.snippet,
+    qualified_name: row.qualified_name,
+    language: row.language,
+    summary: row.summary || '',
+  };
+}
+
 function searchCodeLike(query, repoName, kind, maxResults) {
   const likeQuery = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
   let sql = `
@@ -33,13 +96,13 @@ function searchCodeLike(query, repoName, kind, maxResults) {
       s.id, r.name AS repo, s.file_path AS file,
       s.name AS symbol_name, s.kind, s.start_line, s.end_line,
       s.signature, s.docstring, s.body_preview AS snippet,
-      s.qualified_name, s.language,
+      s.qualified_name, s.language, s.summary,
       0.0 AS score
     FROM code_symbols s
     JOIN code_repos r ON r.id = s.repo_id
-    WHERE s.name LIKE ?
+    WHERE (s.name LIKE ? OR s.qualified_name LIKE ? OR s.signature LIKE ? OR s.summary LIKE ?)
   `;
-  const params = [likeQuery];
+  const params = [likeQuery, likeQuery, likeQuery, likeQuery];
 
   if (repoName) {
     sql += ' AND r.name = ?';
@@ -55,21 +118,10 @@ function searchCodeLike(query, repoName, kind, maxResults) {
 
   const rows = sqlJson(sql, params);
   return {
-    results: rows.map((row, i) => ({
-      rank: i + 1,
-      score: row.score,
-      repo: row.repo,
-      file: row.file,
-      symbol: row.symbol_name,
-      kind: row.kind,
-      line: row.start_line,
-      end_line: row.end_line,
-      signature: row.signature,
-      docstring: row.docstring,
-      snippet: row.snippet,
-      qualified_name: row.qualified_name,
-      language: row.language,
-    })),
+    query,
+    results: rows.map(mapSearchRow),
+    total: rows.length,
+    strategy: 'like',
   };
 }
 
@@ -77,28 +129,25 @@ function searchCode(query, repoName, kind, maxResults) {
   ensureDb();
 
   try {
-    const ftsCheck = sqlJson("SELECT name FROM sqlite_master WHERE type='table' AND name='code_symbols_fts'");
-    if (!ftsCheck.length) {
-      try {
-        sqlRaw(`CREATE VIRTUAL TABLE IF NOT EXISTS code_symbols_fts USING fts5(
-          name, kind, signature, docstring, file_path, body_preview, content=code_symbols, content_rowid=id)`);
-      } catch (_) {
-        return searchCodeLike(query, repoName, kind, maxResults);
-      }
-    }
+    ensureCodeFts();
   } catch (_) {
     return searchCodeLike(query, repoName, kind, maxResults);
   }
 
-  const ftsQuery = query.replace(/"/g, "''").split(/\s+/).join(' OR ');
+  const ftsQuery = tokenize(query)
+    .map((term) => `${term}*`)
+    .join(' OR ');
+  if (!ftsQuery) {
+    return searchCodeLike(query, repoName, kind, maxResults);
+  }
 
   let sql = `
     SELECT
       s.id, r.name AS repo, s.file_path AS file,
       s.name AS symbol_name, s.kind, s.start_line, s.end_line,
       s.signature, s.docstring, s.body_preview AS snippet,
-      s.qualified_name, s.language,
-      bm25(code_symbols_fts) AS score
+      s.qualified_name, s.language, s.summary,
+      bm25(code_symbols_fts) AS bm25_score
     FROM code_symbols_fts
     JOIN code_symbols s ON s.id = code_symbols_fts.rowid
     JOIN code_repos r ON r.id = s.repo_id
@@ -116,25 +165,88 @@ function searchCode(query, repoName, kind, maxResults) {
   }
 
   sql += ' ORDER BY bm25(code_symbols_fts) LIMIT ?';
-  params.push(maxResults);
+  params.push(Math.max(maxResults * 4, maxResults));
 
-  const rows = sqlJson(sql, params);
-  const results = rows.map((row, i) => ({
-    rank: i + 1,
-    score: row.score,
-    repo: row.repo,
-    file: row.file,
-    symbol: row.symbol_name,
-    kind: row.kind,
-    line: row.start_line,
-    end_line: row.end_line,
-    signature: row.signature,
-    docstring: row.docstring,
-    snippet: row.snippet,
-    language: row.language,
-  }));
+  let rows;
+  try {
+    rows = sqlJson(sql, params);
+  } catch (_) {
+    return searchCodeLike(query, repoName, kind, maxResults);
+  }
+  const { scores, max } = centralityBySymbol(repoName || null);
+  const reranked = rows
+    .map((row) => {
+      const bm25Raw = Math.max(0, -Number(row.bm25_score || 0));
+      const bm25Norm = bm25Raw / (1 + bm25Raw);
+      const centralityNorm = (scores.get(row.id) || 0) / max;
+      return { ...row, score: 0.75 * bm25Norm + 0.25 * centralityNorm };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxResults);
 
-  return { query, results, total: results.length };
+  const results = reranked.map(mapSearchRow);
+  return { query, results, total: results.length, strategy: 'bm25-centrality' };
+}
+
+function rankedContext(query, repoName, options = {}) {
+  ensureDb();
+  const tokenBudget = Math.max(200, Number(options.tokenBudget || options.token_budget || 4000));
+  const maxResults = Math.max(1, Number(options.maxResults || options.max_results || 20));
+  const search = searchCode(query, repoName || null, options.kind || null, maxResults);
+  const items = [];
+  let totalTokens = 0;
+  let considered = 0;
+
+  for (const result of search.results || []) {
+    considered++;
+    const source = getCodeSource(result.repo, result.file, result.symbol);
+    if (!source.success) {
+      continue;
+    }
+    const text = [result.signature, result.summary, source.source].filter(Boolean).join('\n');
+    const tokens = estimateTokens(text);
+    if (items.length > 0 && totalTokens + tokens > tokenBudget) {
+      continue;
+    }
+    items.push({
+      repo: result.repo,
+      file: result.file,
+      symbol: result.symbol,
+      qualified_name: result.qualified_name,
+      kind: result.kind,
+      score: result.score,
+      start_line: result.line,
+      end_line: result.end_line,
+      signature: result.signature,
+      summary: result.summary,
+      tokens,
+      source: source.source,
+    });
+    totalTokens += tokens;
+    if (totalTokens >= tokenBudget) {
+      break;
+    }
+  }
+
+  const response = {
+    query,
+    repo: repoName || null,
+    context_items: items,
+    total_tokens: totalTokens,
+    budget_tokens: tokenBudget,
+    items_included: items.length,
+    items_considered: considered,
+    search_strategy: search.strategy,
+  };
+  if (items.length === 0) {
+    response.negative_evidence = {
+      verdict: 'no_implementation_found',
+      scanned_results: (search.results || []).length,
+      best_match_score: search.results && search.results[0] ? search.results[0].score : 0,
+    };
+    response.warning = `No implementation found for '${query.slice(0, 80)}'.`;
+  }
+  return response;
 }
 
 function listCodeRepos(repository = null) {
@@ -153,4 +265,12 @@ function removeCodeRepo(name, repository = null) {
   return { success: true, repo: name, removed: true };
 }
 
-module.exports = { sourceSliceFromRow, getCodeSource, searchCodeLike, searchCode, listCodeRepos, removeCodeRepo };
+module.exports = {
+  sourceSliceFromRow,
+  getCodeSource,
+  rankedContext,
+  searchCodeLike,
+  searchCode,
+  listCodeRepos,
+  removeCodeRepo,
+};

--- a/src/code-index/symbol-extractor.js
+++ b/src/code-index/symbol-extractor.js
@@ -1,7 +1,93 @@
+const crypto = require('crypto');
+const path = require('path');
 const { createParserRegistry } = require('./parser-registry');
 
-function normalizeSymbol(symbol, fallbackFilePath) {
-  return {
+function safeJson(value, fallback = []) {
+  try {
+    return JSON.stringify(Array.isArray(value) ? value : fallback);
+  } catch {
+    return JSON.stringify(fallback);
+  }
+}
+
+function hashText(text) {
+  return crypto
+    .createHash('sha256')
+    .update(text || '')
+    .digest('hex');
+}
+
+function sliceByBytes(content, startByte, endByte) {
+  if (!Number.isFinite(startByte) || !Number.isFinite(endByte) || endByte <= startByte) {
+    return '';
+  }
+  return Buffer.from(content || '', 'utf-8').toString('utf-8', startByte, endByte);
+}
+
+function extractDecorators(source) {
+  const decorators = [];
+  for (const line of (source || '').split('\n').slice(0, 12)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('@')) {
+      decorators.push(trimmed.split(/[\s(]/)[0]);
+    }
+  }
+  return decorators;
+}
+
+function extractKeywords(symbol, source) {
+  const text = [
+    symbol.name,
+    symbol.qualified_name,
+    symbol.kind,
+    symbol.signature,
+    symbol.docstring,
+    symbol.parent_name,
+    source,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const words =
+    text
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .toLowerCase()
+      .match(/[a-z_][a-z0-9_]{2,}/g) || [];
+  return [...new Set(words)].slice(0, 40);
+}
+
+function makeSummary(symbol) {
+  const doc = (symbol.docstring || '').trim().split('\n').find(Boolean);
+  if (doc) {
+    return doc.slice(0, 240);
+  }
+  const signature = (symbol.signature || '').trim();
+  if (signature) {
+    return signature.slice(0, 240);
+  }
+  return `${symbol.kind || 'symbol'} ${symbol.qualified_name || symbol.name}`.slice(0, 240);
+}
+
+function stableSymbolId(symbol, fallbackFilePath) {
+  return `${symbol.file_path || symbol.file || fallbackFilePath}::${symbol.qualified_name || symbol.name}#${symbol.kind || 'symbol'}`;
+}
+
+function collectCallReferences(symbol, callees) {
+  if (!Array.isArray(callees) || !Number.isFinite(symbol.start_line) || !Number.isFinite(symbol.end_line)) {
+    return [];
+  }
+  const refs = [];
+  for (const call of callees) {
+    const line = call.line || 0;
+    const name = call.full_path || call.callee;
+    if (name && line >= symbol.start_line && line <= symbol.end_line && name !== symbol.name) {
+      refs.push(name);
+    }
+  }
+  return [...new Set(refs)].slice(0, 80);
+}
+
+function normalizeSymbol(symbol, fallbackFilePath, context = {}) {
+  const normalized = {
     file_path: symbol.file_path || symbol.file || fallbackFilePath,
     name: symbol.name,
     kind: symbol.kind,
@@ -16,6 +102,18 @@ function normalizeSymbol(symbol, fallbackFilePath) {
     language: symbol.language || '',
     parent_name: symbol.parent_name || '',
   };
+  const source = context.content ? sliceByBytes(context.content, normalized.start_byte, normalized.end_byte) : '';
+  const decorators = symbol.decorators || extractDecorators(source);
+  const callReferences = symbol.call_references || collectCallReferences(normalized, context.callees || []);
+  normalized.stable_symbol_id = symbol.stable_symbol_id || symbol.id || stableSymbolId(normalized, fallbackFilePath);
+  normalized.content_hash =
+    symbol.content_hash || hashText(source || normalized.signature || normalized.qualified_name);
+  normalized.summary = symbol.summary || makeSummary(normalized);
+  normalized.decorators_json = safeJson(decorators);
+  normalized.keywords_json = safeJson(symbol.keywords || extractKeywords(normalized, source));
+  normalized.call_references_json = safeJson(callReferences);
+  normalized.ecosystem_context = symbol.ecosystem_context || '';
+  return normalized;
 }
 
 function extractSymbolsFromFile(filePath, registry, content) {
@@ -23,10 +121,27 @@ function extractSymbolsFromFile(filePath, registry, content) {
   if (!reg.canParseFile(filePath)) {
     return [];
   }
+  let rawSymbols;
+  let source = content;
   if (content !== undefined) {
-    return reg.parseContent(filePath, content).map((symbol) => normalizeSymbol(symbol, filePath));
+    rawSymbols = reg.parseContent(filePath, content);
+  } else {
+    rawSymbols = reg.parseFile(filePath);
+    try {
+      source = require('fs').readFileSync(filePath, 'utf-8');
+    } catch {
+      source = '';
+    }
   }
-  return reg.parseFile(filePath).map((symbol) => normalizeSymbol(symbol, filePath));
+  let callees = [];
+  if (source && typeof reg.extractCalleesFromContent === 'function') {
+    try {
+      callees = reg.extractCalleesFromContent(filePath, source);
+    } catch {}
+  }
+  return rawSymbols.map((symbol) =>
+    normalizeSymbol(symbol, filePath, { content: source || '', callees, relativeFile: path.basename(filePath) }),
+  );
 }
 
 module.exports = { extractSymbolsFromFile, normalizeSymbol };

--- a/src/trust-sync/change-detector.js
+++ b/src/trust-sync/change-detector.js
@@ -172,7 +172,7 @@ function parseChangedSymbolsJson(args, jsonErrNoExit) {
 
 /**
  * Creates a git trust sync adapter for the extension hook.
- * Now uses the built-in code index — no external jCodeMunch dependency.
+ * Uses the built-in code index for symbol-aware trust updates.
  */
 function createGitTrustSyncAdapter(mem, notify) {
   return async function syncGitOperation(repo) {

--- a/test/code-index-modules.test.js
+++ b/test/code-index-modules.test.js
@@ -108,6 +108,35 @@ describe('code-index symbol extractor', () => {
     });
   });
 
+  it('enriches symbols with stable metadata and call references', () => {
+    const source = 'function helper() { return 1; }\nfunction main() { return helper(); }\n';
+    const registry = {
+      canParseFile: () => true,
+      parseContent: () => [
+        {
+          name: 'main',
+          kind: 'function',
+          signature: 'function main()',
+          qualified_name: 'main',
+          start_line: 2,
+          end_line: 2,
+          start_byte: Buffer.byteLength('function helper() { return 1; }\n'),
+          end_byte: Buffer.byteLength(source),
+          language: 'javascript',
+        },
+      ],
+      extractCalleesFromContent: () => [{ callee: 'helper', full_path: 'helper', line: 2 }],
+    };
+
+    const [symbol] = extractSymbolsFromFile('/repo/app.js', registry, source);
+
+    expect(symbol.stable_symbol_id).toBe('/repo/app.js::main#function');
+    expect(symbol.content_hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.parse(symbol.call_references_json)).toEqual(['helper']);
+    expect(JSON.parse(symbol.keywords_json)).toContain('main');
+    expect(symbol.summary).toBe('function main()');
+  });
+
   it('extracts symbols through the parser registry abstraction', () => {
     const registry = {
       canParseFile: () => true,
@@ -200,6 +229,24 @@ describe('code-index source retrieval', () => {
     const endByte = startByte + Buffer.byteLength(expected, 'utf-8');
 
     expect(sourceSliceFromRow({ content, start_byte: startByte, end_byte: endByte })).toBe(expected);
+  });
+});
+
+describe('code-index scanner hardening', () => {
+  it('skips unsafe or noisy files and reports skip reasons', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-scan-hardening-'));
+    fs.mkdirSync(path.join(tmp, 'src'));
+    fs.writeFileSync(path.join(tmp, 'src', 'app.js'), 'function app() {}');
+    fs.writeFileSync(path.join(tmp, '.env.js'), 'TOKEN=secret');
+    fs.writeFileSync(path.join(tmp, 'large.js'), 'x'.repeat(128));
+    fs.writeFileSync(path.join(tmp, 'binary.js'), Buffer.from([0, 1, 2, 3]));
+
+    const result = scanRepository(tmp, { maxFileSize: 32 });
+
+    expect(result.files.map((f) => path.basename(f))).toEqual(['app.js']);
+    expect(result.skipReport.tooLarge).toBe(1);
+    expect(result.skipReport.binary).toBe(1);
+    expect(result.skipReport.secret).toBe(1);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Improve code search relevance and provide bounded source context for LLM use by introducing a ranked, token-budgeted context retrieval API.
- Persist richer code symbol metadata and repository state (branch/base/head) to enable cross-file analysis, stable IDs, and better deduping and reranking.
- Make repository scanning more robust and safer by skipping binaries, secrets, oversize files, honoring nested ignores, and limiting work.

### Description
- Database: bump schema to `PRAGMA user_version = 9`, add columns `current_branch`/`base_head` to `code_repos`, `mtime_ns` to `code_files`, and multiple metadata columns to `code_symbols`, plus new indexes and a `runMigrationV9` routine to backfill columns and indexes.
- Search & retrieval: add FTS-backed search with tokenization, BM25 + centrality reranking, and a new `rankedContext` API that assembles source snippets under a `tokenBudget`; export `rankedContext` through services/CLI/commands (`ranked-code-context`).
- Indexer & scanner: record `mtime_ns` and `current_branch` during indexing and reindexing, accept explicit changed-paths input via `parseChangedPathsInput`, update repo stats with branch/base head, and improve incremental reindex handling for deleted/stale files.
- Scanner hardening: add binary detection, secret file patterns, max file size and max files limits, nested `.gitignore` support, extra ignore patterns, symlink/path traversal checks, and priority sorting for trimming to `maxFiles`.
- Symbol extraction: enrich extracted symbols with `stable_symbol_id`, `content_hash`, `summary`, `decorators_json`, `keywords_json`, `call_references_json`, and `ecosystem_context`, and compute lightweight summaries/keywords/call refs.

### Testing
- Ran the unit test suite including `test/code-index-modules.test.js` which exercises symbol normalization, slicing, scanner hardening, and incremental reindex behavior, and all tests passed.
- Executed the code-index integration flows used by tests (`extractSymbolsFromFile`, `scanRepository`, `reindexRepository`) as part of the test run and observed expected progress reports and DB migrations succeeding in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0badcb0688832fbc0c899d6433bb90)