### PR TITLE
feat: add Aurex todo ledger storage

### DIFF
--- a/db.js
+++ b/db.js
@@ -446,7 +446,7 @@ function runMigrations() {
     console.error('[db] Failed to read user_version:', e.message);
   }
 
-  if (version >= 18) {
+  if (version >= 19) {
     return { migrated: false, version };
   }
 
@@ -468,6 +468,7 @@ function runMigrations() {
     { to: 16, run: runMigrationV16 },
     { to: 17, run: runMigrationV17 },
     { to: 18, run: runMigrationV18 },
+    { to: 19, run: runMigrationV19 },
   ];
 
   const fromVersion = version;
@@ -1198,6 +1199,71 @@ function runMigrationV18() {
     });
   } catch (e) {
     errors.push(`V18: ${e.message}`);
+  }
+  return errors;
+}
+
+function runMigrationV19() {
+  const errors = [];
+  try {
+    withTransaction(() => {
+      sqlRaw(`CREATE TABLE IF NOT EXISTS todo_ledgers (
+        mission_id TEXT PRIMARY KEY,
+        mission_title TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'planning',
+        source_mission TEXT NOT NULL DEFAULT '',
+        planner_summary TEXT NOT NULL DEFAULT '',
+        acceptance_criteria TEXT NOT NULL DEFAULT '[]',
+        constraints_json TEXT NOT NULL DEFAULT '[]',
+        assumptions TEXT NOT NULL DEFAULT '[]',
+        human_questions TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )`);
+      sqlRaw(`CREATE TABLE IF NOT EXISTS todo_items (
+        id TEXT PRIMARY KEY,
+        mission_id TEXT NOT NULL REFERENCES todo_ledgers(mission_id) ON DELETE CASCADE,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        type TEXT NOT NULL DEFAULT 'implementation',
+        priority TEXT NOT NULL DEFAULT 'medium',
+        depends_on TEXT NOT NULL DEFAULT '[]',
+        goal TEXT NOT NULL DEFAULT '',
+        scope_json TEXT NOT NULL DEFAULT '{"in":[],"out":[]}',
+        likely_files TEXT NOT NULL DEFAULT '[]',
+        lapis_context_query TEXT NOT NULL DEFAULT '',
+        acceptance_criteria TEXT NOT NULL DEFAULT '[]',
+        validation_criteria TEXT NOT NULL DEFAULT '[]',
+        test_commands TEXT NOT NULL DEFAULT '[]',
+        risk_level TEXT NOT NULL DEFAULT 'medium',
+        worker_instructions TEXT NOT NULL DEFAULT '[]',
+        validator_instructions TEXT NOT NULL DEFAULT '[]',
+        escalation_rules TEXT NOT NULL DEFAULT '[]',
+        evidence_json TEXT NOT NULL DEFAULT '{"branch":null,"commits":[],"changedFiles":[],"testsRun":[],"testResults":[],"validatorVerdict":null,"notes":[]}',
+        confidence TEXT NOT NULL DEFAULT 'medium',
+        assigned_worker_id TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )`);
+      sqlRaw(`CREATE TABLE IF NOT EXISTS todo_events (
+        id TEXT PRIMARY KEY,
+        mission_id TEXT NOT NULL REFERENCES todo_ledgers(mission_id) ON DELETE CASCADE,
+        todo_id TEXT REFERENCES todo_items(id) ON DELETE CASCADE,
+        event_type TEXT NOT NULL,
+        actor_id TEXT,
+        payload_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )`);
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_todo_ledgers_status ON todo_ledgers(status)');
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_todo_items_mission ON todo_items(mission_id)');
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_todo_items_status ON todo_items(status)');
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_todo_items_context ON todo_items(lapis_context_query)');
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_todo_events_mission ON todo_events(mission_id)');
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_todo_events_todo ON todo_events(todo_id)');
+      sqlRaw('PRAGMA user_version = 19');
+    });
+  } catch (e) {
+    errors.push(`V19: ${e.message}`);
   }
   return errors;
 }

