### PR TITLE
fix: multiple issues in Phase 5 Runtime Reality implementation

### DIFF
--- a/src/agent-intel/audit-diff.js
+++ b/src/agent-intel/audit-diff.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const { AUDIT_DIFF: CFG } = require('../../constants');
 
 function _requireNativeDb(db) {
@@ -152,8 +153,18 @@ function _checkHotPath(db, repoId, sym) {
   try {
     const runtimeIngest = require('./runtime-ingest');
     const hotSymbols = runtimeIngest.getHotSymbols(db, repoId, 100);
-    const hotMatch = hotSymbols.find(s => s.file_path === sym.file_path);
-    
+
+    // Normalize paths for comparison - get basename and check for matches
+    const symFileName = sym.file_path ? path.basename(sym.file_path) : '';
+    const hotMatch = hotSymbols.find(s => {
+      if (!s.file_path) return false;
+      // Try exact match first
+      if (s.file_path === sym.file_path) return true;
+      // Then try basename match for cross-platform compatibility
+      const runtimeFileName = path.basename(s.file_path);
+      return runtimeFileName === symFileName && s.function_name === sym.name;
+    });
+
     if (hotMatch) {
       return {
         type: 'hot_path_modified',

--- a/src/agent-intel/runtime-ingest.js
+++ b/src/agent-intel/runtime-ingest.js
@@ -65,26 +65,56 @@ function ingestCoverage(db, repoId, coveragePath, sourceFile = '') {
   const coverageData = parseCoverageFile(coveragePath);
   const functions = extractFunctionHits(coverageData);
 
+  // Pre-fetch symbol_id mapping for this repo to link runtime data to code symbols
+  const symbolLookup = new Map();
+  try {
+    const symbols = db.prepare(`
+      SELECT id, name, qualified_name, file_path
+      FROM code_symbols
+      WHERE repo_id = ?
+    `).all(repoId);
+    for (const sym of symbols) {
+      const key = `${sym.file_path}:${sym.name}`;
+      symbolLookup.set(key, sym.id);
+      // Also index by qualified name
+      if (sym.qualified_name) {
+        symbolLookup.set(`${sym.file_path}:${sym.qualified_name}`, sym.id);
+      }
+    }
+  } catch {
+    // code_symbols table may not exist yet - continue without linking
+  }
+
   const insertStmt = db.prepare(`
-    INSERT OR REPLACE INTO runtime_symbols 
-      (repo_id, file_path, function_name, line_start, hit_count, traffic, last_seen, source_file)
-    VALUES 
-      (?, ?, ?, ?, ?, ?, datetime('now'), ?)
+    INSERT OR REPLACE INTO runtime_symbols
+      (repo_id, symbol_id, file_path, function_name, line_start, hit_count, traffic, last_seen, source_file)
+    VALUES
+      (?, ?, ?, ?, ?, ?, ?, datetime('now'), ?)
   `);
 
   const upsert = db.transaction((fnList) => {
     let inserted = 0;
+    let linked = 0;
     for (const fn of fnList) {
-      insertStmt.run(repoId, fn.filePath, fn.functionName, fn.lineStart, fn.hitCount, fn.traffic, sourceFile);
+      // Look up symbol_id from code_symbols
+      let symbolId = null;
+      const key = `${fn.filePath}:${fn.functionName}`;
+      if (symbolLookup.has(key)) {
+        symbolId = symbolLookup.get(key);
+        linked++;
+      }
+
+      insertStmt.run(repoId, symbolId, fn.filePath, fn.functionName, fn.lineStart, fn.hitCount, fn.traffic, sourceFile);
       inserted++;
     }
-    return inserted;
+    return { inserted, linked };
   });
 
-  const inserted = upsert(functions);
+  const result = upsert(functions);
 
   return {
-    functions_ingested: inserted,
+    functions_ingested: result.inserted,
+    symbols_linked: result.linked,
     traffic_breakdown: {
       hot: functions.filter(f => f.traffic === 'hot').length,
       warm: functions.filter(f => f.traffic === 'warm').length,

--- a/src/agent-intel/stale-flags.js
+++ b/src/agent-intel/stale-flags.js
@@ -14,9 +14,18 @@ const path = require('path');
 const STALE_FLAG_PATTERNS = [
   /\bif\s*\(\s*true\s*\)/gi,
   /\bif\s*\(\s*false\s*\)/gi,
-  /\bif\s*\(\s*![^()]+\s*\)\s*\{[^}]*\}\s*else\s*\{/g,  // if (!x) { } else { always runs }
   /FEATURE_[A-Z_]+\s*===\s*['"](?:enabled?|on|true)['"]/gi,
   /FEATURE_[A-Z_]+\s*!==\s*['"](?:disabled?|off|false)['"]/gi,
+];
+
+// Pattern to detect one-sided branches where if block is empty or just a comment,
+// meaning the else block always runs
+const ONE_SIDED_IF_PATTERNS = [
+  // if (!x) { /* empty or only comments */ } else { ... }
+  /\bif\s*\(\s*![^)]+\)\s*\{\s*\/(?:\/|\*)[^\}]*\}\s*else/g,
+  // if (constant_expression) { never_runs(); } else { always_runs(); }
+  // Detect when if body clearly never executes (throw, return, etc.)
+  /\bif\s*\(\s*(?:true|false|1\s*==\s*1|0\s*==\s*1)\s*\)\s*\{(?:\s| |\n)*(?:return|throw|break|continue)[^}]*\}\s*else/g,
 ];
 
 const ALWAYS_TRUE_CONTEXT = [
@@ -27,19 +36,19 @@ const ALWAYS_TRUE_CONTEXT = [
 
 function scanFileForStaleFlags(filePath) {
   if (!fs.existsSync(filePath)) return [];
-  
+
   const content = fs.readFileSync(filePath, 'utf-8');
   const lines = content.split('\n');
   const findings = [];
 
-  // Pattern-based detection
+  // Pattern-based detection for constant conditions
   for (const pattern of STALE_FLAG_PATTERNS) {
     let match;
     const regex = new RegExp(pattern.source, pattern.flags);
     while ((match = regex.exec(content)) !== null) {
       const lineNum = content.substring(0, match.index).split('\n').length;
       const line = lines[lineNum - 1]?.trim() || '';
-      
+
       findings.push({
         filePath,
         lineNumber: lineNum,
@@ -49,16 +58,33 @@ function scanFileForStaleFlags(filePath) {
     }
   }
 
+  // Detect one-sided branches using dedicated patterns
+  for (const pattern of ONE_SIDED_IF_PATTERNS) {
+    let match;
+    const regex = new RegExp(pattern.source, pattern.flags || 'g');
+    while ((match = regex.exec(content)) !== null) {
+      const lineNum = content.substring(0, match.index).split('\n').length;
+      const line = lines[lineNum - 1]?.trim() || '';
+
+      findings.push({
+        filePath,
+        lineNumber: lineNum,
+        type: 'one_sided_branch',
+        context: line.substring(0, 100),
+      });
+    }
+  }
+
   // Check for one-sided ternaries: condition ? expr : expr (where expr is same)
   const ternaryRegex = /(\w+)\s*\?\s*(\w+)\s*:\s*\w+/g;
   let match;
   while ((match = ternaryRegex.exec(content)) !== null) {
-    const [, condition, truthyResult] = match;
+    const [, condition] = match;
     // Check if the condition looks like a flag constant
     if (ALWAYS_TRUE_CONTEXT.some(c => condition.includes(c))) {
       const lineNum = content.substring(0, match.index).split('\n').length;
       const line = lines[lineNum - 1]?.trim() || '';
-      
+
       findings.push({
         filePath,
         lineNumber: lineNum,
@@ -79,19 +105,37 @@ function detectStaleFlagsInRepo(db, repoId, repoPath) {
   `).all(repoId);
 
   const allFindings = [];
-  
+
   for (const { path: filePath } of files) {
-    // Resolve relative to repo path
-    const fullPath = path.isAbsolute(filePath) ? filePath : path.join(repoPath, filePath);
+    // Resolve relative to repo path (code_files.path may be absolute or relative to repo root)
+    let fullPath;
+    if (path.isAbsolute(filePath)) {
+      fullPath = filePath;
+    } else if (repoPath) {
+      fullPath = path.join(repoPath, filePath);
+    } else {
+      fullPath = filePath;
+    }
+
     const findings = scanFileForStaleFlags(fullPath);
-    
+
     for (const f of findings) {
+      // Determine branch_type based on finding type
+      let branchType = 'always-true';
+      if (f.type === 'constant_condition') {
+        if (f.context.includes('false')) {
+          branchType = 'always-false';
+        }
+      } else if (f.type === 'one_sided_branch') {
+        branchType = 'one-sided';
+      }
+
       allFindings.push({
         repo_id: repoId,
         file_path: f.filePath,
         line_number: f.lineNumber,
         flag_name: f.context.match(/FEATURE_\w+/)?.[0] || extractCondition(f.context),
-        branch_type: f.type === 'constant_condition' && f.context.includes('false') ? 'always-false' : 'always-true',
+        branch_type: branchType,
         context: f.context,
       });
     }
@@ -106,14 +150,14 @@ function extractCondition(context) {
 }
 
 function persistStaleFlags(db, findings) {
-  if (findings.length === 0) return { inserted: 0 };
+  if (findings.length === 0) return { inserted: 0, errors: [] };
 
   // Check if table exists before inserting
   try {
     const tableCheck = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='stale_flags'").get();
-    if (!tableCheck) return { inserted: 0 };
-  } catch {
-    return { inserted: 0 };
+    if (!tableCheck) return { inserted: 0, errors: ['stale_flags table does not exist'] };
+  } catch (e) {
+    return { inserted: 0, errors: [e.message] };
   }
 
   const insert = db.prepare(`
@@ -121,20 +165,24 @@ function persistStaleFlags(db, findings) {
     VALUES (?, ?, ?, ?, ?, ?)
   `);
 
+  const errors = [];
   const tx = db.transaction((items) => {
     let count = 0;
     for (const f of items) {
       try {
         insert.run(f.repo_id, f.file_path, f.line_number, f.flag_name, f.branch_type, f.context);
         count++;
-      } catch {
-        // Skip duplicates
+      } catch (e) {
+        // Only skip duplicates, collect other errors
+        if (!e.message.includes('UNIQUE constraint failed')) {
+          errors.push(`Insert error for ${f.file_path}:${f.line_number}: ${e.message}`);
+        }
       }
     }
     return count;
   });
 
-  return { inserted: tx(findings) };
+  return { inserted: tx(findings), errors };
 }
 
 function getStaleFlags(db, repoId) {


### PR DESCRIPTION
1. runtime-ingest.js: Link symbol_id when ingesting coverage data
   - Pre-fetch code_symbols to build lookup map
   - Link runtime_symbols to code_symbols via symbol_id
   - Report symbols_linked in result for visibility

2. stale-flags.js: Fix broken regex and improve error handling
   - Remove broken ONE_SIDED_IF pattern that couldn't parse nested parens
   - Add more robust one-sided branch detection patterns
   - Improve error handling in persistStaleFlags to only skip duplicates
   - Fix branch_type determination for new finding types

3. audit-diff.js: Improve path matching for runtime hotness
   - Use basename comparison for cross-platform compatibility
   - Match on both filename AND function name for accuracy

## Description

<!-- What does this PR do? Link to relevant issues. -->

Fixes #

## Extraction Checklist

<!-- For PRs touching extraction/modularization code (labeled `architecture` or `refactor`).
     These checks MUST pass before merge. -->

- [ ] Full test suite passes locally: `npm test`
- [ ] Smoke CLI tests pass: `node test/smoke-cli.js`
- [ ] Lint passes: `npm run lint`
- [ ] No regressions in existing test behavior
- [ ] `docs/MODULE_MAP.md` updated if modules were added, removed, renamed, or dependency boundaries changed
- [ ] If a test behavior change was legitimate, it is documented below

### Legitimate Test Behavior Changes

<!-- If any existing test changed its expected behavior, document why here.
     Example: "Updated test XYZ because the command now returns a typed result
     instead of a raw CLI envelope." -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI/CD

## How Has This Been Tested?

<!-- Describe how you verified the changes. -->
