### PR TITLE
feat(code): add auto coding context

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -76,6 +76,7 @@ Supported languages: JavaScript, TypeScript, TSX, Go, Python, Rust, and SQL.
 | `provenance --repo`         | Git blame-based provenance for symbols.        |
 | `untested --repo`           | Find symbols without test coverage.            |
 | `pr-risk --repo`            | Assess risk of changes for PR review.          |
+| `coding-context --repo`     | Unified before-edit context for a symbol or file. |
 
 | Command                          | Purpose                                        |
 | -------------------------------- | ---------------------------------------------- |

--- a/extensions/memory-layer/hooks/context-injection.ts
+++ b/extensions/memory-layer/hooks/context-injection.ts
@@ -206,8 +206,9 @@ export function registerBeforeAgentStart(pi: ExtensionAPI, deps: ContextDeps) {
 
     // Auto-inject preflight intelligence for coding tasks when an indexed repo exists
     if (cwdRepo && isPreflightWorthyPrompt(promptQuery)) {
+      let preflightResult: any = null;
       try {
-        const preflightResult = await deps.mem('preflight', {
+        preflightResult = await deps.mem('preflight', {
           repo: cwdRepo.name,
           task: promptQuery,
           'code-limit': String(CONTEXT.PREFLIGHT_CODE_LIMIT || 3),
@@ -219,6 +220,23 @@ export function registerBeforeAgentStart(pi: ExtensionAPI, deps: ContextDeps) {
         }
       } catch {
         // Preflight is best-effort; never block context injection on failure
+      }
+
+      try {
+        const target = chooseCodingContextTarget(promptQuery, preflightResult);
+        if (target) {
+          const codingContextResult = await deps.mem('coding-context', {
+            repo: cwdRepo.name,
+            ...target,
+            depth: '2',
+            top: '5',
+          });
+          if (codingContextResult && !codingContextResult.error) {
+            appendCodingContextBlock(lines, unwrapAnalysisData(codingContextResult));
+          }
+        }
+      } catch {
+        // Coding context is best-effort; never block context injection on failure
       }
     }
 
@@ -462,7 +480,6 @@ export function isPreflightWorthyPrompt(prompt: string | null): boolean {
 }
 
 function appendPreflightBlock(lines: string[], result: any): void {
-  const maxChars = CONTEXT.PREFLIGHT_MAX_CHARS || 400;
   const code = (result.likely_existing_code || []) as Array<{
     symbol: string;
     file: string;
@@ -486,13 +503,13 @@ function appendPreflightBlock(lines: string[], result: any): void {
   lines.push('### Preflight — Before Coding');
 
   if (warnings.length > 0) {
-    const riskIcon = risk === 'high' ? '🔴' : risk === 'medium' ? '🟡' : '🟢';
+    const riskIcon = iconForRisk(risk);
     lines.push(`${riskIcon} **Duplicate risk: ${risk}** — existing code may already handle this task.`);
     for (const w of warnings.slice(0, 2)) {
       lines.push(`- ⚠️ \`${w.symbol}\` in \`${w.file}\``);
     }
   } else if (code.length > 0) {
-    const riskIcon = risk === 'high' ? '🔴' : risk === 'medium' ? '🟡' : '🟢';
+    const riskIcon = iconForRisk(risk);
     lines.push(`${riskIcon} Risk: **${risk}** — related code exists.`);
     for (const c of code.slice(0, 2)) {
       const loc = c.line ? `:${c.line}` : '';
@@ -506,6 +523,105 @@ function appendPreflightBlock(lines: string[], result: any): void {
 
   if (action) {
     lines.push(`→ ${action}`);
+  }
+}
+
+function iconForRisk(risk: string): string {
+  if (risk === 'high') {
+    return '🔴';
+  }
+  if (risk === 'medium') {
+    return '🟡';
+  }
+  return '🟢';
+}
+
+function chooseCodingContextTarget(prompt: string | null, preflightResult: any): { file?: string; symbol?: string } | null {
+  const promptFiles = extractFilePaths(prompt || '');
+  if (promptFiles.length > 0) {
+    return { file: promptFiles[0] };
+  }
+
+  const explicitSymbol = extractExplicitSymbol(prompt);
+  if (explicitSymbol) {
+    return { symbol: explicitSymbol };
+  }
+
+  const code = (preflightResult?.likely_existing_code || []) as Array<{ symbol?: string; file?: string }>;
+  const firstCode = code.find((item) => item.symbol || item.file);
+  if (firstCode?.symbol) {
+    return { symbol: firstCode.symbol };
+  }
+  if (firstCode?.file) {
+    return { file: firstCode.file };
+  }
+
+  return null;
+}
+
+function extractExplicitSymbol(prompt: string | null): string | null {
+  if (!prompt) {
+    return null;
+  }
+
+  const codeSymbol = prompt.match(/`([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)`/);
+  if (codeSymbol) {
+    return codeSymbol[1];
+  }
+
+  const callSymbol = prompt.match(/\b([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\s*\(/);
+  if (callSymbol) {
+    return callSymbol[1];
+  }
+
+  return null;
+}
+
+function unwrapAnalysisData(result: any): any {
+  if (result && typeof result === 'object' && result.data && typeof result.data === 'object') {
+    return result.data;
+  }
+  return result;
+}
+
+function appendCodingContextBlock(lines: string[], result: any): void {
+  if (!result || result.error) {
+    return;
+  }
+
+  const target = result.target || {};
+  const summary = result.summary || {};
+  const relatedFiles = (result.related_files || []) as string[];
+  const likelyTests = (result.likely_tests || []) as Array<{ file?: string; reasons?: string[] }>;
+  const maxFiles = CONTEXT.PREFLIGHT_RELATED_FILES || 3;
+
+  if (!target.symbol && !target.file && relatedFiles.length === 0 && likelyTests.length === 0) {
+    return;
+  }
+
+  lines.push('');
+  lines.push('### Coding Context — Before Editing');
+
+  if (target.symbol) {
+    const file = target.file ? ` — \`${target.file}\`` : '';
+    lines.push(`Target: \`${target.symbol}\`${file}`);
+  } else if (target.file) {
+    lines.push(`Target file: \`${target.file}\``);
+  }
+
+  if (summary.risk || summary.review_bar) {
+    const risk = summary.risk || 'unknown';
+    const review = summary.review_bar || 'unknown';
+    const affected = typeof summary.affected_files === 'number' ? ` | affected files: ${summary.affected_files}` : '';
+    lines.push(`Risk: **${risk}** | review: **${review}**${affected}`);
+  }
+
+  if (relatedFiles.length > 0) {
+    lines.push(`Review files: ${relatedFiles.slice(0, maxFiles).map((f: string) => `\`${f}\``).join(', ')}`);
+  }
+
+  if (likelyTests.length > 0) {
+    lines.push(`Likely tests: ${likelyTests.slice(0, 2).map((test) => `\`${test.file || '?'}\``).join(', ')}`);
   }
 }
 

--- a/extensions/memory-layer/tools/code-tools.ts
+++ b/extensions/memory-layer/tools/code-tools.ts
@@ -20,7 +20,7 @@ export function registerCodeTools(pi: ExtensionAPI, deps: CodeDeps) {
     name: 'memory-code',
     label: 'Code Analysis',
     description:
-      'Query indexed code and before-coding agent context. Use mode search, preflight, agent-pack, outline, callers, callees, deps, health, index-repo, or reindex-repo. Include repo when known; if omitted, LaPis infers the current indexed repo when possible.',
+      'Query indexed code and before-coding agent context. Use mode search, coding-context, preflight, agent-pack, outline, callers, callees, deps, health, index-repo, or reindex-repo. Include repo when known; if omitted, LaPis infers the current indexed repo when possible.',
     parameters: Type.Object({
       mode: Type.Optional(
         Type.String({
@@ -43,6 +43,7 @@ export function registerCodeTools(pi: ExtensionAPI, deps: CodeDeps) {
             'hierarchy',
             'signal-chains',
             'layer-violations',
+            'coding-context',
             'preflight',
             'agent-pack',
             'health',
@@ -99,6 +100,7 @@ export function registerCodeTools(pi: ExtensionAPI, deps: CodeDeps) {
           hierarchy: 'hierarchy',
           'signal-chains': 'signal-chains',
           'layer-violations': 'layer-violations',
+          'coding-context': 'coding-context',
           preflight: 'preflight',
           'agent-pack': 'agent-pack',
           health: 'health-code-repo',
@@ -401,11 +403,12 @@ function codeHelpText(): string {
     '- memory-code outline --repo <repo> --file src/foo.ts',
     '- memory-code search --repo <repo> --query "context command return fields"',
     '- memory-code callers --repo <repo> --symbol MyClass.method',
+    '- memory-code coding-context --repo <repo> --symbol saveNotificationPreferences',
     '- memory-code preflight --repo <repo> --task "add notification preferences"',
     '- memory-code agent-pack --repo <repo> --task "add notification preferences"',
     '- memory-code reindex-repo --path . --name <repo>',
     '',
-    'Modes: search, callers, callees, blast-radius, dead-code, complexity, deps, outline, churn, hotspots, cycles, importance, coupling, extractable, hierarchy, signal-chains, layer-violations, preflight, agent-pack, health, index-repo, reindex-repo, dupes, audit-diff, enrich-symbols.',
+    'Modes: search, callers, callees, blast-radius, dead-code, complexity, deps, outline, churn, hotspots, cycles, importance, coupling, extractable, hierarchy, signal-chains, layer-violations, coding-context, preflight, agent-pack, health, index-repo, reindex-repo, dupes, audit-diff, enrich-symbols.',
   ].join('\n');
 }
 
@@ -456,6 +459,10 @@ function validateCodeParams(mode: string, params: Record<string, any>): string |
 
   if (['callers', 'callees', 'blast-radius', 'complexity'].includes(mode) && !params.symbol) {
     return `${mode} requires --symbol.\n\nExample:\nmemory-code ${mode} --repo ${params.repo || '<repo>'} --symbol <symbol>`;
+  }
+
+  if (mode === 'coding-context' && !params.symbol && !params.file) {
+    return `coding-context requires --symbol or --file.\n\nExample:\nmemory-code coding-context --repo ${params.repo || '<repo>'} --symbol <symbol>`;
   }
 
   if (['outline', 'churn'].includes(mode) && !params.file) {

--- a/skills/memory-layer/SKILL.md
+++ b/skills/memory-layer/SKILL.md
@@ -93,6 +93,7 @@ Grammar .wasm files bundled in `grammars/`.
 - `provenance --repo NAME` — Git blame-based provenance for symbols
 - `untested --repo NAME` — Find symbols without test coverage
 - `pr-risk --repo NAME` — Assess risk of changes for PR review
+- `coding-context --repo NAME [--symbol S | --file F]` — Unified before-edit context for coding tasks
 
 **Note:** Layer rules can be defined inline via `--rules` or in a `.pimemory-layers.jsonc` file at the repo root.
 Signal chains detect Express routes (`app.get/post/...`), router patterns, and CLI commands.

--- a/src/cli/commands/code-analysis.js
+++ b/src/cli/commands/code-analysis.js
@@ -21,6 +21,7 @@ const USAGE = {
   provenance: '--repo X --symbol S',
   untested: '--repo X [--min-confidence 0.5] [--include-private]',
   'pr-risk': '--repo X [--branch B] [--base B]',
+  'coding-context': '--repo X [--symbol S | --file F] [--depth N] [--top N]',
 };
 
 const ANALYSIS_TOOLS = new Set([
@@ -44,6 +45,7 @@ const ANALYSIS_TOOLS = new Set([
   'provenance',
   'untested',
   'pr-risk',
+  'coding-context',
 ]);
 
 function _dispatch(cmd, repoName, fn, deps) {
@@ -294,6 +296,24 @@ function register(commands, deps) {
         }),
       dispatchDeps,
     );
+  commands['coding-context'] = (args) => {
+    if (!args.symbol && !args.file) {
+      return jsonErrNoExit('Missing --symbol or --file. Usage: coding-context --repo X [--symbol S | --file F]');
+    }
+    return _dispatch(
+      'coding-context',
+      args.repo,
+      (repoRow) =>
+        codeAnalysis.getCodingContext(getDb(), repoRow.id, {
+          symbol: args.symbol || null,
+          file: args.file || null,
+          depth: args.depth ? parseInt(args.depth) : 2,
+          top: args.top ? parseInt(args.top) : 10,
+          days: args.days ? parseInt(args.days) : 90,
+        }),
+      dispatchDeps,
+    );
+  };
 }
 
 module.exports = { register, USAGE, ANALYSIS_TOOLS, _wrapAnalysis };

--- a/src/code-analysis/coding-context.js
+++ b/src/code-analysis/coding-context.js
@@ -1,0 +1,523 @@
+// Unified before-edit coding context built from the existing code index analyzers.
+
+const graph = require('./graph');
+const impact = require('./impact');
+const quality = require('./quality');
+const gitMetrics = require('./git-metrics');
+
+const DEFAULT_DEPTH = 2;
+const DEFAULT_TOP = 10;
+
+function getCodingContext(db, repoId, opts = {}) {
+  const symbolQuery = normalizeText(opts.symbol);
+  const fileQuery = normalizeFile(opts.file);
+  const depth = clampInt(opts.depth, DEFAULT_DEPTH, 1, 5);
+  const top = clampInt(opts.top, DEFAULT_TOP, 1, 50);
+
+  if (!symbolQuery && !fileQuery) {
+    return { error: 'Missing --symbol or --file' };
+  }
+
+  const repo = db.prepare('SELECT id, name, path, head_commit FROM code_repos WHERE id = ?').get(repoId);
+  if (!repo) {
+    return { error: `Repo id ${repoId} not found` };
+  }
+
+  const target = symbolQuery
+    ? resolveSymbolTarget(db, repoId, symbolQuery)
+    : resolveFileTarget(db, repoId, fileQuery);
+
+  if (target.error) {
+    return target;
+  }
+
+  const partialErrors = [];
+  const outline = runPartial(partialErrors, 'outline', () =>
+    target.file ? quality.getFileOutline(db, repoId, target.file) : null,
+  );
+  const imports = runPartial(partialErrors, 'deps', () =>
+    target.file ? graph.getImportGraph(db, repoId, { file: target.file, direction: 'both', depth }) : null,
+  );
+  const churn = runPartial(partialErrors, 'churn', () =>
+    target.file ? gitMetrics.getChurn(db, repoId, target.file, opts.days ? clampInt(opts.days, 90, 1, 3650) : 90, false) : null,
+  );
+  const coupling = runPartial(partialErrors, 'coupling', () =>
+    target.file ? impact.getCouplingMetrics(db, repoId, { file: target.file, sortBy: 'instability' }) : null,
+  );
+
+  let callers = null;
+  let callees = null;
+  let blastRadius = null;
+  let complexity = null;
+  let provenance = null;
+
+  if (target.symbol) {
+    callers = runPartial(partialErrors, 'callers', () =>
+      graph.getCallHierarchy(db, repoId, { symbol: target.symbol, direction: 'callers', depth }),
+    );
+    callees = runPartial(partialErrors, 'callees', () =>
+      graph.getCallHierarchy(db, repoId, { symbol: target.symbol, direction: 'callees', depth }),
+    );
+    blastRadius = runPartial(partialErrors, 'blast-radius', () =>
+      impact.getBlastRadius(db, repoId, { symbol: target.symbol, depth }),
+    );
+    complexity = runPartial(partialErrors, 'complexity', () =>
+      target.symbol_id ? quality.getComplexity(db, repoId, target.symbol_id) : null,
+    );
+    provenance = runPartial(partialErrors, 'provenance', () => gitMetrics.getProvenance(db, repoId, target.symbol));
+  } else {
+    blastRadius = runPartial(partialErrors, 'blast-radius', () =>
+      impact.getBlastRadius(db, repoId, { file: target.file, maxDepth: depth }),
+    );
+  }
+
+  const likelyTests = findLikelyTests(db, repoId, target, top);
+  const relatedFiles = collectRelatedFiles({ target, imports, callers, callees, blastRadius, likelyTests }, top);
+  const summary = summarizeContext({ target, callers, callees, blastRadius, complexity, imports, coupling, churn, likelyTests });
+
+  return {
+    repo: repo.name,
+    target,
+    summary,
+    recommended_next: recommendedNext(summary, target),
+    outline: compactOutline(outline, top),
+    callers: compactCallHierarchy(callers, 'callers', top),
+    callees: compactCallHierarchy(callees, 'callees', top),
+    blast_radius: compactBlastRadius(blastRadius, top),
+    deps: compactDeps(imports, top),
+    complexity: compactComplexity(complexity),
+    churn: compactChurn(churn),
+    coupling: compactCoupling(coupling),
+    provenance: compactProvenance(provenance),
+    likely_tests: likelyTests,
+    related_files: relatedFiles,
+    partial_errors: partialErrors,
+  };
+}
+
+function resolveSymbolTarget(db, repoId, symbolQuery) {
+  const rows = db
+    .prepare(
+      `SELECT id, name, qualified_name, kind, file_path, file_id, start_line, end_line, signature
+       FROM code_symbols
+       WHERE repo_id = ? AND (name = ? OR qualified_name = ?)
+       ORDER BY length(qualified_name), file_path, start_line`,
+    )
+    .all(repoId, symbolQuery, symbolQuery);
+
+  if (rows.length === 0) {
+    return { error: `Symbol "${symbolQuery}" not found` };
+  }
+  if (rows.length > 1) {
+    return {
+      error: `Multiple symbols matched "${symbolQuery}"`,
+      candidates: rows.slice(0, 20).map((row) => ({
+        symbol: row.name,
+        qualified_name: row.qualified_name,
+        file: row.file_path,
+        line: row.start_line,
+      })),
+    };
+  }
+
+  const row = rows[0];
+  return {
+    symbol: row.name,
+    qualified_name: row.qualified_name,
+    kind: row.kind,
+    file: row.file_path,
+    file_id: row.file_id,
+    symbol_id: row.id,
+    start_line: row.start_line,
+    end_line: row.end_line,
+    signature: row.signature || '',
+  };
+}
+
+function resolveFileTarget(db, repoId, fileQuery) {
+  const row = findFile(db, repoId, fileQuery);
+  if (!row) {
+    return { error: `File "${fileQuery}" not found` };
+  }
+
+  const symbols = db
+    .prepare(
+      `SELECT id, name, qualified_name, kind, start_line, end_line
+       FROM code_symbols
+       WHERE repo_id = ? AND file_id = ?
+       ORDER BY start_line
+       LIMIT 50`,
+    )
+    .all(repoId, row.id);
+
+  return {
+    file: row.path,
+    file_id: row.id,
+    symbols: symbols.map((sym) => ({
+      symbol: sym.name,
+      qualified_name: sym.qualified_name,
+      kind: sym.kind,
+      start_line: sym.start_line,
+      end_line: sym.end_line,
+    })),
+  };
+}
+
+function findFile(db, repoId, fileQuery) {
+  const exact = db.prepare('SELECT id, path FROM code_files WHERE repo_id = ? AND path = ?').get(repoId, fileQuery);
+  if (exact) {
+    return exact;
+  }
+
+  return db
+    .prepare("SELECT id, path FROM code_files WHERE repo_id = ? AND path LIKE ? ESCAPE '!' ORDER BY length(path) LIMIT 1")
+    .get(repoId, `%${likeEscape(fileQuery)}`);
+}
+
+function findLikelyTests(db, repoId, target, top) {
+  const tests = new Map();
+  const add = (path, reason, line = null) => {
+    if (!path) {
+      return;
+    }
+    if (!tests.has(path)) {
+      tests.set(path, { file: path, reasons: [], line });
+    }
+    const item = tests.get(path);
+    if (!item.reasons.includes(reason)) {
+      item.reasons.push(reason);
+    }
+    if (!item.line && line) {
+      item.line = line;
+    }
+  };
+
+  if (target.symbol_id) {
+    const callers = db
+      .prepare(
+        `SELECT DISTINCT cf.path, cc.line_number
+         FROM code_calls cc
+         JOIN code_symbols cs ON cs.id = cc.caller_symbol_id
+         JOIN code_files cf ON cf.id = cs.file_id
+         WHERE cc.repo_id = ? AND cc.callee_symbol_id = ? AND ${testPathSql('cf.path')}
+         ORDER BY cf.path
+         LIMIT ?`,
+      )
+      .all(repoId, target.symbol_id, top);
+    for (const row of callers) {
+      add(row.path, 'calls target symbol', row.line_number);
+    }
+  }
+
+  if (target.file_id) {
+    const importers = db
+      .prepare(
+        `SELECT DISTINCT sf.path, ci.line_number
+         FROM code_imports ci
+         JOIN code_files sf ON sf.id = ci.source_file_id
+         WHERE ci.repo_id = ? AND ci.target_file_id = ? AND ${testPathSql('sf.path')}
+         ORDER BY sf.path
+         LIMIT ?`,
+      )
+      .all(repoId, target.file_id, top);
+    for (const row of importers) {
+      add(row.path, 'imports target file', row.line_number);
+    }
+  }
+
+  const baseName = basenameWithoutExt(target.file || target.symbol || '');
+  if (baseName) {
+    const nameMatches = db
+      .prepare(
+        `SELECT path FROM code_files
+         WHERE repo_id = ? AND ${testPathSql('path')} AND path LIKE ? ESCAPE '!'
+         ORDER BY path
+         LIMIT ?`,
+      )
+      .all(repoId, `%${likeEscape(baseName)}%`, top);
+    for (const row of nameMatches) {
+      add(row.path, 'name matches target');
+    }
+  }
+
+  return [...tests.values()].slice(0, top);
+}
+
+function summarizeContext({ target, callers, callees, blastRadius, complexity, imports, coupling, churn, likelyTests }) {
+  const callerCount = Array.isArray(callers?.callers) ? callers.callers.length : 0;
+  const calleeCount = Array.isArray(callees?.callees) ? callees.callees.length : 0;
+  const affectedFiles = countAffectedFiles(blastRadius);
+  const dependencyEdges = Array.isArray(imports?.edges)
+    ? imports.edges.length
+    : (imports?.upstream?.length || 0) + (imports?.downstream?.length || 0);
+  const complexityLevel = complexity?.assessment || null;
+  const churnPerWeek = typeof churn?.churn_per_week === 'number' ? churn.churn_per_week : null;
+  const couplingRows = Array.isArray(coupling?.files) ? coupling.files : coupling?.metrics || [];
+  const instability = couplingRows[0] ? couplingRows[0].instability : null;
+
+  let risk = 'low';
+  const reasons = [];
+  if (affectedFiles >= 10 || callerCount >= 10) {
+    risk = 'high';
+    reasons.push('large blast radius');
+  } else if (affectedFiles >= 3 || callerCount >= 3 || dependencyEdges >= 5) {
+    risk = 'medium';
+    reasons.push('multiple dependent files or callers');
+  }
+  if (complexityLevel === 'high') {
+    risk = 'high';
+    reasons.push('high complexity');
+  } else if (complexityLevel === 'medium' && risk === 'low') {
+    risk = 'medium';
+    reasons.push('medium complexity');
+  }
+  if (likelyTests.length === 0 && (target.symbol || target.symbols?.length)) {
+    if (risk === 'low') {
+      risk = 'medium';
+    }
+    reasons.push('no likely tests found');
+  }
+  if (churnPerWeek !== null && churnPerWeek >= 1 && risk !== 'high') {
+    risk = 'medium';
+    reasons.push('recent churn');
+  }
+
+  let reviewBar = 'normal';
+  if (risk === 'high') {
+    reviewBar = 'high';
+  } else if (risk === 'medium') {
+    reviewBar = 'normal-plus';
+  }
+
+  return {
+    risk,
+    review_bar: reviewBar,
+    direct_callers: callerCount,
+    direct_callees: calleeCount,
+    affected_files: affectedFiles,
+    dependency_edges: dependencyEdges,
+    likely_tests: likelyTests.length,
+    complexity: complexityLevel,
+    churn_per_week: churnPerWeek,
+    instability,
+    reasons,
+  };
+}
+
+function recommendedNext(summary, target) {
+  const steps = [];
+  if (target.file) {
+    steps.push(`Read targeted lines in ${target.file}${target.start_line ? ` around ${target.start_line}` : ''}.`);
+  }
+  if (summary.direct_callers > 0) {
+    steps.push('Check caller expectations before changing the public contract.');
+  }
+  if (summary.likely_tests > 0) {
+    steps.push('Run or update the likely tests listed in this context.');
+  } else {
+    steps.push('Identify or add focused tests before changing behavior.');
+  }
+  if (summary.risk === 'high') {
+    steps.push('Keep the diff narrow and review affected files before editing.');
+  }
+  return steps;
+}
+
+function collectRelatedFiles({ target, imports, callers, callees, blastRadius, likelyTests }, top) {
+  const files = new Set();
+  if (target.file) {
+    files.add(target.file);
+  }
+  for (const test of likelyTests || []) {
+    files.add(test.file);
+  }
+  for (const edge of imports?.edges || []) {
+    if (edge.source) {
+      files.add(edge.source);
+    }
+    if (edge.target && !edge.target.startsWith('.')) {
+      files.add(edge.target);
+    }
+  }
+  for (const item of imports?.upstream || []) {
+    files.add(item.path);
+  }
+  for (const item of imports?.downstream || []) {
+    files.add(item.path);
+  }
+  for (const item of callers?.callers || []) {
+    files.add(item.file_path);
+  }
+  for (const item of callees?.callees || []) {
+    files.add(item.file_path);
+  }
+  for (const item of normalizedAffectedFiles(blastRadius)) {
+    files.add(item);
+  }
+  return [...files].filter(Boolean).slice(0, top);
+}
+
+function runPartial(errors, name, fn) {
+  try {
+    const result = fn();
+    if (result && result.error) {
+      errors.push({ analyzer: name, error: result.error });
+      return null;
+    }
+    return result;
+  } catch (err) {
+    errors.push({ analyzer: name, error: err && err.message ? err.message : String(err) });
+    return null;
+  }
+}
+
+function compactOutline(outline, top) {
+  if (!outline) {
+    return null;
+  }
+  if (outline.directory || outline.not_found) {
+    return outline;
+  }
+  return {
+    file: outline.file,
+    classes: (outline.classes || []).slice(0, top).map((cls) => ({
+      name: cls.name,
+      methods: (cls.methods || []).slice(0, top),
+    })),
+    standalone: (outline.standalone || []).slice(0, top),
+  };
+}
+
+function compactCallHierarchy(result, key, top) {
+  if (!result) {
+    return null;
+  }
+  return {
+    symbol: result.symbol,
+    direction: result.direction,
+    depth: result.depth,
+    [key]: (result[key] || []).slice(0, top),
+  };
+}
+
+function compactBlastRadius(result, top) {
+  if (!result) {
+    return null;
+  }
+  return {
+    symbol: result.symbol || null,
+    file: result.file || result.seed_file || null,
+    affected_files: normalizedAffectedFileEntries(result).slice(0, top),
+    affected_symbols: (result.affected_symbols || []).slice(0, top),
+    callers: (result.callers || []).slice(0, top),
+    file_importers: (result.file_importers || []).slice(0, top),
+  };
+}
+
+function compactDeps(result, top) {
+  if (!result) {
+    return null;
+  }
+  return {
+    edges: (result.edges || []).slice(0, top),
+    upstream: (result.upstream || []).slice(0, top),
+    downstream: (result.downstream || []).slice(0, top),
+  };
+}
+
+function compactComplexity(result) {
+  if (!result || Array.isArray(result)) {
+    return null;
+  }
+  return {
+    name: result.name,
+    file_path: result.file_path,
+    cyclomatic: result.cyclomatic,
+    nesting_depth: result.nesting_depth,
+    lines_of_code: result.lines_of_code,
+    assessment: result.assessment,
+  };
+}
+
+function compactChurn(result) {
+  if (!result || result.error) {
+    return null;
+  }
+  return {
+    file: result.file,
+    commits: result.commits,
+    unique_authors: result.unique_authors,
+    churn_per_week: result.churn_per_week,
+    last_modified: result.last_modified,
+  };
+}
+
+function compactCoupling(result) {
+  if (!result || result.error) {
+    return null;
+  }
+  if (Array.isArray(result.files)) {
+    return { files: result.files.slice(0, 10) };
+  }
+  return result;
+}
+
+function compactProvenance(result) {
+  if (!result || result.error) {
+    return null;
+  }
+  return {
+    symbol: result.symbol,
+    last_touched: result.last_touched,
+    commit_count: result.commit_count,
+    authors: result.authors,
+  };
+}
+
+function countAffectedFiles(result) {
+  return normalizedAffectedFiles(result).length;
+}
+
+function normalizedAffectedFiles(result) {
+  return normalizedAffectedFileEntries(result).map((item) => item.path || item).filter(Boolean);
+}
+
+function normalizedAffectedFileEntries(result) {
+  if (!result || !Array.isArray(result.affected_files)) {
+    return [];
+  }
+  return result.affected_files.map((item) => (typeof item === 'string' ? { path: item } : item));
+}
+
+function testPathSql(column) {
+  return `(${column} LIKE '%/test/%' OR ${column} LIKE '%/__tests__/%' OR ${column} LIKE 'test/%' OR ${column} LIKE '%test.%' OR ${column} LIKE '%spec.%')`;
+}
+
+function normalizeText(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeFile(value) {
+  return normalizeText(value)?.replace(/\\/g, '/') || null;
+}
+
+function clampInt(value, fallback, min, max) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function basenameWithoutExt(file) {
+  const base = String(file).split('/').pop() || '';
+  return base.replace(/\.[^.]+$/, '');
+}
+
+function likeEscape(value) {
+  return String(value).replace(/[!%_]/g, (m) => `!${m}`);
+}
+
+module.exports = {
+  getCodingContext,
+};

--- a/src/code-analysis/index.js
+++ b/src/code-analysis/index.js
@@ -10,6 +10,7 @@ const gitMetrics = require('./git-metrics');
 const astPatternAnalyzers = require('./ast-patterns');
 const risk = require('./risk');
 const queryWinnow = require('./query-winnow');
+const codingContext = require('./coding-context');
 const legacy = require('./legacy-core');
 const readModel = require('./read-model');
 
@@ -21,6 +22,7 @@ module.exports = {
   ...astPatternAnalyzers,
   ...risk,
   ...queryWinnow,
+  ...codingContext,
   ...readModel,
   buildImportGraphForFiles: legacy.buildImportGraphForFiles,
   buildCallGraphForFiles: legacy.buildCallGraphForFiles,

--- a/src/platform/protocol/envelope.js
+++ b/src/platform/protocol/envelope.js
@@ -247,6 +247,11 @@ const _confidenceCalculators = {
     const hasData = signalKeys.filter((k) => signals[k] != null).length;
     return parseFloat((hasData / signalKeys.length).toFixed(2));
   },
+  'coding-context'(data) {
+    const errors = data?.partial_errors || [];
+    const analyzerCount = 7;
+    return parseFloat(((analyzerCount - Math.min(errors.length, analyzerCount)) / analyzerCount).toFixed(2));
+  },
 };
 
 // ══════════════════════════════════════════════════════════
@@ -293,6 +298,12 @@ function extractResultCount(toolName, data) {
       return (data.untested || []).length;
     case 'getPrRiskProfile':
       return Object.keys(data?.signals || {}).length;
+    case 'coding-context':
+      return (
+        (data.related_files || []).length +
+        (data.likely_tests || []).length +
+        (data.blast_radius?.affected_files || []).length
+      );
     default:
       return 0;
   }

--- a/src/platform/protocol/llm-format.ts
+++ b/src/platform/protocol/llm-format.ts
@@ -278,6 +278,51 @@ function formatCodeResult(mode: string, result: any): string {
         )
         .join('\n\n');
     }
+    case 'coding-context': {
+      if (result.error) {
+        return `Error: ${result.error}`;
+      }
+      const target = result.target || {};
+      const summary = result.summary || {};
+      let targetLabel = 'target';
+      if (target.symbol) {
+        targetLabel = `${target.symbol} (${target.file ?? '?'})`;
+      } else if (target.file) {
+        targetLabel = target.file;
+      }
+      const lines = [
+        `**Coding context:** ${targetLabel}`,
+        `Risk: ${summary.risk ?? 'unknown'} | review: ${summary.review_bar ?? 'unknown'} | affected files: ${summary.affected_files ?? 0}`,
+      ];
+      if ((summary.reasons || []).length) {
+        lines.push(`Reasons: ${(summary.reasons || []).slice(0, 5).join(', ')}`);
+      }
+      if ((result.related_files || []).length) {
+        lines.push('', 'Related files:', ...(result.related_files || []).slice(0, 10).map((file: string) => `  ${file}`));
+      }
+      if ((result.likely_tests || []).length) {
+        lines.push(
+          '',
+          'Likely tests:',
+          ...(result.likely_tests || [])
+            .slice(0, 8)
+            .map((test: any) => `  ${test.file ?? '?'}${test.reasons?.length ? ` - ${test.reasons.join(', ')}` : ''}`),
+        );
+      }
+      if ((result.recommended_next || []).length) {
+        lines.push('', 'Next:', ...(result.recommended_next || []).slice(0, 5).map((step: string) => `  - ${step}`));
+      }
+      if ((result.partial_errors || []).length) {
+        lines.push(
+          '',
+          'Partial errors:',
+          ...(result.partial_errors || [])
+            .slice(0, 5)
+            .map((err: any) => `  ${err.analyzer ?? '?'}: ${err.error ?? 'failed'}`),
+        );
+      }
+      return lines.join('\n');
+    }
     case 'preflight': {
       const code = result.likely_existing_code || [];
       const memories = result.similar_past_tasks || [];

--- a/test/coding-context.test.js
+++ b/test/coding-context.test.js
@@ -1,0 +1,100 @@
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const STORE = path.resolve(__dirname, '..', 'memory-store.js');
+
+function run(cmd, timeout = 45000) {
+  const out = execSync(`node "${STORE}" ${cmd}`, {
+    encoding: 'utf8',
+    timeout,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return JSON.parse(out.trim());
+}
+
+function unwrap(result) {
+  return result && result.data ? result.data : result;
+}
+
+function writeTmpRepo(repoPath, files) {
+  fs.mkdirSync(repoPath, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(repoPath, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+}
+
+describe('coding-context command', () => {
+  const repoName = `test-coding-context-${Date.now()}`;
+  const tmpRepo = path.join('/tmp', repoName);
+
+  beforeAll(() => {
+    writeTmpRepo(tmpRepo, {
+      'src/users.js': `
+export function validateUser(input) {
+  return Boolean(input && input.id);
+}
+
+export function saveUser(input) {
+  if (!validateUser(input)) throw new Error('missing id');
+  return { id: input.id, saved: true };
+}
+`,
+      'src/routes.js': `
+import { saveUser } from './users.js';
+
+export function createUserRoute(req) {
+  return saveUser(req.body);
+}
+`,
+      'test/users.test.js': `
+import { saveUser } from '../src/users.js';
+
+test('saves a user', () => {
+  expect(saveUser({ id: 'u1' }).saved).toBe(true);
+});
+`,
+    });
+    run(`index-repo --path "${tmpRepo}" --name ${repoName}`);
+  }, 60000);
+
+  afterAll(() => {
+    try {
+      run(`remove-code-repo --repo ${repoName}`);
+    } catch {}
+    try {
+      fs.rmSync(tmpRepo, { recursive: true });
+    } catch {}
+  });
+
+  it('builds a unified context packet for a symbol', () => {
+    const result = unwrap(run(`coding-context --repo ${repoName} --symbol saveUser --depth 2 --top 5`));
+
+    expect(result.error).toBeUndefined();
+    expect(result.repo).toBe(repoName);
+    expect(result.target.symbol).toBe('saveUser');
+    expect(result.target.file).toContain('src/users.js');
+    expect(result.summary).toBeTruthy();
+    expect(['low', 'medium', 'high']).toContain(result.summary.risk);
+    expect(Array.isArray(result.related_files)).toBe(true);
+    expect(result.related_files.some((file) => file.includes('src/users.js'))).toBe(true);
+    expect(result.likely_tests.some((testFile) => testFile.file.includes('test/users.test.js'))).toBe(true);
+    expect(result.outline).toBeTruthy();
+    expect(result.callers).toBeTruthy();
+    expect(result.callees).toBeTruthy();
+  });
+
+  it('builds context for a file when no symbol is provided', () => {
+    const result = unwrap(run(`coding-context --repo ${repoName} --file src/users.js --top 5`));
+
+    expect(result.error).toBeUndefined();
+    expect(result.target.file).toContain('src/users.js');
+    expect(Array.isArray(result.target.symbols)).toBe(true);
+    expect(result.target.symbols.some((sym) => sym.symbol === 'saveUser')).toBe(true);
+    expect(result.outline).toBeTruthy();
+    expect(result.deps).toBeTruthy();
+    expect(result.likely_tests.some((testFile) => testFile.file.includes('test/users.test.js'))).toBe(true);
+  });
+});

--- a/test/context-injection-prompt.test.js
+++ b/test/context-injection-prompt.test.js
@@ -285,6 +285,74 @@ describe('context injection prompt extraction', () => {
     expect(content).not.toContain('Stale code index');
     expect(content).toContain('Why: Avoid external services Where: src/memory-domain/search.js');
   });
+
+  test('coding prompt auto-injects coding-context after preflight', async () => {
+    let handler;
+    const pi = {
+      on: vi.fn((_eventName, callback) => {
+        handler = callback;
+      }),
+    };
+    const deps = {
+      state: { currentProject: 'PiMemoryExtension', hasInjectedContext: false, sessionId: 1 },
+      mem: vi.fn(async (cmd) => {
+        if (cmd === 'context') {
+          return {
+            observations: [],
+            personal: [],
+            stats: { total_memories: 42, total_personal: 0, active_workflows: 0 },
+            topic: null,
+          };
+        }
+        if (cmd === 'preflight') {
+          return {
+            likely_existing_code: [{ symbol: 'saveUser', file: 'src/users.js', line: 4, kind: 'function' }],
+            related_files: ['src/users.js'],
+            duplicate_warnings: [],
+            risk: 'medium',
+            recommended_action: 'Review saveUser before editing.',
+          };
+        }
+        if (cmd === 'coding-context') {
+          return {
+            target: { symbol: 'saveUser', file: 'src/users.js' },
+            summary: { risk: 'medium', review_bar: 'normal-plus', affected_files: 2 },
+            related_files: ['src/users.js', 'src/routes.js'],
+            likely_tests: [{ file: 'test/users.test.js', reasons: ['imports target file'] }],
+            partial_errors: [],
+          };
+        }
+        return null;
+      }),
+      getKnownRepos: vi.fn().mockResolvedValue([
+        {
+          name: 'PiMemoryExtension',
+          path: process.cwd(),
+          file_count: 292,
+          symbol_count: 6913,
+          indexed_at: '2026-05-24 00:00:00',
+        },
+      ]),
+      isRepoStale: vi.fn().mockReturnValue(false),
+    };
+
+    registerBeforeAgentStart(pi, deps);
+    const prompt = 'fix saveUser so it validates input';
+    const result = await handler({ prompt }, { cwd: process.cwd() });
+    const content = result.message.content;
+
+    expect(deps.mem).toHaveBeenCalledWith('preflight', expect.objectContaining({ repo: 'PiMemoryExtension', task: prompt }));
+    expect(deps.mem).toHaveBeenCalledWith('coding-context', {
+      repo: 'PiMemoryExtension',
+      symbol: 'saveUser',
+      depth: '2',
+      top: '5',
+    });
+    expect(content).toContain('### Preflight — Before Coding');
+    expect(content).toContain('### Coding Context — Before Editing');
+    expect(content).toContain('Target: `saveUser`');
+    expect(content).toContain('Likely tests: `test/users.test.js`');
+  });
 });
 
 describe('preflight-worthiness detection', () => {

--- a/test/memory-layer-tool-safety.test.js
+++ b/test/memory-layer-tool-safety.test.js
@@ -406,6 +406,45 @@ describe('memory tool renderer safety', () => {
     expect(text).toContain('getNotificationPreferences');
   });
 
+  it('supports memory-code coding-context mode for a symbol', async () => {
+    const mem = vi.fn().mockResolvedValue({
+      repo: 'app',
+      target: { symbol: 'saveUser', file: 'src/users.js' },
+      summary: { risk: 'medium', review_bar: 'normal-plus', affected_files: 2, reasons: ['multiple callers'] },
+      related_files: ['src/users.js', 'test/users.test.js'],
+      likely_tests: [{ file: 'test/users.test.js', reasons: ['imports target file'] }],
+      recommended_next: ['Read targeted lines in src/users.js.'],
+      partial_errors: [],
+    });
+    const tool = captureTool(registerCodeTools, {
+      mem,
+      memStreaming: vi.fn(),
+      getKnownRepos: vi.fn().mockResolvedValue([{ name: 'app' }]),
+      formatCodeResult,
+      invalidateRepoCache: vi.fn(),
+    });
+
+    const result = await tool.execute(
+      'id',
+      { mode: 'coding-context', repo: 'app', symbol: 'saveUser', depth: 2, top: 5 },
+      undefined,
+      vi.fn(),
+      {},
+    );
+    const text = result.content.find((item) => item.type === 'text').text;
+
+    expectRenderable(result);
+    expect(mem).toHaveBeenCalledWith('coding-context', {
+      repo: 'app',
+      symbol: 'saveUser',
+      depth: '2',
+      top: '5',
+    });
+    expect(text).toContain('Coding context');
+    expect(text).toContain('saveUser');
+    expect(text).toContain('test/users.test.js');
+  });
+
   it('infers memory-code repo when only one indexed repo is available', async () => {
     const mem = vi.fn().mockResolvedValue({
       query: 'rankObservations',


### PR DESCRIPTION
## Summary
- Add `coding-context` code-analysis command for unified before-edit symbol/file context
- Expose `memory-code coding-context` and compact Pi formatting
- Auto-inject coding context after preflight for coding prompts
- Add docs and focused CLI/tool/context-injection tests

## Verification
- `npm test -- test/context-injection-prompt.test.js test/coding-context.test.js test/memory-layer-tool-safety.test.js --reporter=verbose`
- `npx oxlint extensions/memory-layer/hooks/context-injection.ts test/context-injection-prompt.test.js extensions/memory-layer/tools/code-tools.ts src/code-analysis/coding-context.js src/cli/commands/code-analysis.js src/platform/protocol/llm-format.ts src/platform/protocol/envelope.js test/coding-context.test.js test/memory-layer-tool-safety.test.js`