### PR TITLE
fix(lapis): close silent-failure gaps found in audit

### DIFF
--- a/config.js
+++ b/config.js
@@ -93,6 +93,22 @@ function expandTilde(p) {
   return p;
 }
 
+// Apply documented environment-variable overrides. Precedence:
+//   env var > config.jsonc value > DEFAULTS.
+// Add future env overrides here so they all flow through getConfig()'s cache.
+function applyEnvOverrides(config) {
+  const raw = process.env.LAPIS_ASYNC_INDEX_THRESHOLD;
+  if (raw !== undefined && raw !== '') {
+    // Accept only clean positive integers (e.g. "500"), not "3.7" or "1e3".
+    if (/^\d+$/.test(raw.trim())) {
+      const parsed = parseInt(raw, 10);
+      if (parsed > 0) {
+        config.async_index_file_threshold = parsed;
+      }
+    }
+  }
+}
+
 function loadConfig() {
   try {
     const raw = fs.readFileSync(CONFIG_PATH, 'utf-8');
@@ -101,6 +117,7 @@ function loadConfig() {
     const merged = deepMerge(DEFAULTS, userConfig);
     merged.db_path = expandTilde(merged.db_path);
     merged.tier_config_path = expandTilde(merged.tier_config_path);
+    applyEnvOverrides(merged);
     return merged;
   } catch (e) {
     if (e instanceof SyntaxError) {
@@ -108,7 +125,9 @@ function loadConfig() {
     } else if (e.code !== 'ENOENT') {
       console.error(`[config] Error reading ${CONFIG_PATH}: ${e.message}`);
     }
-    return { ...DEFAULTS };
+    const fallback = { ...DEFAULTS };
+    applyEnvOverrides(fallback);
+    return fallback;
   }
 }
 
@@ -140,6 +159,7 @@ module.exports = {
   stripJsoncComments,
   expandTilde,
   deepMerge,
+  applyEnvOverrides,
   DEFAULTS,
   CONFIG_PATH,
 };

--- a/src/compression/mission-state.js
+++ b/src/compression/mission-state.js
@@ -40,14 +40,31 @@ function compressMissionState({ sqlJson, missionId, windowSize = 50 }) {
     );
   }
 
-  // NOTE: Handoffs are intentionally omitted. LaPis's writeHandoff handler
-  // (src/http/handlers/handoffs.js) is currently a stub that returns
-  // { accepted: true } without persisting to a table. There is no
-  // `handoffs` table in the V11+ schema. When a real handoffs table is
-  // added in a future migration, re-introduce the join against
-  // working_units -> milestones -> handoffs here.
+  // 2. Recent worker handoffs (what was done vs. what remains)
+  // The handoffs table was added in the V22 migration (see db.js:runMigrationV22)
+  // and is persisted by src/platform/storage/repositories/aurex.js:createHandoff.
+  const handoffs = sqlJson(
+    `SELECT feature_name, description, remaining, status
+     FROM handoffs
+     WHERE mission_id = ?
+     ORDER BY created_at DESC
+     LIMIT ?`,
+    [missionId, windowSize],
+  );
+  if (handoffs.length > 0) {
+    sections.push(
+      `## Worker handoffs (${handoffs.length})\n` +
+        handoffs
+          .map(
+            (h) =>
+              `- [${h.status}] ${h.feature_name}: ${h.description?.slice(0, 200) ?? ''}` +
+              (h.remaining ? ` — remaining: ${String(h.remaining).slice(0, 160)}` : ''),
+          )
+          .join('\n'),
+    );
+  }
 
-  // 2. Failed validation verdicts (what went wrong)
+  // 3. Failed validation verdicts (what went wrong)
   // Schema note: validation_verdicts uses `timestamp`, not `created_at`.
   const verdicts = sqlJson(
     `SELECT vv.verdict, vv.findings, vv.failed_unit_ids
@@ -86,7 +103,7 @@ function compressMissionState({ sqlJson, missionId, windowSize = 50 }) {
 
   if (sections.length === 0) {
     return {
-      summary: 'Mission has no compressible state yet (no findings, verdicts, or cost entries).',
+      summary: 'Mission has no compressible state yet (no findings, handoffs, verdicts, or cost entries).',
       tokensSaved: 0,
     };
   }

--- a/src/http/handlers/code-index.js
+++ b/src/http/handlers/code-index.js
@@ -1,5 +1,16 @@
 const { indexRepository, reindexRepository, getCodeRepoHealth } = require('../../code-index/incremental-indexer');
+const { getDependencyCycles } = require('../../code-analysis/graph');
 const { getDb } = require('../../../db');
+
+// Compute real dependency cycles; degrade gracefully to a zero-value so a
+// graph-build failure never 500s the whole summary/graph endpoint.
+function safeDependencyCycles(db, repoId) {
+  try {
+    return getDependencyCycles(db, repoId);
+  } catch {
+    return { cycles: [], total_circular_files: 0 };
+  }
+}
 
 function indexRepo(deps) {
   return async (req, res, { body }) => {
@@ -103,6 +114,8 @@ function codeRepoSummary(deps) {
     `).all(repoRow.id);
     const entryPoints = entryRows.map(r => r.path.split('/').pop());
 
+    const cyc = safeDependencyCycles(db, repoRow.id);
+
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({
       files: repoRow.file_count,
@@ -110,7 +123,7 @@ function codeRepoSummary(deps) {
       edges: edgeRow.count,
       modules: moduleList,
       entryPoints,
-      cycles: { count: 0, paths: [] },
+      cycles: { count: cyc.cycles.length, paths: cyc.cycles.map((c) => c.files) },
     }));
   };
 }
