### PR TITLE
Deep audit: stubs / dead code / wiring / half-finished features

### DIFF
--- a/docs/AUDIT-2026-06-16.md
+++ b/docs/AUDIT-2026-06-16.md
@@ -13,7 +13,7 @@ The codebase is **remarkably clean**. No stubs, `throw new Error('not implemente
 or unwired runtime handlers were found. (The repo ships its own anti-pattern detector,
 `ast-patterns.js`, covering `empty_function`, `empty_catch`, `todo_fixme`, `hardcoded_secret`, etc.,
 which largely explains the clean state.) Findings are limited to a small amount of **dead/redundant
-code** and one minor **help-text wiring gap**. No issue would cause a silent runtime failure or a
+code** and one minor **usage-string wiring gap**. No issue would cause a silent runtime failure or a
 missing feature in the running application.
 
 **Status legend:** ✅ fixed in this PR · 🟡 recommended follow-up
@@ -119,16 +119,22 @@ default.
 
 Two minor, non-runtime items:
 
-### 3.1 `outline` command missing from `USAGE` help text ✅ fixed in this PR
+### 3.1 `outline` command missing from the `USAGE` object ✅ fixed in this PR
 - **File:** `src/cli/commands/code-analysis.js`
-- **Category:** incomplete wiring (help/docs)
+- **Category:** incomplete wiring (usage/error message)
 - **What it should do:** `outline` is a first-class code-analysis command (registered at
-  `code-analysis.js:132`, listed in `ANALYSIS_TOOLS` at `:33`, and heavily used by the extension's
+  `code-analysis.js:133`, listed in `ANALYSIS_TOOLS` at `:34`, and heavily used by the extension's
   `memory-code outline` mode).
-- **Why broken:** It is **omitted from the `USAGE` object** (`code-analysis.js:4-25`), so it never
-  appears in `lapis` help output, and its missing-args message hardcodes its own usage string
-  (`:134`) instead of reading from `USAGE`. Every other command keeps `USAGE` ↔ handler ↔
-  `ANALYSIS_TOOLS` in sync.
+- **Why broken:** It was the only `ANALYSIS_TOOLS` entry **omitted from the `USAGE` object**
+  (`code-analysis.js:4-26`). `USAGE` is read by `_dispatch` (`code-analysis.js:54`) to build the
+  per-command `Missing --repo. Usage: <cmd> …` error string; with `USAGE['outline']` undefined that
+  message rendered an empty usage tail (`Usage: outline `) while every sibling rendered its
+  arguments. _(Note: `outline` was **not** missing from `lapis` help — the top-level help list at
+  `cli.js:196` is built from `Object.keys(commands)`, which already included `outline`; the `USAGE`
+  object is not used for help rendering, only for `_dispatch` error messages.)_ The missing-arg
+  checks that hardcode their own usage strings (`outline:135`, `call-hierarchy:85`,
+  `blast-radius:101`, `coding-context:302`) are the prevailing pattern across routers, so the real
+  invariant this fix closes is `USAGE` ↔ `ANALYSIS_TOOLS` coverage, which is now 1:1.
 - **Fix:** Added `outline: '--file F --repo X'` to the `USAGE` object in this PR.
 
 ### 3.2 `run` (token-saver) not reachable via in-process `dispatch()` 🟡
@@ -177,7 +183,7 @@ non-existent modules, no feature flag hardcoded off with no toggle path.
 | # | Severity | Category | Location | Status |
 |---|----------|----------|----------|--------|
 | 2.1 | Med | dead module | `services/trust.js` | ✅ fixed |
-| 3.1 | Low | unwired help text | `src/cli/commands/code-analysis.js` (`outline`) | ✅ fixed |
+| 3.1 | Low | unwired usage string | `src/cli/commands/code-analysis.js` (`outline`) | ✅ fixed |
 | 2.2 | Low | dead export | `src/cli/gateway.js:32` `getAllUsage` | 🟡 recommended |
 | 2.3 | Low | orphaned files | `src/platform/protocol/envelope.ts`, `compact-format.ts` | 🟡 recommended |
 | 2.4 | Low | dead public surface | various barrels/re-exports | 🟡 review |

--- a/docs/AUDIT-2026-06-16.md
+++ b/docs/AUDIT-2026-06-16.md
@@ -1,0 +1,190 @@
+# LaPis Dead-Code & Wiring Audit — 2026-06-16
+
+A systematic audit of the codebase looking for **stubs/placeholders**, **dead/unreachable code**,
+**incomplete wiring**, and **half-finished features**.
+
+Scope: all `src/`, `services/`, `data-access/`, `commands/`, `extensions/`, `scripts/`, `bench/`,
+root `*.js` source (~205 JS/TS files). `node_modules`, `test/`, and the separate `crosshash/` Rust
+workspace were excluded from JS dead-code analysis (see informational note at the end).
+
+## TL;DR
+
+The codebase is **remarkably clean**. No stubs, `throw new Error('not implemented')`, broken imports,
+or unwired runtime handlers were found. (The repo ships its own anti-pattern detector,
+`ast-patterns.js`, covering `empty_function`, `empty_catch`, `todo_fixme`, `hardcoded_secret`, etc.,
+which largely explains the clean state.) Findings are limited to a small amount of **dead/redundant
+code** and one minor **help-text wiring gap**. No issue would cause a silent runtime failure or a
+missing feature in the running application.
+
+**Status legend:** ✅ fixed in this PR · 🟡 recommended follow-up
+
+---
+
+## 1. STUB / PLACEHOLDER IMPLEMENTATIONS
+
+**None found.**
+
+Exhaustive search for `TODO/FIXME/HACK/XXX/WIP`, `"not implemented"`/`"placeholder"`/`"stub"`/
+`"coming soon"`, empty function bodies, and `return null/[]/{}`-only bodies turned up **zero** genuine
+stubs. All matches were legitimate:
+
+- `TODO_STATUSES` / `createTodo` etc. in `src/platform/storage/repositories/aurex.js` and
+  `src/http/handlers/todos.js` are the **todo-ledger domain entity**, not code markers.
+- `throw new Error('todo cannot be marked implemented without evidence')` (`aurex.js:775,778,783`)
+  are domain state-machine invariants, not "feature not implemented".
+- The handful of empty/no-op bodies are intentional:
+  - `extensions/memory-layer/tools/render.ts:54` — `invalidate() {}` is an intentional no-op for the
+    text renderer (satisfies a `{ render, invalidate }` interface; text needs no cache invalidation).
+  - `src/memory-domain/context.js:73` — `deps.insertRecallLog || (() => {})` is a default injected dep.
+  - `catch (_) {}` blocks in `src/code-index/index-worker.js` / `worker-pool.js` swallow expected
+    worker-cleanup errors (a pattern the repo's own `empty_catch` detector tolerates).
+
+The one `@deprecated` symbol — `parseChangedSymbolsJson` (`src/trust-sync/change-detector.js:148`)
+— is **fully implemented** (~50 lines); it is retained "for test compatibility", not a stub.
+
+---
+
+## 2. DEAD / UNREACHABLE CODE
+
+### 2.1 `services/trust.js` — dead module ✅ fixed in this PR
+- **Category:** dead module
+- **What it should do:** a service façade re-exporting trust-sync helpers
+  (`{ syncCodeTrust, trustPolicy, changeDetector }`).
+- **Why broken/disconnected:** It has **zero importers**. The only test that names it
+  (`test/services-trust.test.js:4`) does so inside a `describe(...)` **string literal** and actually
+  imports `syncCodeTrust` directly from `../src/trust-sync/symbol-links`. All other trust consumers
+  bypass this file entirely (`src/cli/commands/trust.js` → `commands/symbols` → `src/trust-sync`).
+  Its three dependencies are all live through other paths. It is also **not** a key in
+  `package.json` `exports` (only matched by the `"services/"` files glob), so it is unreachable
+  externally too.
+- **Fix:** Deleted in this PR.
+
+### 2.2 `getAllUsage()` in `src/cli/gateway.js:32-43` — dead export 🟡
+- **Category:** dead export
+- **What it should do:** aggregate every router's `USAGE` (help text) into one object.
+- **Why broken/disconnected:** Exported at `gateway.js:47` but **never imported anywhere** (the only
+  two matches in the repo are its own definition and its export line). The runtime help text in
+  `cli.js` is built from `Object.keys(commands)` instead.
+- **Fix (recommended):** Remove `getAllUsage` (and its `module.exports` entry), or wire it into
+  `cli.js`'s usage/error message so the per-command `USAGE` strings are actually surfaced to users.
+
+### 2.3 Orphaned TypeScript re-export shims — `src/platform/protocol/envelope.ts`, `compact-format.ts` 🟡
+- **Category:** dead/orphaned files
+- **What they should do:** provide TypeScript-friendly named re-exports of the corresponding `.js`
+  modules (`envelope.js`, `compact-format.js`).
+- **Why broken/disconnected:** Both files are pure `require('./x.js')` re-export shims
+  (`envelope.ts` = 11 lines, `compact-format.ts` = 14 lines) with **no importer** anywhere. The `.js`
+  counterparts are the live API: `envelope.js` ← `llm-format.js` + tests; `compact-format.js` ←
+  `llm-format.js`, `bench/bench-tokens.js`, tests. `package.json` `exports` maps
+  `./platform/protocol/envelope` and `.../compact-format` to the **`.js`** files, so even external
+  consumers resolve to the `.js`, never these `.ts` shims. (`tsconfig.json` is `noEmit` type-check
+  only — there is no compile step that would make the `.ts` the entry point.)
+- **Note:** the sibling `llm-format.ts` **is** consumed (by
+  `extensions/memory-layer/tools/format-*.ts`), so only `envelope.ts` / `compact-format.ts` are orphans.
+- **Fix (recommended):** Delete both `.ts` shims, or document them as intentional (they currently add
+  maintenance cost — every new export on the `.js` must be mirrored here by hand).
+
+### 2.4 Redundant public exports / barrels with no internal consumer 🟡
+These are reachable via `package.json` `exports` and may be intentional public surface, so they are
+flagged for review rather than removed. Internally they are dead:
+
+- **`src/code-index/index.js`** — barrel re-export of 8 code-index submodules; **no internal importer**
+  (every consumer imports a submodule directly). Public via `"./code-index"` export.
+- **`src/memory-domain/index.js`** — barrel; only used by `test/memory-domain.test.js` (test-only).
+- **`SCOPE_BUILDER_MAP`** (`src/code-index/scope-builder/index.js`) — exported but used only
+  internally by `getScopeBuilder`; no external importer.
+- **6 factory re-exports** in `src/platform/storage/repositories/index.js`
+  (`createMemoryRepository`, `createCodeIndexRepository`, `createDocIndexRepository`,
+  `createTrustSyncRepository`, `createAnalyticsRepository`, `createAurexRepository`) — every consumer
+  imports the factory from its direct file; the factories themselves are live (invoked inside
+  `createRepositories`).
+- **`createStorageContext`** (`src/platform/storage/index.js`) — used only by
+  `test/storage-repositories.test.js`.
+- **`validateVerdictPayload`** (`src/http/handlers/verdicts.js:62`) — exported but used only
+  *internally* by `writeVerdict`; no external consumer and no route.
+
+**Fix (recommended):** If LaPis is self-contained (no external `@genegulanesjr/lapis/*` consumers — a
+repo-wide search for `@genegulanesjr/lapis/` returns zero), these can be trimmed. If the `exports`
+map is meant as a stable external contract, document them as intentional.
+
+---
+
+## 3. INCOMPLETE WIRING
+
+**No runtime-critical wiring gaps.** All 18 HTTP handler files are required by `src/http/server.js`
+`buildRoutes`, every exported handler maps to a route, every `register()`'d CLI command has logic,
+and all `services/`, root `commands/`, and `data-access/` modules are consumed by production code.
+The only env-var override (`LAPIS_ASYNC_INDEX_THRESHOLD`) is documented in `config.js` and has a
+default.
+
+Two minor, non-runtime items:
+
+### 3.1 `outline` command missing from `USAGE` help text ✅ fixed in this PR
+- **File:** `src/cli/commands/code-analysis.js`
+- **Category:** incomplete wiring (help/docs)
+- **What it should do:** `outline` is a first-class code-analysis command (registered at
+  `code-analysis.js:132`, listed in `ANALYSIS_TOOLS` at `:33`, and heavily used by the extension's
+  `memory-code outline` mode).
+- **Why broken:** It is **omitted from the `USAGE` object** (`code-analysis.js:4-25`), so it never
+  appears in `lapis` help output, and its missing-args message hardcodes its own usage string
+  (`:134`) instead of reading from `USAGE`. Every other command keeps `USAGE` ↔ handler ↔
+  `ANALYSIS_TOOLS` in sync.
+- **Fix:** Added `outline: '--file F --repo X'` to the `USAGE` object in this PR.
+
+### 3.2 `run` (token-saver) not reachable via in-process `dispatch()` 🟡
+- **File:** `cli.js:103-159` vs `src/cli/gateway.js:140-145`
+- **Category:** incomplete wiring (by design)
+- **What it should do:** `lapis run [--raw] [--text] [--remember] <command...>` executes + compresses
+  CLI output.
+- **Why notable:** It is special-cased in `cli.js` (the child-process entry point) and works there,
+  but it is **not** in the `buildCommandMap`, so the extension's in-process `gateway.dispatch('run')`
+  returns `Unknown command: run`. This appears **intentional** (`run` shells out to an arbitrary
+  command and is meant for the child-process path), but worth documenting so it isn't mistaken for a
+  bug.
+- **Fix (recommended):** Add a code comment in `gateway.dispatch` noting `run`/`serve` are handled in
+  `cli.js` and intentionally absent from the command map.
+
+> The optional HTTP server (`lapis serve`) and its ~50 "aurex" routes (missions, milestones, todos,
+> handoffs, contracts, verdicts, broadcasts, findings, sessions, costs, checkpoints, retry,
+> compression) were **verified as intentionally reachable** — it is a documented optional feature
+> (README §"Exposes an HTTP API"; spec `docs/superpowers/specs/2026-05-26-optional-lapis-http-server-design.md`)
+> for an external "Aurex" consumer, explicitly designed not to start automatically with the
+> extension. It is **not** dead code.
+
+---
+
+## 4. HALF-FINISHED FEATURES
+
+**None found in the JS/TS runtime.** No WIP/"coming soon"/"disabled" blocks, no imports of
+non-existent modules, no feature flag hardcoded off with no toggle path.
+
+### 4.1 `crosshash/` — parallel experimental engine (informational) 🟡
+- **Category:** half-finished / experimental (by design)
+- **What it is:** a separate Rust workspace (`Cargo.toml`, 9 crates) reimplementing the
+  indexing/graph/impact engine in native code.
+- **Why notable:** It is **not wired into the running LaPis JS application** at all. The only
+  references are `scripts/crosshash-benchmark.sh` / `crosshash-parity-check.sh` and the migration
+  docs under `docs/superpowers/.../crosshash-*.md`. It is a planned, opt-in migration target, not a
+  live feature.
+- **Fix:** No action required — flagged only so readers don't expect `crosshash/` to affect runtime
+  behavior. If the migration is no longer planned, the workspace + parity scripts could be removed to
+  reduce repo weight.
+
+---
+
+## Summary table
+
+| # | Severity | Category | Location | Status |
+|---|----------|----------|----------|--------|
+| 2.1 | Med | dead module | `services/trust.js` | ✅ fixed |
+| 3.1 | Low | unwired help text | `src/cli/commands/code-analysis.js` (`outline`) | ✅ fixed |
+| 2.2 | Low | dead export | `src/cli/gateway.js:32` `getAllUsage` | 🟡 recommended |
+| 2.3 | Low | orphaned files | `src/platform/protocol/envelope.ts`, `compact-format.ts` | 🟡 recommended |
+| 2.4 | Low | dead public surface | various barrels/re-exports | 🟡 review |
+| 3.2 | Info | unwired (by design) | `run` not in in-process dispatch | 🟡 document |
+| 4.1 | Info | experimental | `crosshash/` Rust workspace | 🟡 optional |
+
+**Method:** structure mapping + targeted ripgrep-style searches for stub markers, exhaustive
+importer verification (grep of every candidate's require-path and symbol across the repo), and
+route/command/handler cross-referencing against `src/http/server.js`, `src/cli/gateway.js`, and
+`src/cli/commands/*.js`.

--- a/docs/AUDIT-2026-06-16.md
+++ b/docs/AUDIT-2026-06-16.md
@@ -55,8 +55,11 @@ The one `@deprecated` symbol — `parseChangedSymbolsJson` (`src/trust-sync/chan
   imports `syncCodeTrust` directly from `../src/trust-sync/symbol-links`. All other trust consumers
   bypass this file entirely (`src/cli/commands/trust.js` → `commands/symbols` → `src/trust-sync`).
   Its three dependencies are all live through other paths. It is also **not** a key in
-  `package.json` `exports` (only matched by the `"services/"` files glob), so it is unreachable
-  externally too.
+  `package.json` `exports` (that map has no `services/*` entry or glob — only explicit paths like
+  `./code-analysis`, `./trust-sync`), so it is not resolvable externally. (Note: `"services/"` *is*
+  in the npm `files` include-list, but `files` controls what is **bundled** into the tarball, not
+  what subpaths are **resolvable**; without an `exports` entry, `require('@genegulanesjr/lapis/services/trust')`
+  still fails.) Either way it is unreachable externally.
 - **Fix:** Deleted in this PR.
 
 ### 2.2 `getAllUsage()` in `src/cli/gateway.js:32-43` — dead export 🟡

--- a/services/trust.js
+++ b/services/trust.js
@@ -1,5 +1,0 @@
-const { syncCodeTrust } = require('../src/trust-sync/symbol-links');
-const trustPolicy = require('../src/trust-sync/trust-policy');
-const changeDetector = require('../src/trust-sync/change-detector');
-
-module.exports = { syncCodeTrust, trustPolicy, changeDetector };

--- a/src/cli/commands/code-analysis.js
+++ b/src/cli/commands/code-analysis.js
@@ -6,6 +6,7 @@ const USAGE = {
   'call-hierarchy': '--symbol S --repo X [--direction callers|callees] [--depth N]',
   'blast-radius': '--symbol S --repo X [--depth N]',
   'dead-code': '--repo X [--min-confidence 0.5] [--include-tests true]',
+  outline: '--file F --repo X',
   complexity: '--repo X [--symbol S | --file F]',
   churn: '--repo X [--file F] [--days 90] [--refresh]',
   hotspots: '--repo X [--top N] [--days N]',


### PR DESCRIPTION
## Summary

Systematic audit of the codebase for **stubs/placeholders**, **dead/unreachable code**, **incomplete wiring**, and **half-finished features**. Full structured report in [`docs/AUDIT-2026-06-16.md`](docs/AUDIT-2026-06-16.md).

### Headline
The codebase is **remarkably clean** — no stubs, `throw new Error('not implemented')`, broken imports, or unwired runtime handlers. (The repo ships its own anti-pattern detector, `ast-patterns.js`, which largely explains this.) Findings are limited to low-severity dead/redundant code and one usage-string gap. **No issue would cause a silent runtime failure or a missing feature.**

### Changes in this PR
- **`docs/AUDIT-2026-06-16.md`** — full structured audit report grouped by category, each with file:line, why it's broken, and a recommended fix.
- **Delete `services/trust.js`** — dead re-export facade (`{ syncCodeTrust, trustPolicy, changeDetector }`) with **zero importers**. Its only test (`test/services-trust.test.js`) imports `syncCodeTrust` directly from `src/trust-sync/symbol-links`; the describe string only *names* the file. It is not in `package.json` `exports`, so unreachable externally too. (`services-trust.test.js` still passes 4/4 after deletion.)
- **`src/cli/commands/code-analysis.js`** — add `outline: '--file F --repo X'` to the `USAGE` object. `outline` already had a handler (`:133`) and an `ANALYSIS_TOOLS` entry (`:34`) but was the only entry missing from `USAGE`. Note this is **not** a `lapis` help gap: top-level help (`cli.js:196`) is built from `Object.keys(commands)`, which already listed `outline`. The `USAGE` object is only read by `_dispatch` (`code-analysis.js:54`) to build the per-command `Missing --repo` error string, which previously rendered an empty usage tail. With this fix `USAGE` ↔ `ANALYSIS_TOOLS` is now 1:1.

### Recommended follow-ups (documented, not applied)
These touch the public package surface / are slightly more contentious, so they're left for maintainer review:
- Drop unused `getAllUsage` export (`src/cli/gateway.js:32`).
- Delete orphaned TS re-export shims `src/platform/protocol/envelope.ts` & `compact-format.ts` (no importer; `.js` counterparts are the live API and the package `exports` point to the `.js`).
- Review redundant barrel/re-exports with no internal consumer (§2.4).
- Document that `run`/`serve` are intentionally handled in `cli.js`, not `gateway.dispatch()`.

### Verification
- `node --check` on the edited file; `USAGE.outline` confirmed populated.
- `services/trust.js` removal confirmed (`MODULE_NOT_FOUND`); `test/services-trust.test.js` → **4 passed**.
- ⚠️ `oxlint` (`npm run lint`) could not be run — `oxlint` is not installed in this sandbox. Please run `npm run lint` + `npm test` locally.