--- a/schema.sql
+++ b/schema.sql
@@ -682,3 +682,62 @@ CREATE TABLE IF NOT EXISTS stale_flags (
 
 CREATE INDEX IF NOT EXISTS idx_sf_repo ON stale_flags(repo_id);
 CREATE INDEX IF NOT EXISTS idx_sf_traffic ON stale_flags(file_path);
+
+-- ═══════════════════════════════════════════════════════════
+-- AUREX TODO LEDGER REPOSITORY
+-- ═══════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS todo_ledgers (
+  mission_id          TEXT PRIMARY KEY,
+  mission_title       TEXT NOT NULL DEFAULT '',
+  status              TEXT NOT NULL DEFAULT 'planning',
+  source_mission      TEXT NOT NULL DEFAULT '',
+  planner_summary     TEXT NOT NULL DEFAULT '',
+  acceptance_criteria TEXT NOT NULL DEFAULT '[]',
+  constraints_json    TEXT NOT NULL DEFAULT '[]',
+  assumptions         TEXT NOT NULL DEFAULT '[]',
+  human_questions     TEXT NOT NULL DEFAULT '[]',
+  created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_todo_ledgers_status ON todo_ledgers(status);
+
+CREATE TABLE IF NOT EXISTS todo_items (
+  id                     TEXT PRIMARY KEY,
+  mission_id             TEXT NOT NULL REFERENCES todo_ledgers(mission_id) ON DELETE CASCADE,
+  title                  TEXT NOT NULL,
+  status                 TEXT NOT NULL DEFAULT 'pending',
+  type                   TEXT NOT NULL DEFAULT 'implementation',
+  priority               TEXT NOT NULL DEFAULT 'medium',
+  depends_on             TEXT NOT NULL DEFAULT '[]',
+  goal                   TEXT NOT NULL DEFAULT '',
+  scope_json             TEXT NOT NULL DEFAULT '{"in":[],"out":[]}',
+  likely_files           TEXT NOT NULL DEFAULT '[]',
+  lapis_context_query    TEXT NOT NULL DEFAULT '',
+  acceptance_criteria    TEXT NOT NULL DEFAULT '[]',
+  validation_criteria    TEXT NOT NULL DEFAULT '[]',
+  test_commands          TEXT NOT NULL DEFAULT '[]',
+  risk_level             TEXT NOT NULL DEFAULT 'medium',
+  worker_instructions    TEXT NOT NULL DEFAULT '[]',
+  validator_instructions TEXT NOT NULL DEFAULT '[]',
+  escalation_rules       TEXT NOT NULL DEFAULT '[]',
+  evidence_json          TEXT NOT NULL DEFAULT '{"branch":null,"commits":[],"changedFiles":[],"testsRun":[],"testResults":[],"validatorVerdict":null,"notes":[]}',
+  confidence             TEXT NOT NULL DEFAULT 'medium',
+  assigned_worker_id     TEXT,
+  created_at             TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at             TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_todo_items_mission ON todo_items(mission_id);
+CREATE INDEX IF NOT EXISTS idx_todo_items_status ON todo_items(status);
+CREATE INDEX IF NOT EXISTS idx_todo_items_context ON todo_items(lapis_context_query);
+
+CREATE TABLE IF NOT EXISTS todo_events (
+  id           TEXT PRIMARY KEY,
+  mission_id   TEXT NOT NULL REFERENCES todo_ledgers(mission_id) ON DELETE CASCADE,
+  todo_id      TEXT REFERENCES todo_items(id) ON DELETE CASCADE,
+  event_type   TEXT NOT NULL,
+  actor_id     TEXT,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_todo_events_mission ON todo_events(mission_id);
+CREATE INDEX IF NOT EXISTS idx_todo_events_todo ON todo_events(todo_id);

--- a/src/http/handlers/todos.js
+++ b/src/http/handlers/todos.js
@@ -1,0 +1,289 @@
+const { jsonOk, jsonCreated, jsonError } = require('../errors');
+
+function createMissionLedger(repo) {
+  return async (req, res, ctx) => {
+    try {
+      const rows = repo.createMissionLedger(ctx.body);
+      jsonCreated(res, rows[0] || null);
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo_ledger', e.message);
+    }
+  };
+}
+
+function getMissionLedger(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.getMissionLedger(ctx.params.missionId);
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'Todo ledger not found');
+      return;
+    }
+    jsonOk(res, rows[0]);
+  };
+}
+
+function listMissionLedgers(repo) {
+  return async (req, res, ctx) => {
+    try {
+      jsonOk(res, repo.listMissionLedgers({ status: ctx.query.get('status') || undefined }));
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo_ledger_filter', e.message);
+    }
+  };
+}
+
+function updateMissionLedger(repo) {
+  return async (req, res, ctx) => {
+    try {
+      const rows = repo.updateMissionLedger(ctx.params.missionId, ctx.body);
+      if (rows.length === 0) {
+        jsonError(res, 404, 'not_found', 'Todo ledger not found');
+        return;
+      }
+      jsonOk(res, rows[0]);
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo_ledger', e.message);
+    }
+  };
+}
+
+function setMissionLedgerStatus(repo) {
+  return async (req, res, ctx) => {
+    try {
+      const rows = repo.setMissionLedgerStatus(ctx.params.missionId, ctx.body.status);
+      if (rows.length === 0) {
+        jsonError(res, 404, 'not_found', 'Todo ledger not found');
+        return;
+      }
+      jsonOk(res, rows[0]);
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo_ledger_status', e.message);
+    }
+  };
+}
+
+function createTodo(repo) {
+  return async (req, res, ctx) => {
+    try {
+      const rows = repo.createTodo(ctx.params.missionId, ctx.body);
+      jsonCreated(res, rows[0] || null);
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo', e.message);
+    }
+  };
+}
+
+function createTodos(repo) {
+  return async (req, res, ctx) => {
+    try {
+      const todos = Array.isArray(ctx.body.todos) ? ctx.body.todos : ctx.body;
+      jsonCreated(res, repo.createTodos(ctx.params.missionId, todos));
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todos', e.message);
+    }
+  };
+}
+
+function getTodo(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.getTodo(ctx.params.todoId);
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'Todo not found');
+      return;
+    }
+    jsonOk(res, rows[0]);
+  };
+}
+
+function listTodos(repo) {
+  return async (req, res, ctx) => {
+    try {
+      jsonOk(res, repo.listTodos({
+        missionId: ctx.query.get('missionId') || undefined,
+        status: ctx.query.get('status') || undefined,
+        type: ctx.query.get('type') || undefined,
+      }));
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo_filter', e.message);
+    }
+  };
+}
+
+function listTodosByMission(repo) {
+  return async (req, res, ctx) => {
+    jsonOk(res, repo.listTodosByMission(ctx.params.missionId));
+  };
+}
+
+function searchTodos(repo) {
+  return async (req, res, ctx) => {
+    jsonOk(res, repo.searchTodos(ctx.body.query || '', { missionId: ctx.body.missionId }));
+  };
+}
+
+function updateTodo(repo) {
+  return async (req, res, ctx) => {
+    try {
+      const rows = repo.updateTodo(ctx.params.todoId, ctx.body);
+      if (rows.length === 0) {
+        jsonError(res, 404, 'not_found', 'Todo not found');
+        return;
+      }
+      jsonOk(res, rows[0]);
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo', e.message);
+    }
+  };
+}
+
+function setTodoStatus(repo) {
+  return async (req, res, ctx) => {
+    try {
+      const rows = repo.setTodoStatus(ctx.params.todoId, ctx.body.status);
+      if (rows.length === 0) {
+        jsonError(res, 404, 'not_found', 'Todo not found');
+        return;
+      }
+      jsonOk(res, rows[0]);
+    } catch (e) {
+      jsonError(res, 400, 'invalid_todo_status', e.message);
+    }
+  };
+}
+
+function addTodoEvidence(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.addTodoEvidence(ctx.params.todoId, ctx.body);
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'Todo not found');
+      return;
+    }
+    jsonOk(res, rows[0]);
+  };
+}
+
+function addTodoNote(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.addTodoNote(ctx.params.todoId, ctx.body.note || '');
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'Todo not found');
+      return;
+    }
+    jsonOk(res, rows[0]);
+  };
+}
+
+function assignTodo(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.assignTodo(ctx.params.todoId, ctx.body.workerId || null);
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'Todo not found');
+      return;
+    }
+    jsonOk(res, rows[0]);
+  };
+}
+
+function claimNextReadyTodo(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.claimNextReadyTodo(ctx.params.missionId, ctx.body.workerId || null);
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'No ready todo found');
+      return;
+    }
+    jsonOk(res, rows[0]);
+  };
+}
+
+function getTodoContextQuery(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.getTodoContextQuery(ctx.params.todoId);
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'Todo not found');
+      return;
+    }
+    jsonOk(res, rows[0]);
+  };
+}
+
+function getContextForTodo(repo, deps) {
+  return async (req, res, ctx) => {
+    const todo = repo.getTodo(ctx.params.todoId)[0];
+    if (!todo) {
+      jsonError(res, 404, 'not_found', 'Todo not found');
+      return;
+    }
+    if (!todo.lapisContextQuery.trim()) {
+      jsonError(res, 400, 'missing_context_query', 'Todo has no lapisContextQuery');
+      return;
+    }
+    const searchDeps = { sqlJson: deps.sqlJson, sqlRun: deps.sqlRun, jsonErrNoExit: (msg) => ({ error: msg }) };
+    const search = require('../../memory-domain/search').search;
+    const limit = ctx.query.get('limit') || '10';
+    const result = search(searchDeps, { query: todo.lapisContextQuery, limit });
+    const context = (Array.isArray(result) ? result : []).map((r) => ({
+      id: r.id,
+      title: r.title || '',
+      content: r.snippet || r.content || '',
+      type: r.type || '',
+      scope: r.scope || '',
+      topicKey: r.topic_key || null,
+    }));
+    jsonOk(res, { todoId: todo.id, query: todo.lapisContextQuery, context });
+  };
+}
+
+function recordTodoEvent(repo) {
+  return async (req, res, ctx) => {
+    const rows = repo.recordTodoEvent(ctx.params.todoId, ctx.body);
+    if (rows.length === 0) {
+      jsonError(res, 404, 'not_found', 'Todo not found');
+      return;
+    }
+    jsonCreated(res, rows[0]);
+  };
+}
+
+function listTodoEvents(repo) {
+  return async (req, res, ctx) => {
+    jsonOk(res, repo.listTodoEvents(ctx.params.todoId));
+  };
+}
+
+function recordMissionEvent(repo) {
+  return async (req, res, ctx) => {
+    jsonCreated(res, repo.recordMissionEvent(ctx.params.missionId, ctx.body)[0]);
+  };
+}
+
+function listMissionEvents(repo) {
+  return async (req, res, ctx) => {
+    jsonOk(res, repo.listMissionEvents(ctx.params.missionId));
+  };
+}
+
+module.exports = {
+  createMissionLedger,
+  getMissionLedger,
+  listMissionLedgers,
+  updateMissionLedger,
+  setMissionLedgerStatus,
+  createTodo,
+  createTodos,
+  getTodo,
+  listTodos,
+  listTodosByMission,
+  searchTodos,
+  updateTodo,
+  setTodoStatus,
+  addTodoEvidence,
+  addTodoNote,
+  assignTodo,
+  claimNextReadyTodo,
+  getTodoContextQuery,
+  getContextForTodo,
+  recordTodoEvent,
+  listTodoEvents,
+  recordMissionEvent,
+  listMissionEvents,
+};