@@ -172,7 +185,12 @@ function codeRepoGraph(deps) {
     }
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ nodes, edges, cycles: [] }));
+    const cyc = safeDependencyCycles(db, repoRow.id);
+    res.end(JSON.stringify({
+      nodes,
+      edges,
+      cycles: cyc.cycles.map((c) => ({ files: c.files, edges: c.edges })),
+    }));
   };
 }
 

--- a/src/http/handlers/health.js
+++ b/src/http/handlers/health.js
@@ -1,7 +1,19 @@
+const { getDb } = require('../../../db');
+
 function healthCheck(deps) {
   return async (req, res, ctx) => {
     const { jsonOk } = require('../errors');
-    jsonOk(res, { status: 'ok', db: true });
+    // Prefer an injected getDb (test seam), else fall back to the shared DB.
+    const getDbFn = (deps && deps.getDb) || getDb;
+    let dbReachable = false;
+    try {
+      const db = getDbFn();
+      db.prepare('SELECT 1').get();
+      dbReachable = true;
+    } catch {
+      dbReachable = false;
+    }
+    jsonOk(res, { status: dbReachable ? 'ok' : 'degraded', db: dbReachable });
   };
 }
 

--- a/src/http/server.js
+++ b/src/http/server.js
@@ -134,7 +134,7 @@ function buildRoutes(deps) {
     { method: 'POST', pattern: '/milestones/:milestoneId/retry', handler: retry.incrementRetry(aurex) },
     { method: 'POST', pattern: '/milestones/:milestoneId/rescope', handler: retry.logRescope(aurex) },
 
-    // Compression (stub)
+    // Mission-state compression
     { method: 'POST', pattern: '/missions/:missionId/compression', handler: compression.runCompression() },
 
     // Checkpoints

--- a/test/compression-mission-state.test.js
+++ b/test/compression-mission-state.test.js
@@ -6,6 +6,7 @@ function makeSqlJson(rowsByQuery) {
   return (sql, params) => {
     // Match by FROM clause to dispatch to the right canned response
     if (/FROM research_findings/.test(sql)) return rowsByQuery.findings ?? [];
+    if (/FROM handoffs/.test(sql)) return rowsByQuery.handoffs ?? [];
     if (/FROM validation_verdicts/.test(sql)) return rowsByQuery.verdicts ?? [];
     if (/FROM cost_entries/.test(sql)) return rowsByQuery.costs ?? [];
     return [];
@@ -38,6 +39,36 @@ describe('compressMissionState', () => {
       ],
     });
     const result = compressMissionState({ sqlJson, missionId: 'm-1' });
+    expect(result.summary).toBeDefined();
+    expect(result.summary.length).toBeGreaterThan(0);
+    expect(result.tokensSaved).toBeGreaterThanOrEqual(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('aggregates worker handoffs into the summary', () => {
+    const queries = [];
+    const baseSqlJson = makeSqlJson({
+      handoffs: [
+        {
+          feature_name: 'Login flow',
+          description: 'Implemented OAuth callback',
+          remaining: 'Add rate limiting',
+          status: 'accepted',
+        },
+      ],
+    });
+    const sqlJson = (sql, params) => {
+      queries.push({ sql, params });
+      return baseSqlJson(sql, params);
+    };
+    const result = compressMissionState({ sqlJson, missionId: 'm-1' });
+
+    // The handoffs table is queried for this mission, bounded by windowSize.
+    const handoffQuery = queries.find((q) => /FROM handoffs/.test(q.sql));
+    expect(handoffQuery).toBeDefined();
+    expect(handoffQuery.params).toEqual(['m-1', 50]);
+
+    // The handoff content flows into the compressor (non-empty summary produced).
     expect(result.summary).toBeDefined();
     expect(result.summary.length).toBeGreaterThan(0);
     expect(result.tokensSaved).toBeGreaterThanOrEqual(0);

--- a/test/config-async-threshold.test.js
+++ b/test/config-async-threshold.test.js
@@ -1,0 +1,46 @@
+// Tests that LAPIS_ASYNC_INDEX_THRESHOLD overrides async_index_file_threshold,
+// closing the gap where the env var was documented but never read.
+const { applyEnvOverrides, DEFAULTS, loadConfig } = require('../config');
+
+describe('LAPIS_ASYNC_INDEX_THRESHOLD env override', () => {
+  const original = process.env.LAPIS_ASYNC_INDEX_THRESHOLD;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.LAPIS_ASYNC_INDEX_THRESHOLD;
+    } else {
+      process.env.LAPIS_ASYNC_INDEX_THRESHOLD = original;
+    }
+  });
+
+  it('overrides the configured value when the env var is a positive integer', () => {
+    process.env.LAPIS_ASYNC_INDEX_THRESHOLD = '42';
+    const config = { async_index_file_threshold: DEFAULTS.async_index_file_threshold };
+    applyEnvOverrides(config);
+    expect(config.async_index_file_threshold).toBe(42);
+  });
+
+  it('leaves the configured value untouched when the env var is unset', () => {
+    delete process.env.LAPIS_ASYNC_INDEX_THRESHOLD;
+    const config = { async_index_file_threshold: 999 };
+    applyEnvOverrides(config);
+    expect(config.async_index_file_threshold).toBe(999);
+  });
+
+  it('ignores non-numeric or non-positive values (falls back to configured)', () => {
+    for (const bad of ['', 'not-a-number', '0', '-5', '3.7']) {
+      process.env.LAPIS_ASYNC_INDEX_THRESHOLD = bad;
+      const config = { async_index_file_threshold: 777 };
+      applyEnvOverrides(config);
+      expect(config.async_index_file_threshold).toBe(777);
+    }
+  });
+
+  it('flows through loadConfig() (env > jsonc > default)', () => {
+    // loadConfig falls back to DEFAULTS when no config.jsonc is present in the
+    // test environment; the env override must still apply to that fallback.
+    process.env.LAPIS_ASYNC_INDEX_THRESHOLD = '13';
+    const cfg = loadConfig();
+    expect(cfg.async_index_file_threshold).toBe(13);
+  });
+});

--- a/test/health-handler.test.js
+++ b/test/health-handler.test.js
@@ -1,0 +1,53 @@
+// Unit tests for src/http/handlers/health.js
+// The handler must actually ping the DB rather than reporting a constant.
+const { healthCheck } = require('../src/http/handlers/health');
+
+// Minimal fake response that captures the JSON body written by jsonOk.
+function fakeRes() {
+  const chunks = [];
+  return {
+    writeHead() {},
+    end(chunk) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    },
+    get body() {
+      return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+    },
+  };
+}
+
+function invoke(deps) {
+  const res = fakeRes();
+  const handler = healthCheck(deps);
+  return handler({}, res, {}).then(() => res.body);
+}
+
+describe('healthCheck', () => {
+  it('reports ok + db:true when SELECT 1 succeeds', async () => {
+    const db = {
+      prepare() {
+        return { get: () => ({ '?': 1, 1: 1 }) };
+      },
+    };
+    const body = await invoke({ getDb: () => db });
+    expect(body.status).toBe('ok');
+    expect(body.db).toBe(true);
+  });
+
+  it('reports degraded + db:false when getDb throws', async () => {
+    const body = await invoke({ getDb: () => { throw new Error('locked'); } });
+    expect(body.status).toBe('degraded');
+    expect(body.db).toBe(false);
+  });
+
+  it('reports degraded + db:false when the query throws', async () => {
+    const db = {
+      prepare() {
+        throw new Error('database disk image is malformed');
+      },
+    };
+    const body = await invoke({ getDb: () => db });
+    expect(body.status).toBe('degraded');
+    expect(body.db).toBe(false);
+  });
+});


### PR DESCRIPTION
Five audit findings where the code silently returned wrong/empty results with no error surfaced. Each fix includes or updates a test.

1. mission-state compression omitted handoffs (stale NOTE claimed the writeHandoff handler was a stub — it has persisted for real since da81dfc / V22 migration). Replaced the stale comment with a real '## Worker handoffs' aggregation section.

2. HTTP /code/summary and /code/graph hardcoded cycles: 0 / []. They now call the existing getDependencyCycles (already wired into the CLI), degrading gracefully on graph-build failure.

3. healthCheck ignored its DB dependency and always returned db: true. It now runs SELECT 1 and reports status: 'degraded' / db: false when the DB is unreachable. getDb is imported directly (matching the other handlers) with an optional deps.getDb override for tests.

4. LAPIS_ASYNC_INDEX_THRESHOLD was documented in config.js but never read. Added applyEnvOverrides() so the env var actually overrides async_index_file_threshold (env > jsonc > default).

5. Stale '// Compression (stub)' route comment in server.js — the handler has been a real implementation since ffb567a.

Tests: +8 passing on this branch vs main (new health/config tests and updated compression-mission-state test). No regressions; the remaining pre-existing failures are order-dependent/env-specific and fail identically on main.

## Description

<!-- What does this PR do? Link to relevant issues. -->

Fixes #

## Extraction Checklist

<!-- For PRs touching extraction/modularization code (labeled `architecture` or `refactor`).
     These checks MUST pass before merge. -->

- [ ] Full test suite passes locally: `npm test`
- [ ] Smoke CLI tests pass: `node test/smoke-cli.js`
- [ ] Lint passes: `npm run lint`
- [ ] No regressions in existing test behavior
- [ ] `docs/MODULE_MAP.md` updated if modules were added, removed, renamed, or dependency boundaries changed
- [ ] If a test behavior change was legitimate, it is documented below

### Legitimate Test Behavior Changes

<!-- If any existing test changed its expected behavior, document why here.
     Example: "Updated test XYZ because the command now returns a typed result
     instead of a raw CLI envelope." -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI/CD

## How Has This Been Tested?

<!-- Describe how you verified the changes. -->
