### PR TITLE
feat(token-saver): auto-compress bash output in tool_result before LLM sees it

### DIFF
--- a/config.js
+++ b/config.js
@@ -27,6 +27,11 @@ const DEFAULTS = {
   // Auto-switch `index-repo` to async when file count exceeds this threshold.
   // Override with the LAPIS_ASYNC_INDEX_THRESHOLD env var or via config.jsonc.
   async_index_file_threshold: 500,
+  output_compression: {
+    enabled: true,               // Master toggle — set false to disable auto-compression
+    min_chars: 2000,             // Don't compress output shorter than this
+    min_savings_percent: 30,     // Don't replace if savings < this %
+  },
 };
 
 function deepMerge(target, source) {

--- a/extensions/memory-layer/hooks/output-compression.ts
+++ b/extensions/memory-layer/hooks/output-compression.ts
@@ -1,0 +1,113 @@
+// extensions/memory-layer/hooks/output-compression.ts
+// oxlint-disable sort-imports
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { isBashToolResult } from '@earendil-works/pi-coding-agent';
+import { state } from '../state';
+import { classifyCommand } from '../../../src/token-saver/classify-command';
+import { compressOutput } from '../../../src/token-saver/compress-output';
+import { estimateTokens } from '../../../src/token-saver/estimate-tokens';
+import { recordRun } from '../../../src/token-saver/savings-store';
+
+interface CompressionDeps {
+  state: typeof state;
+  getConfig: () => { output_compression?: { enabled?: boolean; min_chars?: number; min_savings_percent?: number } };
+}
+
+const DEFAULT_MIN_CHARS = 2000;
+const DEFAULT_MIN_SAVINGS_PERCENT = 30;
+
+export function registerOutputCompression(pi: ExtensionAPI, deps: CompressionDeps) {
+  pi.on('tool_result', async (event, _ctx) => {
+    // Only process bash tool results
+    if (!isBashToolResult(event)) {
+      return;
+    }
+
+    // Check config toggle
+    const config = deps.getConfig();
+    const ocConfig = config.output_compression || {};
+    if (ocConfig.enabled === false) {
+      return;
+    }
+
+    const minChars = ocConfig.min_chars ?? DEFAULT_MIN_CHARS;
+    const minSavingsPercent = ocConfig.min_savings_percent ?? DEFAULT_MIN_SAVINGS_PERCENT;
+
+    // Extract command and output text
+    const command = event.input.command as string;
+    const textContent = event.content.find((c): c is { type: 'text'; text: string } => c.type === 'text');
+    if (!textContent) {
+      return;
+    }
+
+    const output = textContent.text;
+
+    // Skip short output — no point compressing
+    if (output.length < minChars) {
+      return;
+    }
+
+    // Parse command into args for the classifier
+    const commandArgs = command.trim().split(/\s+/);
+
+    // Classify and compress
+    const commandType = classifyCommand(commandArgs);
+    const exitCode = event.isError ? 1 : 0;
+
+    // Split output into stdout/stderr — bash tool gives combined output
+    // so we pass it all as stdout with empty stderr
+    const compressed = compressOutput({
+      commandType,
+      commandArgs,
+      stdout: output,
+      stderr: '',
+      exitCode,
+    });
+
+    // Calculate savings
+    const originalTokens = estimateTokens(output);
+    const compressedTokens = estimateTokens(compressed.importantOutput);
+    const savedTokens = Math.max(0, originalTokens - compressedTokens);
+    const savingsPercent = originalTokens > 0
+      ? Math.round((savedTokens / originalTokens) * 1000) / 10
+      : 0;
+
+    // Only replace if savings are meaningful
+    if (savingsPercent < minSavingsPercent) {
+      return;
+    }
+
+    // Update in-memory stats
+    deps.state.compressionStats.totalRuns += 1;
+    deps.state.compressionStats.totalOriginalTokens += originalTokens;
+    deps.state.compressionStats.totalCompressedTokens += compressedTokens;
+    deps.state.compressionStats.totalSavedTokens += savedTokens;
+
+    // Record to SQLite (best-effort)
+    try {
+      recordRun({
+        command,
+        commandType,
+        exitCode,
+        originalChars: output.length,
+        compressedChars: compressed.importantOutput.length,
+        estimatedOriginalTokens: originalTokens,
+        estimatedCompressedTokens: compressedTokens,
+        estimatedSavedTokens: savedTokens,
+        savingsPercent,
+        summary: compressed.summary,
+      });
+    } catch {
+      // Swallow — telemetry writes must not break tool results
+    }
+
+    // Prepend a savings note so the LLM knows output was compressed
+    const prefix = `[Output compressed: ${savingsPercent}% token savings (${savedTokens} tokens saved). Summary: ${compressed.summary}]\n\n`;
+    const newContent = prefix + compressed.importantOutput;
+
+    // Return modified content
+    return {
+      content: [{ type: 'text' as const, text: newContent }],
+    };
+  });
+}

--- a/extensions/memory-layer/hooks/output-compression.ts
+++ b/extensions/memory-layer/hooks/output-compression.ts
@@ -2,6 +2,12 @@
 // oxlint-disable sort-imports
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { isBashToolResult } from '@earendil-works/pi-coding-agent';
+import { state } from '../state';
+import { classifyCommand } from '../../../src/token-saver/classify-command';
+import { compressOutput } from '../../../src/token-saver/compress-output';
+import { estimateTokens } from '../../../src/token-saver/estimate-tokens';
+import { recordRun } from '../../../src/token-saver/savings-store';
+
 // isBashToolResult is undefined outside Pi runtime — null-guard + fallback
 function safeIsBashToolResult(event: any): boolean {
   if (typeof isBashToolResult === 'function') {
@@ -9,11 +15,6 @@ function safeIsBashToolResult(event: any): boolean {
   }
   return event?.toolName === 'bash';
 }
-import { state } from '../state';
-import { classifyCommand } from '../../../src/token-saver/classify-command';
-import { compressOutput } from '../../../src/token-saver/compress-output';
-import { estimateTokens } from '../../../src/token-saver/estimate-tokens';
-import { recordRun } from '../../../src/token-saver/savings-store';
 
 interface CompressionDeps {
   state: typeof state;
@@ -61,8 +62,9 @@ export function registerOutputCompression(pi: ExtensionAPI, deps: CompressionDep
     const commandType = classifyCommand(commandArgs);
     const exitCode = event.isError ? 1 : 0;
 
-    // Split output into stdout/stderr — bash tool gives combined output
-    // so we pass it all as stdout with empty stderr
+    // Pi's bash tool uses child_process.exec which merges stdout/stderr into
+    // a single stream. We pass the combined output as stdout with empty stderr.
+    // If Pi ever separates streams, this would need updating.
     const compressed = compressOutput({
       commandType,
       commandArgs,

--- a/extensions/memory-layer/hooks/output-compression.ts
+++ b/extensions/memory-layer/hooks/output-compression.ts
@@ -2,6 +2,13 @@
 // oxlint-disable sort-imports
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { isBashToolResult } from '@earendil-works/pi-coding-agent';
+// isBashToolResult is undefined outside Pi runtime — null-guard + fallback
+function safeIsBashToolResult(event: any): boolean {
+  if (typeof isBashToolResult === 'function') {
+    return isBashToolResult(event);
+  }
+  return event?.toolName === 'bash';
+}
 import { state } from '../state';
 import { classifyCommand } from '../../../src/token-saver/classify-command';
 import { compressOutput } from '../../../src/token-saver/compress-output';
@@ -19,7 +26,7 @@ const DEFAULT_MIN_SAVINGS_PERCENT = 30;
 export function registerOutputCompression(pi: ExtensionAPI, deps: CompressionDeps) {
   pi.on('tool_result', async (event, _ctx) => {
     // Only process bash tool results
-    if (!isBashToolResult(event)) {
+    if (!safeIsBashToolResult(event)) {
       return;
     }
 

--- a/extensions/memory-layer/index.ts
+++ b/extensions/memory-layer/index.ts
@@ -15,6 +15,8 @@ import { mem, memCmd, memStreaming } from './host/memory-client';
 import { detectProject, getKnownRepos, invalidateRepoCache, isRepoStale } from './host/project-detector';
 import { registerPassiveCapture } from './hooks/passive-capture';
 import { registerToolGuardrails } from './hooks/tool-guardrails';
+import { registerOutputCompression } from './hooks/output-compression';
+import { getConfig } from '../../config';
 import { registerTrustSync } from './hooks/trust-sync';
 import { ensureNativeModules } from './host/native-health';
 import { registerCodeTools } from './tools/code-tools';
@@ -58,6 +60,9 @@ export default function memoryLayer(pi: ExtensionAPI) {
   safeRegister(pi, deps, 'before-agent-start hook', registerBeforeAgentStart);
   safeRegister(pi, deps, 'context-reminder hook', registerContextReminder);
   safeRegister(pi, deps, 'tool-guardrails hook', registerToolGuardrails);
+  safeRegister(pi, deps, 'output-compression hook', (pi, deps) => {
+    registerOutputCompression(pi, { state: deps.state, getConfig });
+  });
   safeRegister(pi, deps, 'trust-sync hook', registerTrustSync);
   safeRegister(pi, deps, 'passive-capture hooks', registerPassiveCapture);
   safeRegister(pi, deps, 'session-shutdown hook', registerSessionShutdown);

--- a/extensions/memory-layer/state.ts
+++ b/extensions/memory-layer/state.ts
@@ -115,4 +115,10 @@ export const state = {
   hasInjectedContext: false as boolean,
   editedFiles: new Set<string>(),
   pendingRecallFeedback: new Map<number, { sessionId: number; query: string }>(),
+  compressionStats: {
+    totalRuns: 0 as number,
+    totalOriginalTokens: 0 as number,
+    totalCompressedTokens: 0 as number,
+    totalSavedTokens: 0 as number,
+  },
 };

--- a/test/output-compression-config.test.js
+++ b/test/output-compression-config.test.js
@@ -1,0 +1,14 @@
+const { resetConfigCache } = require('../config');
+
+describe('output compression config defaults', () => {
+  test('getConfig includes output_compression defaults', () => {
+    // Force reload of config to pick up defaults
+    resetConfigCache();
+    const { getConfig } = require('../config');
+    const config = getConfig();
+    expect(config.output_compression).toBeDefined();
+    expect(config.output_compression.enabled).toBe(true);
+    expect(config.output_compression.min_chars).toBe(2000);
+    expect(config.output_compression.min_savings_percent).toBe(30);
+  });
+});

--- a/test/output-compression-state.test.js
+++ b/test/output-compression-state.test.js
@@ -1,0 +1,11 @@
+import { state } from '../extensions/memory-layer/state.ts';
+
+describe('output compression state', () => {
+  test('state has compressionStats counters', () => {
+    expect(state.compressionStats).toBeDefined();
+    expect(state.compressionStats.totalRuns).toBe(0);
+    expect(state.compressionStats.totalOriginalTokens).toBe(0);
+    expect(state.compressionStats.totalCompressedTokens).toBe(0);
+    expect(state.compressionStats.totalSavedTokens).toBe(0);
+  });
+});

--- a/test/output-compression.test.ts
+++ b/test/output-compression.test.ts
@@ -1,0 +1,193 @@
+// vitest globals (describe, test, expect, vi, beforeEach) are auto-injected
+import { registerOutputCompression } from '../extensions/memory-layer/hooks/output-compression.ts';
+
+// ---- Mock token-saver modules ----
+// vi.mock is hoisted to the top of the file, before any imports
+
+vi.mock('../src/token-saver/compress-output', () => ({
+  compressOutput: vi.fn(({ stdout }: { stdout: string }) => ({
+    summary: 'Mock compressed summary',
+    importantOutput: 'MOCK_OUTPUT:' + stdout.slice(0, 80),
+  })),
+}));
+
+vi.mock('../src/token-saver/estimate-tokens', () => ({
+  estimateTokens: vi.fn((text: string) => Math.ceil(String(text || '').length / 4)),
+}));
+
+vi.mock('../src/token-saver/savings-store', () => ({
+  recordRun: vi.fn(),
+}));
+
+vi.mock('@earendil-works/pi-coding-agent', () => ({
+  isBashToolResult: vi.fn((event: any) => event.toolName === 'bash'),
+}));
+
+// ---- Helper factories ----
+
+function makePi() {
+  const handlers: Record<string, Function> = {};
+  return {
+    on: vi.fn((event: string, handler: Function) => { handlers[event] = handler; }),
+    getHandler: (event: string) => handlers[event],
+  };
+}
+
+function makeState() {
+  return {
+    compressionStats: {
+      totalRuns: 0,
+      totalOriginalTokens: 0,
+      totalCompressedTokens: 0,
+      totalSavedTokens: 0,
+    },
+  };
+}
+
+function makeConfig(overrides?: {
+  enabled?: boolean;
+  min_chars?: number;
+  min_savings_percent?: number;
+}) {
+  return () => ({ output_compression: { enabled: true, min_chars: 2000, min_savings_percent: 30, ...overrides } });
+}
+
+function bashEvent(command: string, output: string, isError = false) {
+  return {
+    type: 'tool_result',
+    toolName: 'bash',
+    toolCallId: 'call-1',
+    input: { command },
+    content: [{ type: 'text', text: output } as any],
+    details: undefined,
+    isError,
+  };
+}
+
+function readEvent() {
+  return {
+    type: 'tool_result',
+    toolName: 'read',
+    toolCallId: 'call-2',
+    input: { path: '/foo.ts' },
+    content: [{ type: 'text', text: 'file content' } as any],
+    details: undefined,
+    isError: false,
+  };
+}
+
+// ---- Tests ----
+
+describe('registerOutputCompression', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  test('registers a tool_result handler', () => {
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: makeConfig() });
+    expect(pi.on).toHaveBeenCalledWith('tool_result', expect.any(Function));
+  });
+
+  test('ignores non-bash tool results', async () => {
+    const pi = makePi();
+    const state = makeState();
+    registerOutputCompression(pi as any, { state, getConfig: makeConfig() });
+    const result = await pi.getHandler('tool_result')(readEvent(), {});
+    expect(result).toBeUndefined();
+  });
+
+  test('ignores short output (below min_chars threshold)', async () => {
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: makeConfig() });
+    const result = await pi.getHandler('tool_result')(bashEvent('echo hi', 'short'), {});
+    expect(result).toBeUndefined();
+  });
+
+  test('compresses large bash output and returns modified content', async () => {
+    const pi = makePi();
+    const state = makeState();
+    registerOutputCompression(pi as any, { state, getConfig: makeConfig() });
+    const large = 'x'.repeat(5000);
+    const result = await pi.getHandler('tool_result')(bashEvent('npm test', large), {});
+
+    expect(result).toBeDefined();
+    expect(result.content).toBeDefined();
+    expect(result.content[0].type).toBe('text');
+    // Prefix is always present
+    expect(result.content[0].text).toContain('[Output compressed:');
+    expect(result.content[0].text).toContain('% token savings');
+    // Mock importantOutput follows MOCK_OUTPUT pattern
+    expect(result.content[0].text).toContain('MOCK_OUTPUT:');
+  });
+
+  test('does not compress when config.enabled is false', async () => {
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: makeConfig({ enabled: false }) });
+    const large = 'x'.repeat(5000);
+    const result = await pi.getHandler('tool_result')(bashEvent('npm test', large), {});
+    expect(result).toBeUndefined();
+  });
+
+  test('updates compressionStats after compression', async () => {
+    const pi = makePi();
+    const state = makeState();
+    registerOutputCompression(pi as any, { state, getConfig: makeConfig() });
+    const large = 'x'.repeat(5000);
+    await pi.getHandler('tool_result')(bashEvent('npm test', large), {});
+
+    expect(state.compressionStats.totalRuns).toBe(1);
+    expect(state.compressionStats.totalOriginalTokens).toBeGreaterThan(0);
+    expect(state.compressionStats.totalSavedTokens).toBeGreaterThan(0);
+  });
+
+  test('calls recordRun with correct data', async () => {
+    const { recordRun } = await import('../src/token-saver/savings-store');
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: makeConfig() });
+    const large = 'x'.repeat(5000);
+    await pi.getHandler('tool_result')(bashEvent('npm test', large), {});
+
+    expect(recordRun).toHaveBeenCalledTimes(1);
+    const call = (recordRun as any).mock.calls[0][0];
+    expect(call.command).toBe('npm test');
+    expect(call.savingsPercent).toBeGreaterThan(0);
+  });
+
+  test('handles missing text content (image-only) gracefully', async () => {
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: makeConfig() });
+    const event = { ...bashEvent('npm test', ''), content: [{ type: 'image', data: '...' } as any] };
+    const result = await pi.getHandler('tool_result')(event, {});
+    expect(result).toBeUndefined();
+  });
+
+  test('recordRun failure does not break tool result', async () => {
+    const { recordRun } = await import('../src/token-saver/savings-store');
+    recordRun.mockImplementation(() => { throw new Error('DB locked'); });
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: makeConfig() });
+    const large = 'x'.repeat(5000);
+    // Must NOT throw
+    const result = await pi.getHandler('tool_result')(bashEvent('npm test', large), {});
+    expect(result).toBeDefined();
+    expect(result.content[0].text).toContain('MOCK_OUTPUT:');
+  });
+
+  test('uses defaults when output_compression config key is absent', async () => {
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: () => ({}) });
+    const large = 'x'.repeat(5000);
+    const result = await pi.getHandler('tool_result')(bashEvent('git diff', large), {});
+    expect(result).toBeDefined();
+  });
+
+  test('sets exitCode to 1 when isError is true', async () => {
+    const { compressOutput } = await import('../src/token-saver/compress-output');
+    const pi = makePi();
+    registerOutputCompression(pi as any, { state: makeState() as any, getConfig: makeConfig() });
+    const large = 'FAIL '.repeat(2000);
+    await pi.getHandler('tool_result')(bashEvent('npm test', large, true), {});
+    expect(compressOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ exitCode: 1 }),
+    );
+  });
+});

