### PR TITLE
docs: sync documentation with current source

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ npm install
 - **Remembers across sessions** - decisions, bugfixes, patterns, discoveries, and constraints persist.
 - **Auto-injects context** - new sessions start with relevant memories loaded.
 - **Indexes code** - web-tree-sitter parses JS/TS/TSX/Go/Python/Rust/SQL for semantic code lookup and analysis.
-- **Indexes docs** - Markdown sections, links, glossary terms, and code examples become searchable.- **Tracks trust** - memories linked to changed code lose confidence; stable linked code recovers trust.
+- **Indexes docs** - Markdown sections, links, glossary terms, and code examples become searchable.
+- **Tracks trust** - memories linked to changed code lose confidence; stable linked code recovers trust.
 - **Deduplicates memory** - similar saves are merged or flagged before they clutter recall.
 - **Manages workspaces** - project isolation is explicit through create/list/archive workflows.
 - **Cleans stale memory** - the Dream Cycle removes superseded, never-useful, and replaced memories based on quality signals.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -161,7 +161,9 @@ See [`docs/code-indexing.md`](code-indexing.md) for the async indexing pipeline 
 
 | Command                 | Purpose                                              |
 | ----------------------- | ---------------------------------------------------- |
-| `run <command...>`      | Execute a command with output compression. Supports `--raw` (no compression), `--text` (text output), `--remember`. |
+| `run <command...>`      | Execute a command with output compression. Supports `--raw` (no compression), `--text` (text output), `--remember`, `--cwd <path>`. |
+| `token-saver-stats`     | Show cumulative token-saver savings statistics.      |
+| `token-saver-clear`     | Clear accumulated token-saver savings statistics.    |
 
 ## HTTP Server
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -80,7 +80,7 @@ LaPis supports tool access tiers to control which commands are available to the 
 
 | Tier      | Commands included                                                                                       |
 | --------- | ------------------------------------------------------------------------------------------------------- |
-| `core`    | `search`, `save`, `context`, `search-code`, `get-code-source`, `importance`, `outline`, `winnow`, `dream` |
+| `core`    | `search`, `save`, `context`, `search-code`, `get-code-source`, `preflight`, `agent-pack`, `importance`, `outline`, `winnow`, `dream` |
 | `standard`| All core commands + `complexity`, `dead-code`, `hotspots`, `blast-radius`, `call-hierarchy`, `cycles`, `coupling` |
 | `full`    | All commands unrestricted                                                                               |
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -49,7 +49,8 @@ Grouped by router under `src/cli/commands/`. Full syntax in [`docs/COMMANDS.md`]
 - **Sessions/workspaces**: `session-start`, `session-end`, `session-summary`, `auto-recover`, `recover-orphans`, `trust-recovery`, `list-projects`, `list-workspaces`, `create-workspace`, `archive-workspace`
 - **Maintenance**: `init`, `compact`, `dream`, `dashboard`
 - **Agent intel**: `preflight`, `agent-pack`, `dupes`, `enrich-symbols`, `symbol-meta`, `audit-diff`, `runtime-ingest`, `hot-symbols`, `cold-symbols`, `blast`, `stale-flags`
-- **Top-level**: `serve` (HTTP), `run` (token saver)
+- **Token saver**: `run`, `token-saver-stats`, `token-saver-clear`
+- **Top-level**: `serve` (HTTP)
 
 ### HTTP endpoints
 


### PR DESCRIPTION
## Summary

Drift cleanup: bring the top-level docs in line with the actual registered CLI surface, HTTP routes, and tool-tier sets, and use the freshly verified test count.

## Verified counts (npm test)

- Test files: **89**
- Tests passing: **1454**
- Tests skipped: **1**
- Tests total: **1455**

These match the counts already reported in `docs/INDEX.md`.

## Changes

- `README.md` — fix a markdown glitch where a missing space after "searchable." was collapsing two list items into one.
- `docs/COMMANDS.md` — add the previously undocumented `token-saver-stats` and `token-saver-clear` subcommands; document the `--cwd <path>` option on `run` (already accepted by `cli.js`).
- `docs/CONFIGURATION.md` — add `preflight` and `agent-pack` to the `core` and `standard` tier lists, matching the actual `TOOL_TIERS` sets in `cli.js` and `src/cli/gateway.js`.
- `docs/INDEX.md` — split `run` out of "Top-level" into a dedicated Token saver group that includes the two new stats subcommands; "Top-level" now lists only `serve`.

## Audit performed

- `npm test` → 89 files / 1454 passed / 1 skipped.
- `grep commands.X = / commands['x'] =` across `src/cli/commands/*.js` → full inventory of registered CLI subcommands cross-referenced against `docs/COMMANDS.md` and `docs/INDEX.md`.
- `grep pattern:` on `src/http/server.js` → full inventory of HTTP routes cross-referenced against `docs/API.md` (no missing endpoints found).
- `grep TOOL_TIERS` on `cli.js` and `src/cli/gateway.js` → tier membership cross-referenced against the table in `docs/CONFIGURATION.md`.
- `grep process.env.` across `src/`, `db.js`, `config.js`, `bench/` → no undocumented runtime env vars (the only ones are `HOME` / `USERPROFILE` for the home dir, and the benchmark-only `LAPIS_PATH` / `BENCH_PI_MEMORY_OFF_CMD` / `BENCH_PI_MEMORY_ON_CMD` already documented in `bench/README.md`).
- `for f in *.md; do … done` link check across every updated doc — all internal `.md` and image links resolve.

## Out of scope (intentionally not changed)

- No source code touched.
- Historical artifacts left alone: dated plans under `docs/superpowers/plans/`, specs under `docs/superpowers/specs/`, ADR in `docs/decisions/`, the modularization assessment in `docs/ARCHITECTURE_MODULARIZATION.md`, and the issue breakdown in `docs/GITHUB_ISSUE_BREAKDOWN.md`.
- A misleading comment in `config.js` claims `LAPIS_ASYNC_INDEX_THRESHOLD` is honored, but the env var is never read; left as-is because the rule is "Markdown only".

## Test plan

- `npm test` (re-verified after edits — counts unchanged at 89 / 1454 / 1).
- `git diff` of the four changed files is the only diff.