### PR TITLE
fix(memory-layer): repair wiring defects in code/doc tools and protocol

### DIFF
--- a/extensions/memory-layer/host/project-detector.ts
+++ b/extensions/memory-layer/host/project-detector.ts
@@ -1,8 +1,8 @@
-import { REPO_CACHE_TTL, type RepoInfo, state } from '../state';
+import { type DocRepoInfo, REPO_CACHE_TTL, type RepoInfo, state } from '../state';
 import { mem, memCmd } from './memory-client';
 import path from 'node:path';
 
-export { type RepoInfo };
+export { type RepoInfo, type DocRepoInfo };
 
 export async function getKnownRepos(): Promise<RepoInfo[]> {
   const now = Date.now();
@@ -18,9 +18,25 @@ export async function getKnownRepos(): Promise<RepoInfo[]> {
   return state.cachedRepos;
 }
 
+export async function getKnownDocRepos(): Promise<DocRepoInfo[]> {
+  const now = Date.now();
+  if (state.cachedDocRepos && now - state.docRepoCacheTime < REPO_CACHE_TTL) {
+    return state.cachedDocRepos;
+  }
+  const result = await memCmd('list-doc-repos');
+  if (!result || !(result as any).repos) {
+    return state.cachedDocRepos || [];
+  }
+  state.cachedDocRepos = (result as any).repos as DocRepoInfo[];
+  state.docRepoCacheTime = now;
+  return state.cachedDocRepos;
+}
+
 export function invalidateRepoCache(): void {
   state.cachedRepos = null;
   state.repoCacheTime = 0;
+  state.cachedDocRepos = null;
+  state.docRepoCacheTime = 0;
 }
 
 export function isRepoStale(repo: RepoInfo): boolean {

--- a/extensions/memory-layer/index.ts
+++ b/extensions/memory-layer/index.ts
@@ -12,7 +12,7 @@ import { isCodeFile, state, trustIcon } from './state';
 import { registerBeforeAgentStart, registerContextReminder } from './hooks/context-injection';
 import { registerSessionCompact, registerSessionShutdown, registerSessionStart } from './hooks/session-lifecycle';
 import { mem, memCmd, memStreaming } from './host/memory-client';
-import { detectProject, getKnownRepos, invalidateRepoCache, isRepoStale } from './host/project-detector';
+import { detectProject, getKnownRepos, getKnownDocRepos, invalidateRepoCache, isRepoStale } from './host/project-detector';
 import { registerPassiveCapture } from './hooks/passive-capture';
 import { registerToolGuardrails } from './hooks/tool-guardrails';
 import { registerOutputCompression } from './hooks/output-compression';
@@ -48,12 +48,14 @@ export default function memoryLayer(pi: ExtensionAPI) {
     memStreaming,
     detectProject,
     getKnownRepos,
+    getKnownDocRepos,
     invalidateRepoCache,
     isRepoStale,
     isCodeFile,
     trustIcon,
     formatCodeResult,
     formatDocResult,
+    getSettings: () => ({ contextLimit: getConfig().context_limit }),
   };
 
   safeRegister(pi, deps, 'session-lifecycle hooks', registerSessionStart);

--- a/extensions/memory-layer/state.ts
+++ b/extensions/memory-layer/state.ts
@@ -17,6 +17,14 @@ export interface RepoInfo {
   symbol_count: number;
 }
 
+export interface DocRepoInfo {
+  name: string;
+  path: string;
+  indexed_at: string;
+  file_count: number;
+  section_count: number;
+}
+
 const TIMEOUT_DEFAULTS: Record<string, number> = {
   _default: 15000,
   'dead-code': 60000,
@@ -103,6 +111,8 @@ export const state = {
   nativeChecked: false as boolean,
   cachedRepos: null as RepoInfo[] | null,
   repoCacheTime: 0 as number,
+  cachedDocRepos: null as DocRepoInfo[] | null,
+  docRepoCacheTime: 0 as number,
   sessionId: null as number | null,
   currentProject: null as string | null,
   projectSessionCount: 0 as number,

--- a/extensions/memory-layer/tools/code-tools.ts
+++ b/extensions/memory-layer/tools/code-tools.ts
@@ -80,6 +80,7 @@ export function registerCodeTools(pi: ExtensionAPI, deps: CodeDeps) {
       path: Type.Optional(Type.String({ description: 'Local repo path' })),
       name: Type.Optional(Type.String({ description: 'Repo name' })),
       rules: Type.Optional(Type.String({ description: 'Layer rules JSON' })),
+      files: Type.Optional(Type.String({ description: 'Comma-separated list of files (audit-diff)' })),
     }),
     renderResult: renderCompactToolResult,
     async execute(_id, params, _signal, onUpdate, ctx) {
@@ -206,6 +207,9 @@ export function registerCodeTools(pi: ExtensionAPI, deps: CodeDeps) {
         }
         if (params.rules) {
           args.rules = typeof params.rules === 'string' ? params.rules : JSON.stringify(params.rules);
+        }
+        if (params.files) {
+          args.files = params.files;
         }
 
         if (mode === 'index-repo' || mode === 'reindex-repo') {

--- a/extensions/memory-layer/tools/doc-tools.ts
+++ b/extensions/memory-layer/tools/doc-tools.ts
@@ -2,13 +2,13 @@ import { normalizeToolResult, stringifyToolError, toolTextResult } from './tool-
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from './schema';
 import { formatDocResult } from './format-doc-result';
-import { getKnownRepos } from '../host/project-detector';
+import { getKnownDocRepos } from '../host/project-detector';
 import { mem } from '../host/memory-client';
 import { renderCompactToolResult } from './render';
 
 interface DocDeps {
   mem: typeof mem;
-  getKnownRepos: typeof getKnownRepos;
+  getKnownDocRepos: typeof getKnownDocRepos;
   formatDocResult: typeof formatDocResult;
 }
 
@@ -152,7 +152,7 @@ export function registerDocTools(pi: ExtensionAPI, deps: DocDeps) {
           return toolTextResult(fmt || 'Doc indexing completed.', result ?? {});
         }
 
-        const docRepos = await deps.getKnownRepos();
+        const docRepos = await deps.getKnownDocRepos();
         const docRepoMatch = docRepos.find((r) => r.name.toLowerCase() === params.repo?.toLowerCase());
         if (!docRepoMatch) {
           const available = docRepos.map((r) => r.name).join(', ') || 'none';

--- a/src/cli/commands/docs.js
+++ b/src/cli/commands/docs.js
@@ -15,6 +15,7 @@ const USAGE = {
   'code-examples': '--query Q --repo X [--lang X]',
   'index-docs': '--path P --name X [--ignore GLOB]',
   'doc-coverage': '--repo X [--doc-repo X]',
+  'list-doc-repos': '',
 };
 
 function _dispatchDoc(cmd, repoName, fn, deps) {
@@ -66,6 +67,10 @@ function register(commands, deps) {
       return jsonErrNoExit('Usage: index-docs --path P --name X [--ignore GLOB]');
     }
     return docIndexer.indexDocs(getDb(), path.resolve(docPath), name, args.ignore || null);
+  };
+  commands['list-doc-repos'] = () => {
+    const rows = sqlJson('SELECT name, path, file_count, section_count, indexed_at, updated_at FROM doc_repos ORDER BY updated_at DESC');
+    return { repos: rows, total: rows.length };
   };
   commands['reindex-docs'] = async (args) =>
     _dispatchDoc(

--- a/src/memory-domain/search.js
+++ b/src/memory-domain/search.js
@@ -376,35 +376,33 @@ function related(deps, args) {
   }
 
   const result = [];
-  if (symbols.length > 0) {
-    const symbolIds = symbols.map((s) => s.symbol_id);
-    const placeholders = symbolIds.map(() => '?').join(',');
-    const clusters = sqlJson(
-      `
-      SELECT sl.symbol_id, o.id, o.title, o.type, o.project, o.created_at
-      FROM observations o
-      JOIN symbol_links sl ON sl.memory_id = CAST(o.id AS TEXT)
-      WHERE sl.symbol_id IN (${placeholders})
-        AND o.id != ?
-        AND o.deleted_at IS NULL
-      ORDER BY o.created_at DESC
-    `,
-      [...symbolIds, id],
-    );
-    const grouped = new Map();
-    for (const row of clusters) {
-      if (!grouped.has(row.symbol_id)) {
-        grouped.set(row.symbol_id, []);
-      }
-      if (grouped.get(row.symbol_id).length < RESULT_LIMITS.RELATED_PER_SYMBOL) {
-        grouped.get(row.symbol_id).push(row);
-      }
+  const symbolIds = symbols.map((s) => s.symbol_id);
+  const placeholders = symbolIds.map(() => '?').join(',');
+  const clusters = sqlJson(
+    `
+    SELECT sl.symbol_id, o.id, o.title, o.type, o.project, o.created_at
+    FROM observations o
+    JOIN symbol_links sl ON sl.memory_id = CAST(o.id AS TEXT)
+    WHERE sl.symbol_id IN (${placeholders})
+      AND o.id != ?
+      AND o.deleted_at IS NULL
+    ORDER BY o.created_at DESC
+  `,
+    [...symbolIds, id],
+  );
+  const grouped = new Map();
+  for (const row of clusters) {
+    if (!grouped.has(row.symbol_id)) {
+      grouped.set(row.symbol_id, []);
     }
-    for (const sym of symbols) {
-      const cluster = grouped.get(sym.symbol_id);
-      if (cluster && cluster.length > 0) {
-        result.push({ symbol: sym.symbol_id, repo: sym.repo, memories: cluster });
-      }
+    if (grouped.get(row.symbol_id).length < RESULT_LIMITS.RELATED_PER_SYMBOL) {
+      grouped.get(row.symbol_id).push(row);
+    }
+  }
+  for (const sym of symbols) {
+    const cluster = grouped.get(sym.symbol_id);
+    if (cluster && cluster.length > 0) {
+      result.push({ symbol: sym.symbol_id, repo: sym.repo, memories: cluster });
     }
   }
 

--- a/src/platform/protocol/envelope.js
+++ b/src/platform/protocol/envelope.js
@@ -388,6 +388,9 @@ const TOOL_NAMES = {
   provenance: 'getProvenance',
   untested: 'getUntestedSymbols',
   'pr-risk': 'getPrRiskProfile',
+  'coding-context': 'getCodingContext',
+  preflight: 'preflight',
+  'agent-pack': 'agentPack',
 };
 
 function buildAnalysisEnvelope(toolName, data, repoRow, startTime, deps) {

--- a/src/platform/protocol/llm-format.ts
+++ b/src/platform/protocol/llm-format.ts
@@ -415,6 +415,66 @@ function formatCodeResult(mode: string, result: any): string {
       }
       return `✅ Doc repo "${result.name || result.repo}" reindexed: ${result.section_count || 0} sections (${result.mode || 'full'})`;
     }
+    case 'health': {
+      const diagnostics = result.diagnostics || {};
+      const lines = [
+        `# Index Health: ${result.repo}`,
+        '',
+        `Score: ${result.health_score}`,
+        `Indexed: ${result.indexed_files} files, ${result.indexed_symbols} symbols`,
+        `Fresh: ${result.stale ? 'no' : 'yes'}`,
+      ];
+      if (result.scan) {
+        const delta = result.scan.indexed_file_delta;
+        lines.push(
+          `Discovered: ${result.scan.parseable_files_found} parseable files (${delta >= 0 ? '+' : ''}${delta} vs indexed)`,
+        );
+      }
+      lines.push(
+        `Diagnostics: ok=${diagnostics.ok || 0}, zero_symbols=${diagnostics.zero_symbols || 0}, error=${diagnostics.error || 0}`,
+      );
+      if ((result.recommendations || []).length) {
+        lines.push('', 'Recommendations:', ...(result.recommendations || []).map((r: string) => `- ${r}`));
+      }
+      return lines.join('\n');
+    }
+    case 'dupes': {
+      const groups = result.duplicate_groups || [];
+      if (!groups.length) {
+        return 'No duplicate code groups found.';
+      }
+      return `Found ${result.groups_found ?? groups.length} duplicate groups (${result.total_symbols_scanned ?? '?'} symbols scanned, ${result.scan_duration_ms ?? '?'}ms):\n\n${groups
+        .slice(0, 10)
+        .map((g: any) => {
+          const instances = (g.instances || []).map((i: any) => `  - ${i.symbol_name} in ${safePop(i.file_path)}:${i.line_start ?? '?'}`).join('\n');
+          return `**${g.intent || 'Group'}** (${g.risk || '?'}, ${g.detection_type || '?'})\n${instances}`;
+        })
+        .join('\n\n')}`;
+    }
+    case 'audit-diff': {
+      const violations = result.violations || [];
+      const lines = [
+        `**Audit diff** — risk: ${result.risk || '?'} (score ${result.risk_score ?? '?'}), files checked: ${result.files_checked ?? 0}`,
+      ];
+      if (!violations.length) {
+        lines.push('', 'No violations found.');
+        return lines.join('\n');
+      }
+      lines.push('', `Violations (${violations.length}):`);
+      for (const v of violations.slice(0, 20)) {
+        lines.push(`  [${v.severity || '?'}] ${v.type || '?'}: ${v.message || ''}`);
+      }
+      return lines.join('\n');
+    }
+    case 'enrich-symbols': {
+      const total = result.total_symbols ?? 0;
+      const enriched = result.enriched_count ?? 0;
+      const skipped = result.skipped_count ?? 0;
+      if (result.error) {
+        return `Error: ${result.error}`;
+      }
+      return `Enriched ${enriched} / ${total} symbols (${skipped} skipped).`;
+    }
     default:
       return JSON.stringify(result, null, 2).slice(0, 2000);
   }


### PR DESCRIPTION
## Summary

Fixes six functional wiring defects identified during a wiring-bug audit of the memory-layer extension and CLI gateway.

## Changes

- **H2 `audit-diff` mode is reachable** — `extensions/memory-layer/tools/code-tools.ts`: added `files` to the tool schema and propagated it to `args.files` so the `audit-diff` mode is no longer rejected by the validator.
- **H1 Doc-repo validation uses doc repos, not code repos** — added a new `list-doc-repos` CLI command and a `getKnownDocRepos()` host function with its own cache. `doc-tools.ts` now uses it for the repo-name guardrail.
- **M1 LLM formatter covers the dispatch-table gap** — added `case` blocks in `formatCodeResult` for `health`, `dupes`, `audit-diff`, and `enrich-symbols` so those modes render human-readable summaries instead of falling through to the JSON-stringify default.
- **L3 `context_limit` config is honored** — wired `getSettings: () => ({ contextLimit: getConfig().context_limit })` into the extension `deps` object so the previously declared but never-provided callback actually returns the configured value.
- **L2 `TOOL_NAMES` map complete** — added `coding-context`, `preflight`, and `agent-pack` so envelopes emit canonical function names instead of falling back to the raw mode string.
- **L1 Dead branch removed** — `src/memory-domain/search.js`: dropped the redundant `if (symbols.length > 0)` wrapper that followed the early-return guard on the empty case.

## Verification

- `npm run lint` — 529 warnings and 10 errors, all pre-existing (no-shadow in test files and `extensions/memory-layer/index.ts:42-43`).
- `npx vitest run test/format-code-result.test.js` — 21/21 pass.
- `npx vitest run test/format-doc-result.test.js` — 12/12 pass.
- `npx vitest run test/state.test.js` — pass.
- `npx vitest run test/context-limit-override.test.js` — 6/6 pass (covers L3).
- Tests that need `better-sqlite3` were not run in this environment because the native module could not be compiled (sandbox lacks `make`).