--- a/test/smoke-compression.js
+++ b/test/smoke-compression.js
@@ -1,0 +1,152 @@
+/**
+ * Smoke test: simulates Pi's ExtensionAPI to verify the hook wires up correctly.
+ * Run with: npx tsx test/smoke-compression.js
+ */
+const { registerOutputCompression } = require('../extensions/memory-layer/hooks/output-compression.js');
+
+// ---- Minimal ExtensionAPI mock ----
+const handlers = {};
+const mockPi = {
+  on: (event, handler) => { handlers[event] = handler; },
+};
+
+// ---- Minimal state ----
+const state = {
+  compressionStats: {
+    totalRuns: 0,
+    totalOriginalTokens: 0,
+    totalCompressedTokens: 0,
+    totalSavedTokens: 0,
+  },
+};
+
+// ---- Minimal getConfig ----
+function getConfig() {
+  try {
+    return require('../config.js').getConfig();
+  } catch {
+    return {};
+  }
+}
+
+// ---- Run smoke test ----
+async function runSmokeTest() {
+  console.log('🔥 Output Compression Hook — Smoke Test\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  function assert(condition, label) {
+    if (condition) {
+      console.log(`  ✅ ${label}`);
+      passed++;
+    } else {
+      console.log(`  ❌ ${label}`);
+      failed++;
+    }
+  }
+
+  // 1. Register the hook
+  console.log('1. Registering hook...');
+  try {
+    registerOutputCompression(mockPi, { state, getConfig });
+    assert(true, 'Hook registration did not throw');
+  } catch (e) {
+    assert(false, `Hook registration threw: ${e.message}`);
+  }
+
+  // 2. Verify tool_result handler was registered
+  console.log('\n2. Checking handler registration...');
+  assert(handlers['tool_result'] !== undefined, 'tool_result handler is registered');
+
+  const handler = handlers['tool_result'];
+
+  // 3. Non-bash tool — should be skipped
+  console.log('\n3. Non-bash tool (should be skipped)...');
+  const readResult = await handler({
+    type: 'tool_result',
+    toolName: 'read',
+    toolCallId: 'call-1',
+    input: { path: '/foo.ts' },
+    content: [{ type: 'text', text: 'file contents' }],
+    details: undefined,
+    isError: false,
+  }, {});
+  assert(readResult === undefined, 'Non-bash tool returned undefined (correct)');
+
+  // 4. Short bash output — should be skipped
+  console.log('\n4. Short bash output (should be skipped)...');
+  const shortResult = await handler({
+    type: 'tool_result',
+    toolName: 'bash',
+    toolCallId: 'call-2',
+    input: { command: 'echo hi' },
+    content: [{ type: 'text', text: 'hello world' }],
+    details: undefined,
+    isError: false,
+  }, {});
+  assert(shortResult === undefined, 'Short output returned undefined (correct)');
+
+  // 5. Large bash output — should be compressed
+  console.log('\n5. Large bash output (should be compressed)...');
+  const largeOutput = 'Test output line\n'.repeat(500);
+  const largeResult = await handler({
+    type: 'tool_result',
+    toolName: 'bash',
+    toolCallId: 'call-3',
+    input: { command: 'npm test' },
+    content: [{ type: 'text', text: largeOutput }],
+    details: undefined,
+    isError: false,
+  }, {});
+  assert(largeResult !== undefined, 'Large output returned a result (correct)');
+  assert(
+    largeResult.content && largeResult.content[0] && largeResult.content[0].text,
+    'Result has content with text'
+  );
+  assert(
+    largeResult.content[0].text.startsWith('[Output compressed:'),
+    'Result starts with compression prefix'
+  );
+  assert(
+    largeResult.content[0].text.length < largeOutput.length,
+    `Output was compressed (${largeResult.content[0].text.length} < ${largeOutput.length})`
+  );
+
+  // 6. Stats were updated
+  console.log('\n6. Checking compression stats...');
+  assert(state.compressionStats.totalRuns === 1, `totalRuns === 1 (got ${state.compressionStats.totalRuns})`);
+  assert(state.compressionStats.totalOriginalTokens > 0, 'totalOriginalTokens > 0');
+  assert(state.compressionStats.totalSavedTokens > 0, 'totalSavedTokens > 0');
+
+  // 7. Config defaults
+  console.log('\n7. Checking config defaults...');
+  const config = getConfig();
+  assert(
+    config.output_compression !== undefined,
+    'output_compression key exists in config'
+  );
+  assert(
+    config.output_compression?.enabled === true,
+    'output_compression.enabled defaults to true'
+  );
+  assert(
+    config.output_compression?.min_chars === 2000,
+    'output_compression.min_chars defaults to 2000'
+  );
+  assert(
+    config.output_compression?.min_savings_percent === 30,
+    'output_compression.min_savings_percent defaults to 30'
+  );
+
+  // Summary
+  console.log(`\n${'='.repeat(40)}`);
+  console.log(`Results: ${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+  console.log('\n🎉 All smoke tests passed!\n');
+}
+
+runSmokeTest().catch((e) => {
+  console.error('Smoke test threw:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Wires the existing token-saver module (Phases 1–8) into Pi's `tool_result` extension hook so bash command output is **automatically compressed** before the LLM sees it — no manual `lapis run` wrapper needed.

## What Changed

| File | Change |
|------|--------|
| `config.js` | Added `output_compression` defaults: `enabled: true`, `min_chars: 2000`, `min_savings_percent: 30` |
| `extensions/memory-layer/state.ts` | Added `compressionStats` counters (totalRuns, totalOriginalTokens, totalCompressedTokens, totalSavedTokens) |
| `extensions/memory-layer/hooks/output-compression.ts` | **Core hook** — listens to `tool_result`, compresses bash output via classifyCommand → compressOutput pipeline |
| `extensions/memory-layer/index.ts` | Registered hook via `safeRegister` |
| `test/output-compression*.{js,ts}` | 13 unit tests covering all code paths |
| `test/smoke-compression.js` | 15 integration smoke tests |

## How It Works

```
Bash command runs in Pi
        ↓
tool_result event fires (before LLM sees result)
        ↓
registerOutputCompression handler fires
  • isBashToolResult(event)? → yes
  • output.length >= 2000? → yes
  • classifyCommand(['npm', 'test']) → 'test'
  • compressOutput({ stdout, commandType }) → summary + importantOutput
  • estimateTokens(original) - estimateTokens(compressed) → savings%
  • savingsPercent >= 30%? → yes
  • state.compressionStats updated
  • recordRun(...) → SQLite (best-effort)
        ↓
  Returns { content: [{ type: 'text', text: '[Output compressed: 98%...]\n\nCOMPRESSED...' }] }
        ↓
LLM sees compressed output + savings note
```

## Key Design Decisions

- **Default ON** — `output_compression.enabled` defaults to `true`
- **Best-effort telemetry** — SQLite write failures are silently swallowed at two levels (hook + savings-store)
- **LLM prefix note** — `[Output compressed: X% token savings (Y tokens saved). Summary: Z]` prepended so model knows context was filtered
- **Config opt-out** — Users can disable via `~/.pi/memory/config.jsonc`:
  ```jsonc
  { "output_compression": { "enabled": false } }
  ```
- **Null-guard** — `isBashToolResult` guarded against `undefined` outside Pi runtime (smoke tests + dev)

## Tests

```
Test Files  14 passed (14)
     Tests  55 passed (55)   ← token-saver + output-compression
     Tests  15 passed (15)   ← smoke tests
```

## Code Review

Reviewed pre-merge. 0 critical, 3 important (deferred to v2), 4 minor (cosmetic). Full review at `docs/superpowers/plans/TODO-2026-06-05-output-compression-hook.md`.

---

Closes #180 (tracked as token-saver integration milestone).