--- a/src/http/handlers/verdicts.js
+++ b/src/http/handlers/verdicts.js
@@ -1,7 +1,13 @@
-const { jsonOk, jsonCreated } = require('../errors');
+const { jsonOk, jsonCreated, jsonError } = require('../errors');
 
 function writeVerdict(repo) {
   return async (req, res, ctx) => {
+    const errors = validateVerdictPayload(ctx.body);
+    if (errors.length > 0) {
+      jsonError(res, 400, 'invalid_verdict', errors.join('; '));
+      return;
+    }
+
     const { sessionId, ...verdict } = ctx.body;
     const id = `vv-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const rows = repo.createVerdict({ id, sessionId, ...verdict });
@@ -24,4 +30,33 @@ function getVerdicts(repo) {
   };
 }
 
-module.exports = { writeVerdict, classifyVerdict, getVerdicts };
+function validateVerdictPayload(body) {
+  const errors = [];
+  if (!body || typeof body !== 'object') {
+    return ['body must be a JSON object'];
+  }
+
+  for (const field of ['sessionId', 'milestoneId', 'contractId', 'validatorType', 'verdict', 'findings']) {
+    if (typeof body[field] !== 'string' || body[field].trim().length === 0) {
+      errors.push(`${field} is required`);
+    }
+  }
+
+  if (!['validator_scrutiny', 'validator_user_testing'].includes(body.validatorType)) {
+    errors.push('validatorType must be validator_scrutiny or validator_user_testing');
+  }
+
+  if (!['pass', 'fail'].includes(body.verdict)) {
+    errors.push('verdict must be pass or fail');
+  }
+
+  if (!Array.isArray(body.failedUnitIds)) {
+    errors.push('failedUnitIds must be an array');
+  } else if (body.failedUnitIds.some((id) => typeof id !== 'string' || id.trim().length === 0)) {
+    errors.push('failedUnitIds must contain only non-empty strings');
+  }
+
+  return errors;
+}
+
+module.exports = { writeVerdict, classifyVerdict, getVerdicts, validateVerdictPayload };

--- a/src/http/server.js
+++ b/src/http/server.js
@@ -71,6 +71,7 @@ function buildRoutes(deps) {
   const checkpoints = require('./handlers/checkpoints');
   const settings = require('./handlers/settings');
   const codeIndex = require('./handlers/code-index');
+  const todos = require('./handlers/todos');
 
   return [
     // Health
@@ -137,6 +138,33 @@ function buildRoutes(deps) {
     { method: 'GET', pattern: '/checkpoints/:id', handler: checkpoints.getCheckpoint(aurex) },
     { method: 'PATCH', pattern: '/checkpoints/:id', handler: checkpoints.resolveCheckpoint(aurex) },
     { method: 'GET', pattern: '/missions/:missionId/checkpoints', handler: checkpoints.getPendingCheckpoints(aurex) },
+
+    // Todo ledgers
+    { method: 'POST', pattern: '/todo-ledgers', handler: todos.createMissionLedger(aurex) },
+    { method: 'GET', pattern: '/todo-ledgers', handler: todos.listMissionLedgers(aurex) },
+    { method: 'GET', pattern: '/missions/:missionId/todo-ledger', handler: todos.getMissionLedger(aurex) },
+    { method: 'PATCH', pattern: '/missions/:missionId/todo-ledger', handler: todos.updateMissionLedger(aurex) },
+    { method: 'PATCH', pattern: '/missions/:missionId/todo-ledger/status', handler: todos.setMissionLedgerStatus(aurex) },
+    { method: 'POST', pattern: '/missions/:missionId/todo-events', handler: todos.recordMissionEvent(aurex) },
+    { method: 'GET', pattern: '/missions/:missionId/todo-events', handler: todos.listMissionEvents(aurex) },
+
+    // Todo items
+    { method: 'POST', pattern: '/missions/:missionId/todos', handler: todos.createTodo(aurex) },
+    { method: 'POST', pattern: '/missions/:missionId/todos/bulk', handler: todos.createTodos(aurex) },
+    { method: 'GET', pattern: '/missions/:missionId/todos', handler: todos.listTodosByMission(aurex) },
+    { method: 'GET', pattern: '/todos', handler: todos.listTodos(aurex) },
+    { method: 'POST', pattern: '/todos/search', handler: todos.searchTodos(aurex) },
+    { method: 'POST', pattern: '/missions/:missionId/todos/claim-next', handler: todos.claimNextReadyTodo(aurex) },
+    { method: 'GET', pattern: '/todos/:todoId', handler: todos.getTodo(aurex) },
+    { method: 'PATCH', pattern: '/todos/:todoId', handler: todos.updateTodo(aurex) },
+    { method: 'PATCH', pattern: '/todos/:todoId/status', handler: todos.setTodoStatus(aurex) },
+    { method: 'POST', pattern: '/todos/:todoId/evidence', handler: todos.addTodoEvidence(aurex) },
+    { method: 'POST', pattern: '/todos/:todoId/notes', handler: todos.addTodoNote(aurex) },
+    { method: 'PATCH', pattern: '/todos/:todoId/assignment', handler: todos.assignTodo(aurex) },
+    { method: 'GET', pattern: '/todos/:todoId/context-query', handler: todos.getTodoContextQuery(aurex) },
+    { method: 'GET', pattern: '/todos/:todoId/context', handler: todos.getContextForTodo(aurex, deps) },
+    { method: 'POST', pattern: '/todos/:todoId/events', handler: todos.recordTodoEvent(aurex) },
+    { method: 'GET', pattern: '/todos/:todoId/events', handler: todos.listTodoEvents(aurex) },
 
     // Settings (KV store)
     { method: 'GET', pattern: '/settings/:key', handler: settings.getSetting(deps.sqlJson) },

--- a/src/platform/storage/repositories/aurex.js
+++ b/src/platform/storage/repositories/aurex.js
@@ -265,6 +265,319 @@ function createAurexRepository(deps) {
       );
     },
 
+    // --- Todo Ledgers ---
+    createMissionLedger({
+      missionId,
+      missionTitle,
+      status,
+      sourceMission,
+      plannerSummary,
+      acceptanceCriteria,
+      constraints,
+      assumptions,
+      humanQuestions,
+    }) {
+      assertInSet(status || 'planning', MISSION_LEDGER_STATUSES, 'status');
+      sqlRun(
+        `INSERT INTO todo_ledgers (
+          mission_id, mission_title, status, source_mission, planner_summary,
+          acceptance_criteria, constraints_json, assumptions, human_questions
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          missionId,
+          missionTitle || '',
+          status || 'planning',
+          sourceMission || '',
+          plannerSummary || '',
+          toJson(acceptanceCriteria || []),
+          toJson(constraints || []),
+          toJson(assumptions || []),
+          toJson(humanQuestions || []),
+        ],
+      );
+      this.recordMissionEvent(missionId, {
+        eventType: 'ledger_created',
+        payload: { status: status || 'planning', missionTitle: missionTitle || '' },
+      });
+      return this.getMissionLedger(missionId);
+    },
+    getMissionLedger(missionId) {
+      const ledgers = sqlJson('SELECT * FROM todo_ledgers WHERE mission_id = ?', [missionId]).map(mapLedgerRow);
+      if (ledgers.length === 0) {
+        return [];
+      }
+      const todos = this.listTodosByMission(missionId);
+      return [{ ...ledgers[0], todos }];
+    },
+    listMissionLedgers(filters = {}) {
+      if (filters.status) {
+        assertInSet(filters.status, MISSION_LEDGER_STATUSES, 'status');
+        return sqlJson('SELECT * FROM todo_ledgers WHERE status = ? ORDER BY updated_at DESC', [filters.status]).map(mapLedgerRow);
+      }
+      return sqlJson('SELECT * FROM todo_ledgers ORDER BY updated_at DESC').map(mapLedgerRow);
+    },
+    updateMissionLedger(missionId, patch) {
+      const existing = this.getMissionLedger(missionId);
+      if (existing.length === 0) {
+        return [];
+      }
+      const next = { ...existing[0], ...patch };
+      assertInSet(next.status, MISSION_LEDGER_STATUSES, 'status');
+      sqlRun(
+        `UPDATE todo_ledgers SET
+          mission_title = ?, status = ?, source_mission = ?, planner_summary = ?,
+          acceptance_criteria = ?, constraints_json = ?, assumptions = ?,
+          human_questions = ?, updated_at = datetime('now')
+         WHERE mission_id = ?`,
+        [
+          next.missionTitle || '',
+          next.status,
+          next.sourceMission || '',
+          next.plannerSummary || '',
+          toJson(next.acceptanceCriteria || []),
+          toJson(next.constraints || []),
+          toJson(next.assumptions || []),
+          toJson(next.humanQuestions || []),
+          missionId,
+        ],
+      );
+      this.recordMissionEvent(missionId, { eventType: 'ledger_updated', payload: patch });
+      return this.getMissionLedger(missionId);
+    },
+    setMissionLedgerStatus(missionId, status) {
+      assertInSet(status, MISSION_LEDGER_STATUSES, 'status');
+      const current = this.getMissionLedger(missionId)[0];
+      sqlRun('UPDATE todo_ledgers SET status = ?, updated_at = datetime(\'now\') WHERE mission_id = ?', [status, missionId]);
+      this.recordMissionEvent(missionId, {
+        eventType: 'mission_status_changed',
+        payload: { from: current?.status || null, to: status },
+      });
+      return this.getMissionLedger(missionId);
+    },
+
+    // --- Todo Items ---
+    createTodo(missionId, todo) {
+      const id = todo.id || `td-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const normalized = normalizeTodoInput({ ...todo, id, missionId });
+      sqlRun(
+        `INSERT INTO todo_items (
+          id, mission_id, title, status, type, priority, depends_on, goal,
+          scope_json, likely_files, lapis_context_query, acceptance_criteria,
+          validation_criteria, test_commands, risk_level, worker_instructions,
+          validator_instructions, escalation_rules, evidence_json, confidence,
+          assigned_worker_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          normalized.id,
+          normalized.missionId,
+          normalized.title,
+          normalized.status,
+          normalized.type,
+          normalized.priority,
+          toJson(normalized.dependsOn),
+          normalized.goal,
+          toJson(normalized.scope),
+          toJson(normalized.likelyFiles),
+          normalized.lapisContextQuery,
+          toJson(normalized.acceptanceCriteria),
+          toJson(normalized.validationCriteria),
+          toJson(normalized.testCommands),
+          normalized.riskLevel,
+          toJson(normalized.workerInstructions),
+          toJson(normalized.validatorInstructions),
+          toJson(normalized.escalationRules),
+          toJson(normalized.evidence),
+          normalized.confidence,
+          normalized.assignedWorkerId || null,
+        ],
+      );
+      this.recordTodoEvent(id, {
+        eventType: 'todo_created',
+        payload: { status: normalized.status, title: normalized.title },
+      });
+      return this.getTodo(id);
+    },
+    createTodos(missionId, todos) {
+      const created = [];
+      for (const todo of todos || []) {
+        created.push(...this.createTodo(missionId, todo));
+      }
+      return created;
+    },
+    getTodo(todoId) {
+      return sqlJson('SELECT * FROM todo_items WHERE id = ?', [todoId]).map(mapTodoRow);
+    },
+    listTodos(filters = {}) {
+      const clauses = [];
+      const params = [];
+      if (filters.missionId) {
+        clauses.push('mission_id = ?');
+        params.push(filters.missionId);
+      }
+      if (filters.status) {
+        assertInSet(filters.status, TODO_STATUSES, 'status');
+        clauses.push('status = ?');
+        params.push(filters.status);
+      }
+      if (filters.type) {
+        assertInSet(filters.type, TODO_TYPES, 'type');
+        clauses.push('type = ?');
+        params.push(filters.type);
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+      return sqlJson(`SELECT * FROM todo_items ${where} ORDER BY created_at`, params).map(mapTodoRow);
+    },
+    listTodosByMission(missionId) {
+      return this.listTodos({ missionId });
+    },
+    searchTodos(query, filters = {}) {
+      const like = `%${query || ''}%`;
+      const params = [like, like, like, like];
+      let missionClause = '';
+      if (filters.missionId) {
+        missionClause = ' AND mission_id = ?';
+        params.push(filters.missionId);
+      }
+      return sqlJson(
+        `SELECT * FROM todo_items
+         WHERE (title LIKE ? OR goal LIKE ? OR lapis_context_query LIKE ? OR likely_files LIKE ?)
+         ${missionClause}
+         ORDER BY updated_at DESC`,
+        params,
+      ).map(mapTodoRow);
+    },
+    updateTodo(todoId, patch) {
+      const current = this.getTodo(todoId)[0];
+      if (!current) {
+        return [];
+      }
+      const next = normalizeTodoInput({ ...current, ...patch, id: todoId, missionId: current.missionId });
+      validateTodoStatusEvidence(next.status, next.evidence);
+      sqlRun(
+        `UPDATE todo_items SET
+          title = ?, status = ?, type = ?, priority = ?, depends_on = ?, goal = ?,
+          scope_json = ?, likely_files = ?, lapis_context_query = ?,
+          acceptance_criteria = ?, validation_criteria = ?, test_commands = ?,
+          risk_level = ?, worker_instructions = ?, validator_instructions = ?,
+          escalation_rules = ?, evidence_json = ?, confidence = ?,
+          assigned_worker_id = ?, updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          next.title,
+          next.status,
+          next.type,
+          next.priority,
+          toJson(next.dependsOn),
+          next.goal,
+          toJson(next.scope),
+          toJson(next.likelyFiles),
+          next.lapisContextQuery,
+          toJson(next.acceptanceCriteria),
+          toJson(next.validationCriteria),
+          toJson(next.testCommands),
+          next.riskLevel,
+          toJson(next.workerInstructions),
+          toJson(next.validatorInstructions),
+          toJson(next.escalationRules),
+          toJson(next.evidence),
+          next.confidence,
+          next.assignedWorkerId || null,
+          todoId,
+        ],
+      );
+      this.recordTodoEvent(todoId, { eventType: 'todo_updated', payload: patch });
+      return this.getTodo(todoId);
+    },
+    setTodoStatus(todoId, status) {
+      assertInSet(status, TODO_STATUSES, 'status');
+      const current = this.getTodo(todoId)[0];
+      if (!current) {
+        return [];
+      }
+      validateTodoStatusEvidence(status, current.evidence);
+      sqlRun('UPDATE todo_items SET status = ?, updated_at = datetime(\'now\') WHERE id = ?', [status, todoId]);
+      this.recordTodoEvent(todoId, {
+        eventType: 'todo_status_changed',
+        payload: { from: current.status, to: status },
+      });
+      return this.getTodo(todoId);
+    },
+    addTodoEvidence(todoId, evidencePatch) {
+      const current = this.getTodo(todoId)[0];
+      if (!current) {
+        return [];
+      }
+      const evidence = mergeEvidence(current.evidence, evidencePatch || {});
+      sqlRun('UPDATE todo_items SET evidence_json = ?, updated_at = datetime(\'now\') WHERE id = ?', [
+        toJson(evidence),
+        todoId,
+      ]);
+      this.recordTodoEvent(todoId, { eventType: 'todo_evidence_added', payload: evidencePatch || {} });
+      return this.getTodo(todoId);
+    },
+    addTodoNote(todoId, note) {
+      return this.addTodoEvidence(todoId, { notes: [note] });
+    },
+    assignTodo(todoId, workerId) {
+      const current = this.getTodo(todoId)[0];
+      if (!current) {
+        return [];
+      }
+      sqlRun('UPDATE todo_items SET assigned_worker_id = ?, updated_at = datetime(\'now\') WHERE id = ?', [workerId, todoId]);
+      this.recordTodoEvent(todoId, {
+        eventType: 'todo_assigned',
+        payload: { from: current.assignedWorkerId || null, to: workerId || null },
+      });
+      return this.getTodo(todoId);
+    },
+    claimNextReadyTodo(missionId, workerId) {
+      const rows = sqlJson(
+        "SELECT * FROM todo_items WHERE mission_id = ? AND status = 'ready' ORDER BY priority DESC, created_at LIMIT 1",
+        [missionId],
+      ).map(mapTodoRow);
+      if (rows.length === 0) {
+        return [];
+      }
+      const todo = rows[0];
+      this.assignTodo(todo.id, workerId);
+      return this.setTodoStatus(todo.id, 'in_progress');
+    },
+    getTodoContextQuery(todoId) {
+      const todo = this.getTodo(todoId)[0];
+      if (!todo) {
+        return [];
+      }
+      return [{ todoId, lapisContextQuery: todo.lapisContextQuery }];
+    },
+
+    // --- Todo Audit Events ---
+    recordTodoEvent(todoId, event) {
+      const todo = this.getTodo(todoId)[0];
+      if (!todo) {
+        return [];
+      }
+      const id = event.id || `te-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      sqlRun(
+        'INSERT INTO todo_events (id, mission_id, todo_id, event_type, actor_id, payload_json) VALUES (?, ?, ?, ?, ?, ?)',
+        [id, todo.missionId, todoId, event.eventType || 'todo_event', event.actorId || null, toJson(event.payload || {})],
+      );
+      return sqlJson('SELECT * FROM todo_events WHERE id = ?', [id]).map(mapTodoEventRow);
+    },
+    listTodoEvents(todoId) {
+      return sqlJson('SELECT * FROM todo_events WHERE todo_id = ? ORDER BY created_at', [todoId]).map(mapTodoEventRow);
+    },
+    recordMissionEvent(missionId, event) {
+      const id = event.id || `me-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      sqlRun(
+        'INSERT INTO todo_events (id, mission_id, todo_id, event_type, actor_id, payload_json) VALUES (?, ?, ?, ?, ?, ?)',
+        [id, missionId, null, event.eventType || 'mission_event', event.actorId || null, toJson(event.payload || {})],
+      );
+      return sqlJson('SELECT * FROM todo_events WHERE id = ?', [id]).map(mapTodoEventRow);
+    },
+    listMissionEvents(missionId) {
+      return sqlJson('SELECT * FROM todo_events WHERE mission_id = ? ORDER BY created_at', [missionId]).map(mapTodoEventRow);
+    },
+
     // --- Checkpoints ---
     createCheckpoint({ id, missionId, trigger, milestoneId, summary }) {
       sqlRun('INSERT INTO checkpoints (id, mission_id, trigger, milestone_id, summary) VALUES (?, ?, ?, ?, ?)', [
@@ -304,6 +617,209 @@ function createAurexRepository(deps) {
   };
 
   return Object.freeze(repository);
+}
+
+const MISSION_LEDGER_STATUSES = new Set(['planning', 'ready', 'in_progress', 'blocked', 'validating', 'completed', 'cancelled']);
+const TODO_STATUSES = new Set([
+  'pending',
+  'ready',
+  'in_progress',
+  'blocked',
+  'implemented',
+  'validating',
+  'needs_changes',
+  'passed',
+  'merged',
+  'cancelled',
+]);
+const TODO_TYPES = new Set(['discovery', 'implementation', 'test', 'refactor', 'validation', 'documentation']);
+const PRIORITIES = new Set(['low', 'medium', 'high']);
+const RISK_LEVELS = new Set(['low', 'medium', 'high']);
+const CONFIDENCE_LEVELS = new Set(['low', 'medium', 'high']);
+
+function assertInSet(value, allowed, field) {
+  if (!allowed.has(value)) {
+    throw new Error(`${field} must be one of: ${Array.from(allowed).join(', ')}`);
+  }
+}
+
+function toJson(value) {
+  return JSON.stringify(value ?? null);
+}
+
+function parseJson(value, fallback) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function defaultEvidence() {
+  return {
+    branch: null,
+    commits: [],
+    changedFiles: [],
+    testsRun: [],
+    testResults: [],
+    validatorVerdict: null,
+    notes: [],
+  };
+}
+
+function normalizeEvidence(evidence) {
+  const base = defaultEvidence();
+  const input = evidence && typeof evidence === 'object' ? evidence : {};
+  return {
+    branch: input.branch ?? base.branch,
+    commits: Array.isArray(input.commits) ? input.commits : base.commits,
+    changedFiles: Array.isArray(input.changedFiles) ? input.changedFiles : base.changedFiles,
+    testsRun: Array.isArray(input.testsRun) ? input.testsRun : base.testsRun,
+    testResults: Array.isArray(input.testResults) ? input.testResults : base.testResults,
+    validatorVerdict: input.validatorVerdict ?? base.validatorVerdict,
+    notes: Array.isArray(input.notes) ? input.notes : base.notes,
+  };
+}
+
+function mergeEvidence(current, patch) {
+  const evidence = normalizeEvidence(current);
+  const next = patch && typeof patch === 'object' ? patch : {};
+  for (const field of ['commits', 'changedFiles', 'testsRun', 'testResults', 'notes']) {
+    if (Array.isArray(next[field])) {
+      evidence[field] = [...evidence[field], ...next[field]];
+    }
+  }
+  if (Object.hasOwn(next, 'branch')) {
+    evidence.branch = next.branch;
+  }
+  if (Object.hasOwn(next, 'validatorVerdict')) {
+    evidence.validatorVerdict = next.validatorVerdict;
+  }
+  return evidence;
+}
+
+function hasEvidence(evidence) {
+  const normalized = normalizeEvidence(evidence);
+  return Boolean(
+    normalized.branch ||
+      normalized.validatorVerdict ||
+      normalized.commits.length ||
+      normalized.changedFiles.length ||
+      normalized.testsRun.length ||
+      normalized.testResults.length ||
+      normalized.notes.length,
+  );
+}
+
+function validateTodoStatusEvidence(status, evidence) {
+  if (status === 'implemented' && !hasEvidence(evidence)) {
+    throw new Error('todo cannot be marked implemented without evidence');
+  }
+  if (status === 'passed' && !normalizeEvidence(evidence).validatorVerdict) {
+    throw new Error('todo cannot be marked passed without validator verdict evidence');
+  }
+  if (status === 'merged') {
+    const normalized = normalizeEvidence(evidence);
+    if (!normalized.branch || normalized.commits.length === 0) {
+      throw new Error('todo cannot be marked merged without branch and commit evidence');
+    }
+  }
+}
+
+function normalizeTodoInput(todo) {
+  const normalized = {
+    id: todo.id,
+    missionId: todo.missionId,
+    title: todo.title || todo.goal || 'Untitled todo',
+    status: todo.status || 'pending',
+    type: todo.type || 'implementation',
+    priority: todo.priority || 'medium',
+    dependsOn: Array.isArray(todo.dependsOn) ? todo.dependsOn : [],
+    goal: todo.goal || '',
+    scope: todo.scope && typeof todo.scope === 'object' ? {
+      in: Array.isArray(todo.scope.in) ? todo.scope.in : [],
+      out: Array.isArray(todo.scope.out) ? todo.scope.out : [],
+    } : { in: [], out: [] },
+    likelyFiles: Array.isArray(todo.likelyFiles) ? todo.likelyFiles : [],
+    lapisContextQuery: todo.lapisContextQuery || '',
+    acceptanceCriteria: Array.isArray(todo.acceptanceCriteria) ? todo.acceptanceCriteria : [],
+    validationCriteria: Array.isArray(todo.validationCriteria) ? todo.validationCriteria : [],
+    testCommands: Array.isArray(todo.testCommands) ? todo.testCommands : [],
+    riskLevel: todo.riskLevel || 'medium',
+    workerInstructions: Array.isArray(todo.workerInstructions) ? todo.workerInstructions : [],
+    validatorInstructions: Array.isArray(todo.validatorInstructions) ? todo.validatorInstructions : [],
+    escalationRules: Array.isArray(todo.escalationRules) ? todo.escalationRules : [],
+    evidence: normalizeEvidence(todo.evidence),
+    confidence: todo.confidence || 'medium',
+    assignedWorkerId: todo.assignedWorkerId || todo.assigned_worker_id || null,
+  };
+  assertInSet(normalized.status, TODO_STATUSES, 'status');
+  assertInSet(normalized.type, TODO_TYPES, 'type');
+  assertInSet(normalized.priority, PRIORITIES, 'priority');
+  assertInSet(normalized.riskLevel, RISK_LEVELS, 'riskLevel');
+  assertInSet(normalized.confidence, CONFIDENCE_LEVELS, 'confidence');
+  validateTodoStatusEvidence(normalized.status, normalized.evidence);
+  return normalized;
+}
+
+function mapLedgerRow(row) {
+  return {
+    missionId: row.mission_id,
+    missionTitle: row.mission_title,
+    status: row.status,
+    sourceMission: row.source_mission,
+    plannerSummary: row.planner_summary,
+    acceptanceCriteria: parseJson(row.acceptance_criteria, []),
+    constraints: parseJson(row.constraints_json, []),
+    assumptions: parseJson(row.assumptions, []),
+    humanQuestions: parseJson(row.human_questions, []),
+    todos: [],
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapTodoRow(row) {
+  return {
+    id: row.id,
+    missionId: row.mission_id,
+    title: row.title,
+    status: row.status,
+    type: row.type,
+    priority: row.priority,
+    dependsOn: parseJson(row.depends_on, []),
+    goal: row.goal,
+    scope: parseJson(row.scope_json, { in: [], out: [] }),
+    likelyFiles: parseJson(row.likely_files, []),
+    lapisContextQuery: row.lapis_context_query,
+    acceptanceCriteria: parseJson(row.acceptance_criteria, []),
+    validationCriteria: parseJson(row.validation_criteria, []),
+    testCommands: parseJson(row.test_commands, []),
+    riskLevel: row.risk_level,
+    workerInstructions: parseJson(row.worker_instructions, []),
+    validatorInstructions: parseJson(row.validator_instructions, []),
+    escalationRules: parseJson(row.escalation_rules, []),
+    evidence: normalizeEvidence(parseJson(row.evidence_json, defaultEvidence())),
+    confidence: row.confidence,
+    assignedWorkerId: row.assigned_worker_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapTodoEventRow(row) {
+  return {
+    id: row.id,
+    missionId: row.mission_id,
+    todoId: row.todo_id,
+    eventType: row.event_type,
+    actorId: row.actor_id,
+    payload: parseJson(row.payload_json, {}),
+    createdAt: row.created_at,
+  };
 }
 
 module.exports = { createAurexRepository };

--- a/test/http-server.test.js
+++ b/test/http-server.test.js
@@ -63,6 +63,13 @@ describe('Aurex HTTP Server', () => {
       const rows = sqlJson("SELECT name FROM sqlite_master WHERE type='table' AND name='checkpoints'");
       expect(rows.length).toBe(1);
     });
+
+    it('creates todo ledger tables after migration', () => {
+      for (const table of ['todo_ledgers', 'todo_items', 'todo_events']) {
+        const rows = sqlJson("SELECT name FROM sqlite_master WHERE type='table' AND name=?", [table]);
+        expect(rows.length).toBe(1);
+      }
+    });
   });
 
   describe('Aurex repository', () => {
@@ -239,6 +246,48 @@ describe('Aurex HTTP Server', () => {
       expect(rows.length).toBeGreaterThanOrEqual(1);
       expect(rows.some((r) => r.reason === 'scope changed')).toBe(true);
     });
+
+    it('creates a mission todo ledger and todo items with audit events', () => {
+      const ledger = repo.createMissionLedger({
+        missionId: 'm1',
+        missionTitle: 'Todo mission',
+        sourceMission: 'Implement todo ledger',
+        plannerSummary: 'Add storage and API',
+        acceptanceCriteria: ['ledger can be read'],
+      })[0];
+      expect(ledger.missionId).toBe('m1');
+      expect(ledger.status).toBe('planning');
+
+      const todo = repo.createTodo('m1', {
+        id: 'todo-1',
+        title: 'Add todo storage',
+        status: 'ready',
+        type: 'implementation',
+        goal: 'Persist todos',
+        likelyFiles: ['src/platform/storage/repositories/aurex.js'],
+        lapisContextQuery: 'todo ledger storage repository tests',
+      })[0];
+      expect(todo.id).toBe('todo-1');
+      expect(repo.listTodosByMission('m1').length).toBe(1);
+      expect(repo.listMissionEvents('m1').some((e) => e.eventType === 'ledger_created')).toBe(true);
+      expect(repo.listTodoEvents('todo-1').some((e) => e.eventType === 'todo_created')).toBe(true);
+    });
+
+    it('enforces todo status safety rules', () => {
+      expect(() => repo.setTodoStatus('todo-1', 'not-real')).toThrow(/status must be/);
+      expect(() => repo.setTodoStatus('todo-1', 'passed')).toThrow(/validator verdict/);
+
+      repo.addTodoEvidence('todo-1', {
+        branch: 'task/todo-1',
+        changedFiles: ['src/platform/storage/repositories/aurex.js'],
+        notes: ['storage added'],
+      });
+      expect(repo.setTodoStatus('todo-1', 'implemented')[0].status).toBe('implemented');
+
+      repo.addTodoEvidence('todo-1', { validatorVerdict: { verdict: 'pass' }, commits: ['abc123'] });
+      expect(repo.setTodoStatus('todo-1', 'passed')[0].status).toBe('passed');
+      expect(repo.setTodoStatus('todo-1', 'merged')[0].status).toBe('merged');
+    });
   });
 
   const http = require('http');
@@ -374,6 +423,7 @@ describe('Aurex HTTP Server', () => {
     let milestoneId;
     let unitId;
     let contractId;
+    let todoId;
 
     it('creates a mission', async () => {
       const res = await req('POST', '/missions', { description: 'E2E mission', config: { modelHints: {} } });
@@ -394,6 +444,84 @@ describe('Aurex HTTP Server', () => {
       expect(res.status).toBe(200);
       const updated = await req('GET', `/missions/${missionId}`);
       expect(updated.body.status).toBe('running');
+    });
+
+    it('creates a todo ledger for a mission', async () => {
+      const res = await req('POST', '/todo-ledgers', {
+        missionId,
+        missionTitle: 'E2E mission',
+        status: 'planning',
+        sourceMission: 'E2E mission',
+        plannerSummary: 'Verify todo ledger API',
+        acceptanceCriteria: ['todo can be tracked'],
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.missionId).toBe(missionId);
+      expect(res.body.acceptanceCriteria).toContain('todo can be tracked');
+    });
+
+    it('creates and lists mission todos', async () => {
+      const res = await req('POST', `/missions/${missionId}/todos`, {
+        title: 'Implement E2E todo',
+        status: 'ready',
+        type: 'implementation',
+        priority: 'high',
+        goal: 'Exercise todo APIs',
+        scope: { in: ['src/http/handlers/todos.js'], out: ['UI'] },
+        likelyFiles: ['src/http/handlers/todos.js'],
+        lapisContextQuery: 'todo ledger HTTP handler tests',
+        acceptanceCriteria: ['HTTP endpoints work'],
+        validationCriteria: ['invalid status is rejected'],
+        testCommands: ['npx vitest run test/http-server.test.js'],
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.status).toBe('ready');
+      todoId = res.body.id;
+
+      const list = await req('GET', `/missions/${missionId}/todos`);
+      expect(list.status).toBe(200);
+      expect(list.body.some((todo) => todo.id === todoId)).toBe(true);
+    });
+
+    it('rejects unsafe todo status transitions over HTTP', async () => {
+      const res = await req('PATCH', `/todos/${todoId}/status`, { status: 'passed' });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('invalid_todo_status');
+    });
+
+    it('adds todo evidence, notes, and status updates', async () => {
+      const evidence = await req('POST', `/todos/${todoId}/evidence`, {
+        branch: 'task/e2e-todo',
+        changedFiles: ['src/http/handlers/todos.js'],
+        testsRun: [{ command: 'npx vitest run test/http-server.test.js', exitCode: 0 }],
+      });
+      expect(evidence.status).toBe(200);
+      expect(evidence.body.evidence.changedFiles).toContain('src/http/handlers/todos.js');
+
+      const note = await req('POST', `/todos/${todoId}/notes`, { note: 'Evidence captured' });
+      expect(note.status).toBe(200);
+      expect(note.body.evidence.notes).toContain('Evidence captured');
+
+      const implemented = await req('PATCH', `/todos/${todoId}/status`, { status: 'implemented' });
+      expect(implemented.status).toBe(200);
+      expect(implemented.body.status).toBe('implemented');
+    });
+
+    it('returns todo context query and focused context', async () => {
+      const query = await req('GET', `/todos/${todoId}/context-query`);
+      expect(query.status).toBe(200);
+      expect(query.body.lapisContextQuery).toBe('todo ledger HTTP handler tests');
+
+      const context = await req('GET', `/todos/${todoId}/context`);
+      expect(context.status).toBe(200);
+      expect(context.body.query).toBe('todo ledger HTTP handler tests');
+      expect(Array.isArray(context.body.context)).toBe(true);
+    });
+
+    it('records todo audit events', async () => {
+      const events = await req('GET', `/todos/${todoId}/events`);
+      expect(events.status).toBe(200);
+      expect(events.body.some((event) => event.eventType === 'todo_evidence_added')).toBe(true);
     });
 
     it('creates a milestone', async () => {
@@ -478,6 +606,23 @@ describe('Aurex HTTP Server', () => {
       });
       expect(res.status).toBe(201);
       expect(res.body.verdict).toBe('pass');
+    });
+
+    it('rejects malformed verdict payloads', async () => {
+      const res = await req('POST', '/verdicts', {
+        sessionId: 's-e2e',
+        milestoneId,
+        contractId,
+        validatorType: 'validator_scrutiny',
+        verdict: 'maybe',
+        findings: '',
+        failedUnitIds: 'unit-1',
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('invalid_verdict');
+      expect(res.body.error.message).toContain('verdict must be pass or fail');
+      expect(res.body.error.message).toContain('failedUnitIds must be an array');
     });
 
     it('gets verdicts for milestone', async () => {


### PR DESCRIPTION
## Summary
- add V19 migration and schema coverage for todo_ledgers, todo_items, and todo_events
- add Aurex repository methods and HTTP routes for mission ledgers, todos, evidence, notes, audit events, assignment, search, and focused todo context retrieval
- validate verdict payloads before writing and add todo/status safety checks for evidence, validator verdicts, and merge evidence

## Verification
- npx vitest run test/http-server.test.js
- npx oxlint src/http/handlers/todos.js src/http/server.js src/platform/storage/repositories/aurex.js test/http-server.test.js
- npm test (full suite currently has 3 unrelated failures: test/context-injection-prompt.test.js, test/services-dream.test.js, test/agent-intel/e2e-runtime.test.js)

## Notes
- Untracked docs/media already present locally were left out of this PR.