### PR TITLE
feat(mcp): add MCP server as second transport alongside Pi extension

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -100,6 +100,13 @@ const cmd = process.argv[2];
     return;
   }
 
+  if (cmd === 'mcp') {
+    // MCP transport adapter. startMcpServer owns ensureDb() internally.
+    const { startMcpServer } = require('./src/mcp/server');
+    await startMcpServer();
+    return;
+  }
+
   if (cmd === 'run') {
     ensureDb();
     const { executeAndCompress, formatTextOutput } = require('./src/cli/commands/token-saver');
@@ -125,7 +132,9 @@ const cmd = process.argv[2];
     }
 
     if (runArgs.length === 0) {
-      process.stderr.write(`${JSON.stringify({ error: 'Usage: lapis run [--raw] [--text] [--remember] <command...>' })}\n`);
+      process.stderr.write(
+        `${JSON.stringify({ error: 'Usage: lapis run [--raw] [--text] [--remember] <command...>' })}\n`,
+      );
       process.exit(1);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",
         "ignore": "^7.0.5",
         "web-tree-sitter": "^0.26.9"
@@ -1582,6 +1583,18 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
@@ -2189,6 +2202,46 @@
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4349,6 +4402,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -4363,7 +4429,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4374,6 +4439,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/angular-html-parser": {
@@ -4561,6 +4643,58 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -4656,11 +4790,19 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4674,7 +4816,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4858,6 +4999,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4865,11 +5028,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4894,7 +5091,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4947,6 +5143,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -4988,7 +5193,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5009,6 +5213,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.368",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
@@ -5023,6 +5233,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5036,7 +5255,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5046,7 +5264,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5063,7 +5280,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5081,6 +5297,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
@@ -5146,6 +5368,36 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -5224,6 +5476,67 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5256,7 +5569,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
@@ -5280,7 +5592,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5434,6 +5745,27 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -5445,6 +5777,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -5472,7 +5822,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5545,7 +5894,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5570,7 +5918,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5677,7 +6024,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5707,7 +6053,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5720,7 +6065,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5737,6 +6081,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -5758,6 +6111,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -5801,7 +6174,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5859,10 +6231,18 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -5887,6 +6267,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
@@ -5918,7 +6304,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5968,6 +6353,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-md4": {
@@ -6032,8 +6426,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6423,17 +6822,36 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6443,7 +6861,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -6520,7 +6937,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mutation-server-protocol": {
@@ -6613,6 +7029,15 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/netmask": {
       "version": "2.1.1",
@@ -6742,7 +7167,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6752,7 +7176,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6771,6 +7194,18 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6973,6 +7408,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/partial-json": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
@@ -7000,7 +7444,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7021,6 +7464,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -7055,6 +7508,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -7186,6 +7648,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -7237,7 +7712,6 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -7247,6 +7721,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -7292,7 +7790,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7342,6 +7839,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -7376,7 +7889,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -7391,11 +7903,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7408,7 +7970,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7418,7 +7979,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7438,7 +7998,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7455,7 +8014,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7474,7 +8032,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7617,6 +8174,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -7858,6 +8424,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
@@ -8029,6 +8604,37 @@
         "node": "*"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typebox": {
       "version": "1.1.37",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.37.tgz",
@@ -8127,6 +8733,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -8176,6 +8791,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -8373,7 +8997,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8561,7 +9184,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -8571,7 +9193,6 @@
       "version": "3.25.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "bin": {
         "lapis": "memory-store.js",
+        "lapis-mcp": "memory-store.js",
         "memory-store": "memory-store.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "bin": {
     "lapis": "./memory-store.js",
-    "memory-store": "./memory-store.js"
+    "memory-store": "./memory-store.js",
+    "lapis-mcp": "./memory-store.js"
   },
   "directories": {
     "doc": "docs"
@@ -78,6 +79,7 @@
     "check": "oxlint && oxfmt --check"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.10.0",
     "ignore": "^7.0.5",
     "web-tree-sitter": "^0.26.9"

--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "pi": {
     "extensions": [
       "./extensions"

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -20,9 +20,17 @@ const SERVER_VERSION = require('../../package.json').version || '0.0.0';
 
 /**
  * Derive a project name from the current working directory.
- * Matches the Pi extension's project-detection intent (state.currentProject):
- * the directory basename, lowercased. MCP clients run with a cwd, so this
- * scopes memories the same way Pi does per-session.
+ *
+ * Uses a simpler heuristic than the Pi extension's `detectProject()` in
+ * `extensions/memory-layer/host/project-detector.ts` (which walks up the tree
+ * matching known `code_repos.path` and `knownProjects`). MCP clients typically
+ * run with a stable cwd at session start, so the basename is a reasonable
+ * default and avoids an async DB round-trip before the first tool call.
+ *
+ * NOTE: This is NOT identical to `state.currentProject` in the Pi extension.
+ * If you run LaPis MCP from inside a git worktree or subdirectory whose name
+ * differs from the registered repo, MCP and Pi will scope memories under
+ * different project keys. Sharing the full detector is a future refactor.
  */
 function projectFromCwd(cwd = process.cwd()) {
   const base = path.basename(path.resolve(cwd));
@@ -109,7 +117,17 @@ function createServer(opts = {}) {
  */
 async function startMcpServer(opts = {}) {
   const db = require('../../db');
-  db.ensureDb();
+  try {
+    db.ensureDb();
+  } catch (err) {
+    // Stdio is the only output channel MCP clients reliably read; without this
+    // Guard a crash here would leave the host staring at a silent close. Emit a
+    // Clear stderr line + non-zero exit so the host surfaces the failure.
+    process.stderr.write(
+      `lapis mcp: database initialization failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
 
   const server = createServer(opts);
   const transport = new StdioServerTransport();

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -49,8 +49,8 @@ function createServer(opts = {}) {
         tools: {},
       },
       instructions:
-        'LaPis persistent memory. Use memory_save for decisions/bugfixes/discoveries, ' +
-        'memory_search to recall them, memory_code/memory_doc to query indexed code & docs. ' +
+        'LaPis persistent memory. Use memory-save for decisions/bugfixes/discoveries, ' +
+        'memory-search to recall them, memory-code/memory-doc to query indexed code & docs. ' +
         'Memories are scoped to the current project (cwd-derived).',
     },
   );

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -1,0 +1,120 @@
+// Module boundary:
+// MCP transport adapter for LaPis. Exposes the transport-agnostic
+// Gateway.dispatch() core over the Model Context Protocol (stdio).
+// Mirrors how the Pi extension's memory-client.ts consumes dispatch —
+// No business logic here, only framing and tool routing.
+//
+// This is the SECOND transport alongside the Pi extension. The Pi extension
+// Remains primary (it owns hooks, TUI rendering, session lifecycle). MCP
+// Gets the tool surface only, which is the natural protocol boundary.
+
+const path = require('node:path');
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const { ListToolsRequestSchema, CallToolRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
+const { tools } = require('./tools');
+const { toCallToolResult } = require('./translate-result');
+
+const SERVER_NAME = 'lapis';
+const SERVER_VERSION = require('../../package.json').version || '0.0.0';
+
+/**
+ * Derive a project name from the current working directory.
+ * Matches the Pi extension's project-detection intent (state.currentProject):
+ * the directory basename, lowercased. MCP clients run with a cwd, so this
+ * scopes memories the same way Pi does per-session.
+ */
+function projectFromCwd(cwd = process.cwd()) {
+  const base = path.basename(path.resolve(cwd));
+  return base ? base.toLowerCase() : 'unknown';
+}
+
+/**
+ * Build an MCP Server wired to the LaPis tool catalog.
+ * Accepts an injected `dispatch` (defaults to the real gateway) so tests
+ * can pass the SDK's InMemoryTransport without touching the real DB.
+ *
+ * @param {{ dispatch?: Function, project?: string }} [opts]
+ * @returns {Server}
+ */
+function createServer(opts = {}) {
+  const dispatch = opts.dispatch || require('../cli/gateway').dispatch;
+  const project = opts.project || projectFromCwd();
+  const ctx = { project };
+
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    {
+      capabilities: {
+        tools: {},
+      },
+      instructions:
+        'LaPis persistent memory. Use memory_save for decisions/bugfixes/discoveries, ' +
+        'memory_search to recall them, memory_code/memory_doc to query indexed code & docs. ' +
+        'Memories are scoped to the current project (cwd-derived).',
+    },
+  );
+
+  // --- tools/list ---
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    })),
+  }));
+
+  // --- tools/call ---
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: params } = request.params;
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) {
+      return {
+        content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+        isError: true,
+      };
+    }
+
+    const { cmd, args, error } = tool.toCommand(params || {}, ctx);
+    if (error || !cmd) {
+      return {
+        content: [{ type: 'text', text: error || 'No command produced.' }],
+        isError: true,
+      };
+    }
+
+    let result;
+    try {
+      result = await dispatch(cmd, args);
+    } catch (err) {
+      return {
+        content: [
+          { type: 'text', text: `Dispatch error for ${cmd}: ${err instanceof Error ? err.message : String(err)}` },
+        ],
+        isError: true,
+      };
+    }
+
+    return toCallToolResult(result);
+  });
+
+  return server;
+}
+
+/**
+ * Start the MCP server on stdio. Entry point for `lapis mcp`.
+ * Owns ensureDb() — same pattern as src/http/server.js:192.
+ *
+ * @param {{ project?: string }} [opts]
+ */
+async function startMcpServer(opts = {}) {
+  const db = require('../../db');
+  db.ensureDb();
+
+  const server = createServer(opts);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  return server;
+}
+
+module.exports = { createServer, startMcpServer, projectFromCwd };

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -130,9 +130,9 @@ module.exports.DOC_MODE_TO_COMMAND = DOC_MODE_TO_COMMAND;
 // State.currentProject.
 
 const tools = [
-  // ============ memory_save ============
+  // ============ memory-save ============
   {
-    name: 'memory_save',
+    name: 'memory-save',
     description:
       'Save persistent memory; checks duplicates. Use What/Why/Where/Learned content. ' +
       'Types: decision, bugfix, architecture, pattern, discovery, config, preference, learning, manual.',
@@ -186,9 +186,9 @@ const tools = [
     },
   },
 
-  // ============ memory_search ============
+  // ============ memory-search ============
   {
-    name: 'memory_search',
+    name: 'memory-search',
     description: 'Search persistent memory for decisions, bugfixes, patterns, and discoveries.',
     inputSchema: obj({
       query: { schema: str('Search query') },
@@ -205,9 +205,9 @@ const tools = [
     },
   },
 
-  // ============ memory_get ============
+  // ============ memory-get ============
   {
-    name: 'memory_get',
+    name: 'memory-get',
     description: 'Get full memory details by ID.',
     inputSchema: obj({
       id: { schema: num('Memory ID') },
@@ -225,9 +225,9 @@ const tools = [
     },
   },
 
-  // ============ memory_update ============
+  // ============ memory-update ============
   {
-    name: 'memory_update',
+    name: 'memory-update',
     description: 'Update an existing memory in place by ID.',
     inputSchema: obj({
       id: { schema: num('Memory ID') },
@@ -261,9 +261,9 @@ const tools = [
     },
   },
 
-  // ============ memory_delete ============
+  // ============ memory-delete ============
   {
-    name: 'memory_delete',
+    name: 'memory-delete',
     description: 'Soft-delete a stale, incorrect, or duplicate memory.',
     inputSchema: obj({
       id: { schema: num('Memory ID') },
@@ -273,9 +273,9 @@ const tools = [
     },
   },
 
-  // ============ memory_related ============
+  // ============ memory-related ============
   {
-    name: 'memory_related',
+    name: 'memory-related',
     description: 'Find memories linked to the same code symbols.',
     inputSchema: obj({
       id: { schema: num('Memory ID') },
@@ -285,9 +285,9 @@ const tools = [
     },
   },
 
-  // ============ memory_load_context ============
+  // ============ memory-load-context ============
   {
-    name: 'memory_load_context',
+    name: 'memory-load-context',
     description: 'Load deeper memory context for a topic.',
     inputSchema: obj({
       query: { schema: str('Topic or keyword') },
@@ -307,9 +307,9 @@ const tools = [
     },
   },
 
-  // ============ memory_code ============
+  // ============ memory-code ============
   {
-    name: 'memory_code',
+    name: 'memory-code',
     description:
       'Query indexed code and before-coding agent context. Use mode search, coding-context, ' +
       'preflight, agent-pack, outline, callers, callees, deps, health, index-repo, or reindex-repo. ' +
@@ -342,7 +342,7 @@ const tools = [
     toCommand(p) {
       const mode = p.mode;
       if (!mode || !CODE_MODE_TO_COMMAND[mode]) {
-        return { cmd: null, error: !mode ? 'memory_code requires a mode.' : `Unknown memory_code mode: ${mode}` };
+        return { cmd: null, error: !mode ? 'memory-code requires a mode.' : `Unknown memory-code mode: ${mode}` };
       }
       const cmd = CODE_MODE_TO_COMMAND[mode];
       const args = {};
@@ -406,9 +406,9 @@ const tools = [
     },
   },
 
-  // ============ memory_doc ============
+  // ============ memory-doc ============
   {
-    name: 'memory_doc',
+    name: 'memory-doc',
     description: 'Query indexed docs. Use mode search, outline, backlinks, coverage, index-docs, or reindex-docs.',
     inputSchema: obj({
       mode: { schema: opt(strEnum('Query mode', DOC_MODES)), optional: true },
@@ -430,7 +430,7 @@ const tools = [
     toCommand(p) {
       const mode = p.mode;
       if (!mode || !DOC_MODE_TO_COMMAND[mode]) {
-        return { cmd: null, error: !mode ? 'memory_doc requires a mode.' : `Unknown memory_doc mode: ${mode}` };
+        return { cmd: null, error: !mode ? 'memory-doc requires a mode.' : `Unknown memory-doc mode: ${mode}` };
       }
       const cmd = DOC_MODE_TO_COMMAND[mode];
       const args = {};
@@ -462,9 +462,9 @@ const tools = [
     },
   },
 
-  // ============ memory_sync_code_trust ============
+  // ============ memory-sync-code-trust ============
   {
-    name: 'memory_sync_code_trust',
+    name: 'memory-sync-code-trust',
     description: 'Sync memory trust scores with changed code after pull, checkout, merge, or rebase.',
     inputSchema: obj({
       repo: { schema: str('Indexed repo name') },
@@ -474,9 +474,9 @@ const tools = [
     },
   },
 
-  // ============ index_status ============
+  // ============ index-status ============
   {
-    name: 'index_status',
+    name: 'index-status',
     description:
       'Check the progress of an async code-indexing job. Returns job state, file progress, ' +
       'current file, and language breakdown.',

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -1,0 +1,493 @@
+// Module boundary:
+// Owns the MCP tool catalog — the single source of truth for what the MCP
+// Transport exposes. Mirrors the Pi extension tools
+// (extensions/memory-layer/tools/*.ts) but emits plain JSON schemas and
+// {cmd, args} pairs ready for gateway.dispatch. No business logic lives here;
+// Every tool delegates to the transport-agnostic dispatch core.
+
+// Reused verbatim from extensions/memory-layer/tools/code-tools.ts:89-116.
+// Keeping these in sync is enforced by test/mcp-tools-catalog.test.js.
+const CODE_MODE_TO_COMMAND = {
+  search: 'search-code',
+  callers: 'call-hierarchy',
+  callees: 'call-hierarchy',
+  'blast-radius': 'blast-radius',
+  'dead-code': 'dead-code',
+  complexity: 'complexity',
+  deps: 'import-graph',
+  outline: 'outline',
+  churn: 'churn',
+  hotspots: 'hotspots',
+  cycles: 'cycles',
+  importance: 'importance',
+  coupling: 'coupling',
+  extractable: 'extractable',
+  hierarchy: 'hierarchy',
+  'signal-chains': 'signal-chains',
+  'layer-violations': 'layer-violations',
+  'coding-context': 'coding-context',
+  preflight: 'preflight',
+  'agent-pack': 'agent-pack',
+  health: 'health-code-repo',
+  'index-repo': 'index-repo',
+  'reindex-repo': 'reindex-repo',
+  dupes: 'dupes',
+  'audit-diff': 'audit-diff',
+  'enrich-symbols': 'enrich-symbols',
+};
+
+// Reused verbatim from extensions/memory-layer/tools/doc-tools.ts:64-78.
+const DOC_MODE_TO_COMMAND = {
+  search: 'doc-search',
+  outline: 'doc-outline',
+  backlinks: 'backlinks',
+  'broken-links': 'broken-links',
+  glossary: 'glossary',
+  'tutorial-path': 'tutorial-path',
+  'code-examples': 'code-examples',
+  orphans: 'doc-orphans',
+  coverage: 'doc-coverage',
+  'stale-pages': 'stale-pages',
+  duplicates: 'doc-duplicates',
+  'index-docs': 'index-docs',
+  'reindex-docs': 'reindex-docs',
+};
+
+const CODE_MODES = Object.keys(CODE_MODE_TO_COMMAND);
+const DOC_MODES = Object.keys(DOC_MODE_TO_COMMAND);
+
+// --- small JSON-schema helpers (plain objects — no Zod, per SDK low-level Server) ---
+
+function opt(schema) {
+  // Shallow-clone + mark optional by removing from any required list.
+  // Required/optional is encoded at the Object() level, not the field level.
+  return { ...schema };
+}
+
+function str(desc) {
+  return { type: 'string', description: desc };
+}
+
+function strEnum(desc, values) {
+  return { type: 'string', description: desc, enum: values };
+}
+
+function num(desc) {
+  return { type: 'number', description: desc };
+}
+
+function bool(desc) {
+  return { type: 'boolean', description: desc };
+}
+
+/**
+ * Build a JSON schema object. `required` is derived from the optional flag.
+ * @param {Record<string, {schema: object, optional?: boolean}>} fields
+ */
+function obj(fields) {
+  const properties = {};
+  const required = [];
+  for (const [name, def] of Object.entries(fields)) {
+    properties[name] = def.schema;
+    if (!def.optional) {
+      required.push(name);
+    }
+  }
+  const schema = { type: 'object', properties };
+  if (required.length > 0) {
+    schema.required = required;
+  }
+  return schema;
+}
+
+// --- arg normalization helpers ---
+// These mirror the param→dispatch-arg logic in code-tools.ts:139-213 and
+// Doc-tools.ts:94-136. Centralizing here keeps the catalog self-contained.
+
+function setIfPresent(args, key, value) {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+  args[key] = String(value);
+}
+
+/**
+ * Convert a snake_case param name to the kebab-case arg key used by dispatch.
+ * e.g. "topic_key" → "topic-key", "min_confidence" → "min-confidence".
+ */
+function kebab(key) {
+  return key.replace(/_/g, '-');
+}
+
+module.exports.CODE_MODE_TO_COMMAND = CODE_MODE_TO_COMMAND;
+module.exports.DOC_MODE_TO_COMMAND = DOC_MODE_TO_COMMAND;
+
+// --- the catalog ---
+// Each entry: { name, description, inputSchema, toCommand(params, ctx) }
+// ToCommand returns { cmd, args } ready for gateway.dispatch.
+// `ctx` carries project (derived from cwd by the server) and is injected
+// Into memory tools that need it, matching the Pi extension's use of
+// State.currentProject.
+
+const tools = [
+  // ============ memory_save ============
+  {
+    name: 'memory_save',
+    description:
+      'Save persistent memory; checks duplicates. Use What/Why/Where/Learned content. ' +
+      'Types: decision, bugfix, architecture, pattern, discovery, config, preference, learning, manual.',
+    inputSchema: obj({
+      title: { schema: str('Short searchable title') },
+      content: { schema: str('What/Why/Where/Learned content') },
+      type: {
+        schema: opt(
+          strEnum('Memory type', [
+            'decision',
+            'bugfix',
+            'architecture',
+            'pattern',
+            'discovery',
+            'config',
+            'preference',
+            'learning',
+            'manual',
+          ]),
+        ),
+        optional: true,
+      },
+      scope: { schema: opt(strEnum('project|personal', ['project', 'personal'])), optional: true },
+      topic_key: { schema: opt(str('Optional topic key')), optional: true },
+      force: { schema: opt(bool('Bypass duplicate warning')), optional: true },
+      expires_in: {
+        schema: opt(
+          str('Optional TTL duration (e.g., "7d", "2w", "1m", "12h"). Memory auto-expires after this period.'),
+        ),
+        optional: true,
+      },
+    }),
+    toCommand(p, ctx) {
+      const args = {
+        title: p.title,
+        content: p.content,
+        type: p.type || 'manual',
+        project: ctx.project || 'unknown',
+        scope: p.scope || 'project',
+      };
+      if (p.topic_key) {
+        args[kebab('topic_key')] = p.topic_key;
+      }
+      if (p.force) {
+        args.force = 'true';
+      }
+      if (p.expires_in) {
+        args[kebab('expires_in')] = p.expires_in;
+      }
+      return { cmd: 'save', args };
+    },
+  },
+
+  // ============ memory_search ============
+  {
+    name: 'memory_search',
+    description: 'Search persistent memory for decisions, bugfixes, patterns, and discoveries.',
+    inputSchema: obj({
+      query: { schema: str('Search query') },
+      type: { schema: opt(str('Optional type filter')), optional: true },
+      scope: { schema: opt(strEnum('project|personal', ['project', 'personal'])), optional: true },
+      limit: { schema: opt(num('Max results')), optional: true },
+    }),
+    toCommand(p, ctx) {
+      const args = { query: p.query, project: ctx.project || 'unknown' };
+      setIfPresent(args, 'type', p.type);
+      setIfPresent(args, 'scope', p.scope);
+      setIfPresent(args, 'limit', p.limit);
+      return { cmd: 'search', args };
+    },
+  },
+
+  // ============ memory_get ============
+  {
+    name: 'memory_get',
+    description: 'Get full memory details by ID.',
+    inputSchema: obj({
+      id: { schema: num('Memory ID') },
+      allow_cross_project: {
+        schema: opt(bool('Return full content even when the memory belongs to a different project.')),
+        optional: true,
+      },
+    }),
+    toCommand(p) {
+      const args = { id: String(p.id) };
+      if (p.allow_cross_project) {
+        args[kebab('allow_cross_project')] = 'true';
+      }
+      return { cmd: 'get', args };
+    },
+  },
+
+  // ============ memory_update ============
+  {
+    name: 'memory_update',
+    description: 'Update an existing memory in place by ID.',
+    inputSchema: obj({
+      id: { schema: num('Memory ID') },
+      title: { schema: opt(str('New title')), optional: true },
+      content: { schema: opt(str('New content')), optional: true },
+      type: { schema: opt(str('New type')), optional: true },
+      scope: { schema: opt(str('New scope')), optional: true },
+      topic_key: { schema: opt(str('New topic key')), optional: true },
+      expires_in: {
+        schema: opt(str('Set or change TTL duration (e.g., "7d", "2w", "1m", "12h"). Replaces any existing expiry.')),
+        optional: true,
+      },
+      clear_expiry: { schema: opt(bool('Remove any existing expiry (make memory permanent).')), optional: true },
+    }),
+    toCommand(p) {
+      const args = { id: String(p.id) };
+      setIfPresent(args, 'title', p.title);
+      setIfPresent(args, 'content', p.content);
+      setIfPresent(args, 'type', p.type);
+      setIfPresent(args, 'scope', p.scope);
+      if (p.topic_key) {
+        args[kebab('topic_key')] = p.topic_key;
+      }
+      if (p.expires_in) {
+        args[kebab('expires_in')] = p.expires_in;
+      }
+      if (p.clear_expiry) {
+        args[kebab('clear_expiry')] = 'true';
+      }
+      return { cmd: 'update', args };
+    },
+  },
+
+  // ============ memory_delete ============
+  {
+    name: 'memory_delete',
+    description: 'Soft-delete a stale, incorrect, or duplicate memory.',
+    inputSchema: obj({
+      id: { schema: num('Memory ID') },
+    }),
+    toCommand(p) {
+      return { cmd: 'delete', args: { id: String(p.id) } };
+    },
+  },
+
+  // ============ memory_related ============
+  {
+    name: 'memory_related',
+    description: 'Find memories linked to the same code symbols.',
+    inputSchema: obj({
+      id: { schema: num('Memory ID') },
+    }),
+    toCommand(p) {
+      return { cmd: 'related', args: { id: String(p.id) } };
+    },
+  },
+
+  // ============ memory_load_context ============
+  {
+    name: 'memory_load_context',
+    description: 'Load deeper memory context for a topic.',
+    inputSchema: obj({
+      query: { schema: str('Topic or keyword') },
+      deep: { schema: opt(bool('More results')), optional: true },
+      token_budget: { schema: opt(num('Max tokens to use (default: 2000)')), optional: true },
+    }),
+    toCommand(p, ctx) {
+      const tokenBudget = p.token_budget || 2000;
+      const args = {
+        project: ctx.project || 'unknown',
+        query: p.query,
+        limit: '50',
+        [kebab('token_budget')]: String(tokenBudget),
+        deep: p.deep ? 'true' : 'false',
+      };
+      return { cmd: 'context', args };
+    },
+  },
+
+  // ============ memory_code ============
+  {
+    name: 'memory_code',
+    description:
+      'Query indexed code and before-coding agent context. Use mode search, coding-context, ' +
+      'preflight, agent-pack, outline, callers, callees, deps, health, index-repo, or reindex-repo. ' +
+      'Include repo when known; if omitted, LaPis infers the current indexed repo when possible.',
+    inputSchema: obj({
+      mode: { schema: opt(strEnum('Analysis mode', CODE_MODES)), optional: true },
+      repo: { schema: opt(str('Indexed repo name')), optional: true },
+      symbol: { schema: opt(str('Symbol name')), optional: true },
+      query: { schema: opt(str('Search query')), optional: true },
+      task: { schema: opt(str('Agent task for preflight or agent-pack')), optional: true },
+      file: { schema: opt(str('File path')), optional: true },
+      depth: { schema: opt(num('Depth 1-5')), optional: true },
+      direction: { schema: opt(str('imports|importers|both')), optional: true },
+      min_confidence: { schema: opt(num('Min confidence')), optional: true },
+      days: { schema: opt(num('Lookback days')), optional: true },
+      refresh: { schema: opt(bool('Refresh cache')), optional: true },
+      top: { schema: opt(num('Max results')), optional: true },
+      scope: { schema: opt(str('Subdirectory scope')), optional: true },
+      sort_by: { schema: opt(str('instability|afferent|efferent')), optional: true },
+      min_complexity: { schema: opt(num('Min complexity')), optional: true },
+      min_callers: { schema: opt(num('Min caller files')), optional: true },
+      direction_hier: { schema: opt(str('both|ancestors|descendants')), optional: true },
+      kind: { schema: opt(str('Gateway kind')), optional: true },
+      symbol_chain: { schema: opt(str('Signal-chain symbol')), optional: true },
+      path: { schema: opt(str('Local repo path (index-repo/reindex-repo)')), optional: true },
+      name: { schema: opt(str('Repo name (index-repo/reindex-repo)')), optional: true },
+      rules: { schema: opt(str('Layer rules JSON')), optional: true },
+      files: { schema: opt(str('Comma-separated list of files (audit-diff)')), optional: true },
+    }),
+    toCommand(p) {
+      const mode = p.mode;
+      if (!mode || !CODE_MODE_TO_COMMAND[mode]) {
+        return { cmd: null, error: !mode ? 'memory_code requires a mode.' : `Unknown memory_code mode: ${mode}` };
+      }
+      const cmd = CODE_MODE_TO_COMMAND[mode];
+      const args = {};
+      setIfPresent(args, 'repo', p.repo);
+      setIfPresent(args, 'symbol', p.symbol);
+      if (p.query || (mode === 'search' && p.symbol)) {
+        args.query = String(p.query || p.symbol);
+      }
+      if (p.task || ((mode === 'preflight' || mode === 'agent-pack') && p.query)) {
+        args.task = String(p.task || p.query);
+      }
+      setIfPresent(args, 'file', p.file);
+      if (p.depth) {
+        args.depth = String(p.depth);
+      }
+      // Callers/callees map to call-hierarchy with explicit direction
+      if (cmd === 'call-hierarchy') {
+        args.direction = mode === 'callers' ? 'callers' : 'callees';
+      } else if (p.direction) {
+        args.direction = p.direction;
+      }
+      if (p.min_confidence) {
+        args[kebab('min_confidence')] = String(p.min_confidence);
+      }
+      setIfPresent(args, 'days', p.days);
+      if (p.refresh) {
+        args.refresh = 'true';
+      }
+      const top = p.top || (cmd === 'search-code' ? 5 : null);
+      if (top) {
+        if (cmd === 'search-code') {
+          args[kebab('max_results')] = String(top);
+        } else {
+          args.top = String(top);
+        }
+      }
+      setIfPresent(args, 'scope', p.scope);
+      if (p.sort_by) {
+        args[kebab('sort_by')] = p.sort_by;
+      }
+      if (p.min_complexity) {
+        args[kebab('min_complexity')] = String(p.min_complexity);
+      }
+      if (p.min_callers) {
+        args[kebab('min_callers')] = String(p.min_callers);
+      }
+      if (p.direction_hier) {
+        args.direction = p.direction_hier;
+      }
+      setIfPresent(args, 'kind', p.kind);
+      if (p.symbol_chain) {
+        args.symbol = String(p.symbol_chain);
+      }
+      setIfPresent(args, 'path', p.path);
+      setIfPresent(args, 'name', p.name);
+      if (p.rules) {
+        args.rules = typeof p.rules === 'string' ? p.rules : JSON.stringify(p.rules);
+      }
+      setIfPresent(args, 'files', p.files);
+      return { cmd, args };
+    },
+  },
+
+  // ============ memory_doc ============
+  {
+    name: 'memory_doc',
+    description: 'Query indexed docs. Use mode search, outline, backlinks, coverage, index-docs, or reindex-docs.',
+    inputSchema: obj({
+      mode: { schema: opt(strEnum('Query mode', DOC_MODES)), optional: true },
+      repo: { schema: opt(str('Indexed doc repo name')), optional: true },
+      query: { schema: opt(str('Search query')), optional: true },
+      file: { schema: opt(str('Doc file path')), optional: true },
+      doc_path: { schema: opt(str('Doc path for backlinks')), optional: true },
+      term: { schema: opt(str('Glossary term')), optional: true },
+      section: { schema: opt(num('Section ID')), optional: true },
+      level: { schema: opt(num('Heading level')), optional: true },
+      role: { schema: opt(str('Doc role')), optional: true },
+      lang: { schema: opt(str('Code language')), optional: true },
+      include_same_doc: { schema: opt(bool('Include intra-doc links')), optional: true },
+      doc_repo: { schema: opt(str('Code repo for coverage')), optional: true },
+      path: { schema: opt(str('Local docs path (index-docs/reindex-docs)')), optional: true },
+      name: { schema: opt(str('Doc repo name (index-docs/reindex-docs)')), optional: true },
+      ignore: { schema: opt(str('Ignore glob')), optional: true },
+    }),
+    toCommand(p) {
+      const mode = p.mode;
+      if (!mode || !DOC_MODE_TO_COMMAND[mode]) {
+        return { cmd: null, error: !mode ? 'memory_doc requires a mode.' : `Unknown memory_doc mode: ${mode}` };
+      }
+      const cmd = DOC_MODE_TO_COMMAND[mode];
+      const args = {};
+      setIfPresent(args, 'repo', p.repo);
+      setIfPresent(args, 'query', p.query);
+      setIfPresent(args, 'file', p.file);
+      if (p.doc_path) {
+        args.path = p.doc_path;
+      }
+      setIfPresent(args, 'term', p.term);
+      if (p.section) {
+        args.section = String(p.section);
+      }
+      if (p.level) {
+        args.level = String(p.level);
+      }
+      setIfPresent(args, 'role', p.role);
+      setIfPresent(args, 'lang', p.lang);
+      if (p.include_same_doc) {
+        args[kebab('include_same_doc')] = 'true';
+      }
+      if (p.doc_repo) {
+        args[kebab('doc_repo')] = p.doc_repo;
+      }
+      setIfPresent(args, 'path', p.path);
+      setIfPresent(args, 'name', p.name);
+      setIfPresent(args, 'ignore', p.ignore);
+      return { cmd, args };
+    },
+  },
+
+  // ============ memory_sync_code_trust ============
+  {
+    name: 'memory_sync_code_trust',
+    description: 'Sync memory trust scores with changed code after pull, checkout, merge, or rebase.',
+    inputSchema: obj({
+      repo: { schema: str('Indexed repo name') },
+    }),
+    toCommand(p) {
+      return { cmd: 'sync-code-trust', args: { repo: p.repo } };
+    },
+  },
+
+  // ============ index_status ============
+  {
+    name: 'index_status',
+    description:
+      'Check the progress of an async code-indexing job. Returns job state, file progress, ' +
+      'current file, and language breakdown.',
+    inputSchema: obj({
+      job: { schema: str('Job ID returned by index-repo-async') },
+    }),
+    toCommand(p) {
+      return { cmd: 'index-status', args: { job: String(p.job) } };
+    },
+  },
+];
+
+module.exports.tools = tools;
+module.exports.toolByName = Object.fromEntries(tools.map((t) => [t.name, t]));

--- a/src/mcp/translate-result.js
+++ b/src/mcp/translate-result.js
@@ -1,0 +1,103 @@
+// Module boundary:
+// Converts gateway.dispatch() results into the MCP CallToolResult shape.
+// Dispatch returns one of:
+//   - { error: '...' }                      → tool error
+//   - { content: [{type:'text',text}], ...} → already MCP-shaped (rare from dispatch)
+//   - any plain object                      → success, JSON-stringified as text
+// This module normalizes all three into { content: [{type:'text',text}], isError }.
+
+/**
+ * Strip Pi-TUI emoji icons that add noise in non-TUI MCP clients.
+ * Only removes a LEADING run of decorative icons on each line — mid-string
+ * emoji inside data values (titles, snippets) are preserved, since they may
+ * carry meaning.
+ *
+ * Structure: one or more decorative emoji/symbol chars, each optionally
+ * followed by a variation selector (U+FE0F) or ZWJ (U+200D) joiner. The
+ * joiner/selector chars are suffixes on a base emoji, NOT standalone
+ * alternatives, so they live outside the base class (else a lone orphan
+ * selector would remain — which is what originally happened with "⚠️").
+ */
+// Base decorative ranges, each optionally extended by FE0F/200D modifiers.
+const LEADING_ICON_RUN =
+  /^\s*(?:[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{1F1E6}-\u{1F1FF}][\u{FE0F}\u{200D}]*)+\s*/u;
+
+function stripTuiArtifacts(text) {
+  if (typeof text !== 'string') {
+    return text;
+  }
+  return text
+    .split('\n')
+    .map((line) => line.replace(LEADING_ICON_RUN, '').trimEnd())
+    .join('\n')
+    .trim();
+}
+
+function truncate(text, max = 100000) {
+  if (typeof text !== 'string') {
+    return text;
+  }
+  if (text.length <= max) {
+    return text;
+  }
+  return `${text.slice(0, max)}\n…[truncated by MCP adapter, ${text.length - max} chars omitted]`;
+}
+
+/**
+ * @param {unknown} result - output from gateway.dispatch(cmd, args)
+ * @returns {{ content: Array<{type:'text', text:string}>, isError?: boolean }}
+ */
+function toCallToolResult(result) {
+  // Null/undefined — dispatch treats this as a failure
+  if (result === null || result === undefined) {
+    return {
+      content: [{ type: 'text', text: 'No result returned from memory engine.' }],
+      isError: true,
+    };
+  }
+
+  if (typeof result !== 'object') {
+    return {
+      content: [{ type: 'text', text: truncate(String(result)) }],
+    };
+  }
+
+  const r = result;
+
+  // Explicit error envelope from dispatch
+  if (Object.hasOwn(r, 'error') && r.error) {
+    return {
+      content: [{ type: 'text', text: truncate(`Error: ${r.error}`) }],
+      isError: true,
+    };
+  }
+
+  // Already in MCP content shape (dispatch sometimes forwards these)
+  if (
+    Array.isArray(r.content) &&
+    r.content.length > 0 &&
+    r.content.every((c) => c && typeof c === 'object' && c.type === 'text')
+  ) {
+    const text = r.content.map((c) => c.text).join('\n');
+    return {
+      content: [{ type: 'text', text: truncate(stripTuiArtifacts(text)) }],
+      ...(r.isError === true ? { isError: true } : {}),
+    };
+  }
+
+  // Plain object — serialize as formatted JSON. This is the common case for
+  // Dispatch results (search results, outlines, analysis, etc.).
+  let text;
+  try {
+    text = JSON.stringify(r, null, 2);
+  } catch {
+    text = String(r);
+  }
+  return {
+    content: [{ type: 'text', text: truncate(stripTuiArtifacts(text)) }],
+  };
+}
+
+module.exports = { toCallToolResult, stripTuiArtifacts, truncate };
+// Re-export for tests that want to assert the regex is unused externally
+module.exports.LEADING_ICON_RUN = LEADING_ICON_RUN;

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -271,6 +271,55 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
   });
 });
 
+// --- startMcpServer error handling ---
+
+describe('startMcpServer', () => {
+  it('writes to stderr and exits non-zero when ensureDb() throws', async () => {
+    // Swap the cached db module for one whose ensureDb() throws so we
+    // Exercise the real error path without touching the real DB.
+    const dbPath = require.resolve('../db');
+    // Ensure the module is cached so we can swap its exports.
+    require(dbPath);
+    const realDb = require.cache[dbPath].exports;
+    require.cache[dbPath].exports = {
+      ensureDb: () => {
+        throw new Error('EACCES: ~/.lapis unwritable');
+      },
+    };
+
+    const stderrChunks = [];
+    const realStderrWrite = process.stderr.write.bind(process.stderr);
+    const realExit = process.exit;
+    process.stderr.write = (chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    };
+    let exitCode = null;
+    process.exit = (code) => {
+      exitCode = code;
+      // Throw to unwind startMcpServer before it reaches server.connect()
+      throw new Error(`__synthetic_exit_${code}__`);
+    };
+
+    const { startMcpServer } = require('../src/mcp/server');
+    let thrown = null;
+    try {
+      await startMcpServer();
+    } catch (err) {
+      thrown = err;
+    } finally {
+      process.stderr.write = realStderrWrite;
+      process.exit = realExit;
+      require.cache[dbPath].exports = realDb;
+    }
+
+    expect(thrown, 'startMcpServer should propagate the synthetic exit signal').not.toBeNull();
+    expect(exitCode).toBe(1);
+    expect(stderrChunks.join('')).toMatch(/lapis mcp: database initialization failed/);
+    expect(stderrChunks.join('')).toMatch(/EACCES/);
+  });
+});
+
 // --- helper ---
 
 function sampleParams(name) {

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -1,0 +1,301 @@
+// MCP server tests.
+// Covers three layers:
+//   1. tool catalog sanity (every tool has valid schema + working toCommand)
+//   2. translate-result mapping (error/success/raw shapes → CallToolResult)
+//   3. end-to-end through the SDK's InMemoryTransport with a fake dispatch,
+//      Proving the server wires tools → dispatch → MCP framing correctly.
+//
+// Uses vitest globals (vitest.config.mjs: globals:true) — no import needed.
+
+// --- catalog sanity ---
+
+describe('MCP tool catalog', () => {
+  const { tools, toolByName, CODE_MODE_TO_COMMAND, DOC_MODE_TO_COMMAND } = require('../src/mcp/tools');
+
+  it('exposes the 10 expected tools', () => {
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(
+      [
+        'index_status',
+        'memory_code',
+        'memory_delete',
+        'memory_doc',
+        'memory_get',
+        'memory_load_context',
+        'memory_related',
+        'memory_save',
+        'memory_search',
+        'memory_sync_code_trust',
+        'memory_update',
+      ].sort(),
+    );
+  });
+
+  for (const tool of tools) {
+    describe(`tool: ${tool.name}`, () => {
+      it('has a valid JSON-schema inputSchema', () => {
+        expect(tool.inputSchema).toBeDefined();
+        expect(tool.inputSchema.type).toBe('object');
+        expect(tool.inputSchema.properties).toBeTypeOf('object');
+        // Required, if present, must list known properties
+        if (tool.inputSchema.required) {
+          for (const r of tool.inputSchema.required) {
+            expect(tool.inputSchema.properties[r], `required field "${r}" missing from properties`).toBeDefined();
+          }
+        }
+      });
+
+      it('toCommand returns a non-empty cmd for valid input', () => {
+        // Provide enough params to satisfy tools with required fields.
+        // Mode-bearing tools get a valid first mode.
+        const sample = sampleParams(tool.name);
+        const out = tool.toCommand(sample, { project: 'test-project' });
+        expect(out.cmd, `${tool.name} should produce a cmd`).toBeTypeOf('string');
+        expect(out.cmd.length).toBeGreaterThan(0);
+        expect(out.args).toBeTypeOf('object');
+      });
+    });
+  }
+
+  it('memory_code toCommand maps every mode to a known dispatch command', () => {
+    const t = toolByName.memory_code;
+    for (const mode of Object.keys(CODE_MODE_TO_COMMAND)) {
+      const out = t.toCommand({ mode, repo: 'r' }, { project: 'p' });
+      expect(out.cmd, `mode ${mode} → ${out.cmd}`).toBe(CODE_MODE_TO_COMMAND[mode]);
+    }
+  });
+
+  it('memory_doc toCommand maps every mode to a known dispatch command', () => {
+    const t = toolByName.memory_doc;
+    for (const mode of Object.keys(DOC_MODE_TO_COMMAND)) {
+      const out = t.toCommand({ mode, repo: 'r' }, { project: 'p' });
+      expect(out.cmd, `mode ${mode} → ${out.cmd}`).toBe(DOC_MODE_TO_COMMAND[mode]);
+    }
+  });
+
+  it('memory_code rejects unknown mode', () => {
+    const t = toolByName.memory_code;
+    const out = t.toCommand({ mode: 'bogus', repo: 'r' }, { project: 'p' });
+    expect(out.cmd).toBeNull();
+    expect(out.error).toMatch(/Unknown memory_code mode/);
+  });
+
+  it('memory_save injects project + defaults from ctx', () => {
+    const t = toolByName.memory_save;
+    const out = t.toCommand({ title: 'T', content: 'C' }, { project: 'myproj' });
+    expect(out.cmd).toBe('save');
+    expect(out.args.project).toBe('myproj');
+    expect(out.args.type).toBe('manual'); // Default
+    expect(out.args.scope).toBe('project'); // Default
+  });
+
+  it('memory_save forwards optional kebab-case flags', () => {
+    const t = toolByName.memory_save;
+    const out = t.toCommand(
+      { title: 'T', content: 'C', topic_key: 'auth', force: true, expires_in: '7d' },
+      { project: 'p' },
+    );
+    expect(out.args['topic-key']).toBe('auth');
+    expect(out.args.force).toBe('true');
+    expect(out.args['expires-in']).toBe('7d');
+  });
+
+  it('memory_code callers/callees map to call-hierarchy with direction', () => {
+    const t = toolByName.memory_code;
+    expect(t.toCommand({ mode: 'callers', repo: 'r', symbol: 's' }, { project: 'p' }).args.direction).toBe('callers');
+    expect(t.toCommand({ mode: 'callees', repo: 'r', symbol: 's' }, { project: 'p' }).args.direction).toBe('callees');
+  });
+
+  it('memory_code search uses max-results instead of top', () => {
+    const t = toolByName.memory_code;
+    const out = t.toCommand({ mode: 'search', repo: 'r', query: 'q', top: 3 }, { project: 'p' });
+    expect(out.args['max-results']).toBe('3');
+    expect(out.args.top).toBeUndefined();
+  });
+});
+
+// --- translate-result ---
+
+describe('translate-result', () => {
+  const { toCallToolResult, stripTuiArtifacts, truncate } = require('../src/mcp/translate-result');
+
+  it('maps null to an error result', () => {
+    const r = toCallToolResult(null);
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/No result/);
+  });
+
+  it('maps dispatch { error } envelope to an error result', () => {
+    const r = toCallToolResult({ error: 'boom' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/Error: boom/);
+  });
+
+  it('serializes plain objects as JSON text', () => {
+    const r = toCallToolResult({ results: [{ id: 1, title: 'x' }] });
+    expect(r.isError).toBeUndefined();
+    const parsed = JSON.parse(r.content[0].text);
+    expect(parsed.results[0].id).toBe(1);
+  });
+
+  it('passes through already-shaped content, stripping only leading icons', () => {
+    const r = toCallToolResult({
+      content: [{ type: 'text', text: '✅ Memory saved: hello world' }],
+    });
+    // Leading status icon stripped; mid-string text preserved.
+    expect(r.content[0].text).toBe('Memory saved: hello world');
+    expect(r.isError).toBeUndefined();
+  });
+
+  it('preserves isError=true on content-shaped results', () => {
+    const r = toCallToolResult({
+      content: [{ type: 'text', text: 'failed' }],
+      isError: true,
+    });
+    expect(r.isError).toBe(true);
+  });
+
+  it('stripTuiArtifacts removes leading decorative icons (incl. variation selectors)', () => {
+    expect(stripTuiArtifacts('✅ Memory saved')).toBe('Memory saved');
+    expect(stripTuiArtifacts('⚠️ Warning')).toBe('Warning'); // U+26A0 + U+FE0F
+    expect(stripTuiArtifacts('📦 Indexing…')).toBe('Indexing…');
+    expect(stripTuiArtifacts('plain text')).toBe('plain text');
+  });
+
+  it('stripTuiArtifacts preserves mid-string emoji in data values', () => {
+    // Only LEADING icons are stripped — emoji inside content may be meaningful.
+    expect(stripTuiArtifacts('Memory: use ✅ for success')).toBe('Memory: use ✅ for success');
+  });
+
+  it('truncate caps very long output', () => {
+    const long = 'x'.repeat(100);
+    const r = toCallToolResult({ big: 'y'.repeat(200000) });
+    expect(r.content[0].text.length).toBeLessThan(200000);
+    expect(r.content[0].text).toMatch(/truncated/);
+    // Helper itself
+    expect(truncate(long, 10).length).toBeLessThanOrEqual(80); // Includes suffix
+  });
+});
+
+// --- end-to-end through SDK InMemoryTransport ---
+
+describe('MCP server end-to-end (InMemoryTransport)', () => {
+  it('lists all tools and calls memory_save → dispatch → result', async () => {
+    vi.resetModules();
+
+    // Fake dispatch: records calls, returns canned responses keyed by cmd.
+    const calls = [];
+    const fakeDispatch = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'save') {
+        return { id: 42, title: args.title, saved: true };
+      }
+      if (cmd === 'search') {
+        return { results: [{ id: 42, title: 'T', type: 'decision', snippet: 'S', _score: 0.9 }] };
+      }
+      return { ok: true };
+    };
+
+    const { createServer } = require('../src/mcp/server');
+    const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+
+    const server = createServer({ dispatch: fakeDispatch, project: 'e2e-project' });
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    // Tools/list
+    const toolsList = await client.listTools();
+    const toolNames = toolsList.tools.map((t) => t.name);
+    expect(toolNames).toContain('memory_save');
+    expect(toolNames).toContain('memory_search');
+    expect(toolsList.tools.find((t) => t.name === 'memory_save').inputSchema.type).toBe('object');
+
+    // Tools/call — save
+    const saveResult = await client.callTool({
+      name: 'memory_save',
+      arguments: { title: 'My Decision', content: 'Use X because Y' },
+    });
+    expect(saveResult.isError).toBeUndefined();
+    const parsed = JSON.parse(saveResult.content[0].text);
+    expect(parsed.id).toBe(42);
+    expect(parsed.title).toBe('My Decision');
+
+    // Dispatch received the project-scoped args
+    expect(calls[0].cmd).toBe('save');
+    expect(calls[0].args.project).toBe('e2e-project');
+
+    // Tools/call — search returns serialized object
+    const searchResult = await client.callTool({ name: 'memory_search', arguments: { query: 'decisions' } });
+    const searchParsed = JSON.parse(searchResult.content[0].text);
+    expect(searchParsed.results[0].id).toBe(42);
+
+    // Unknown tool → error
+    const unknownResult = await client.callTool({ name: 'does_not_exist', arguments: {} });
+    expect(unknownResult.isError).toBe(true);
+    expect(unknownResult.content[0].text).toMatch(/Unknown tool/);
+
+    // Unknown memory_code mode → error
+    const badMode = await client.callTool({ name: 'memory_code', arguments: { mode: 'not-a-mode' } });
+    expect(badMode.isError).toBe(true);
+
+    server.close?.();
+    client.close?.();
+  });
+
+  it('translates dispatch { error } into an MCP error result', async () => {
+    vi.resetModules();
+    const fakeDispatch = async () => ({ error: 'repo not indexed' });
+    const { createServer } = require('../src/mcp/server');
+    const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+
+    const server = createServer({ dispatch: fakeDispatch, project: 'p' });
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    const result = await client.callTool({ name: 'memory_search', arguments: { query: 'x' } });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/repo not indexed/);
+
+    server.close?.();
+    client.close?.();
+  });
+
+  it('projectFromCwd derives project from a directory basename', () => {
+    const { projectFromCwd } = require('../src/mcp/server');
+    expect(projectFromCwd('/home/user/MyProject')).toBe('myproject');
+    expect(projectFromCwd('/tmp/lapis-test')).toBe('lapis-test');
+  });
+});
+
+// --- helper ---
+
+function sampleParams(name) {
+  switch (name) {
+    case 'memory_save':
+      return { title: 'T', content: 'C' };
+    case 'memory_search':
+      return { query: 'q' };
+    case 'memory_get':
+    case 'memory_delete':
+    case 'memory_related':
+      return { id: 1 };
+    case 'memory_update':
+      return { id: 1, title: 'T' };
+    case 'memory_load_context':
+      return { query: 'q' };
+    case 'memory_code':
+      return { mode: 'outline', repo: 'r', file: 'src/foo.ts' };
+    case 'memory_doc':
+      return { mode: 'search', repo: 'r', query: 'q' };
+    case 'memory_sync_code_trust':
+      return { repo: 'r' };
+    case 'index_status':
+      return { job: 'j1' };
+    default:
+      return {};
+  }
+}

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -12,21 +12,21 @@
 describe('MCP tool catalog', () => {
   const { tools, toolByName, CODE_MODE_TO_COMMAND, DOC_MODE_TO_COMMAND } = require('../src/mcp/tools');
 
-  it('exposes the 10 expected tools', () => {
+  it('exposes the 11 expected tools', () => {
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual(
       [
-        'index_status',
-        'memory_code',
-        'memory_delete',
-        'memory_doc',
-        'memory_get',
-        'memory_load_context',
-        'memory_related',
-        'memory_save',
-        'memory_search',
-        'memory_sync_code_trust',
-        'memory_update',
+        'index-status',
+        'memory-code',
+        'memory-delete',
+        'memory-doc',
+        'memory-get',
+        'memory-load-context',
+        'memory-related',
+        'memory-save',
+        'memory-search',
+        'memory-sync-code-trust',
+        'memory-update',
       ].sort(),
     );
   });
@@ -57,31 +57,31 @@ describe('MCP tool catalog', () => {
     });
   }
 
-  it('memory_code toCommand maps every mode to a known dispatch command', () => {
-    const t = toolByName.memory_code;
+  it('memory-code toCommand maps every mode to a known dispatch command', () => {
+    const t = toolByName['memory-code'];
     for (const mode of Object.keys(CODE_MODE_TO_COMMAND)) {
       const out = t.toCommand({ mode, repo: 'r' }, { project: 'p' });
       expect(out.cmd, `mode ${mode} → ${out.cmd}`).toBe(CODE_MODE_TO_COMMAND[mode]);
     }
   });
 
-  it('memory_doc toCommand maps every mode to a known dispatch command', () => {
-    const t = toolByName.memory_doc;
+  it('memory-doc toCommand maps every mode to a known dispatch command', () => {
+    const t = toolByName['memory-doc'];
     for (const mode of Object.keys(DOC_MODE_TO_COMMAND)) {
       const out = t.toCommand({ mode, repo: 'r' }, { project: 'p' });
       expect(out.cmd, `mode ${mode} → ${out.cmd}`).toBe(DOC_MODE_TO_COMMAND[mode]);
     }
   });
 
-  it('memory_code rejects unknown mode', () => {
-    const t = toolByName.memory_code;
+  it('memory-code rejects unknown mode', () => {
+    const t = toolByName['memory-code'];
     const out = t.toCommand({ mode: 'bogus', repo: 'r' }, { project: 'p' });
     expect(out.cmd).toBeNull();
-    expect(out.error).toMatch(/Unknown memory_code mode/);
+    expect(out.error).toMatch(/Unknown memory-code mode/);
   });
 
-  it('memory_save injects project + defaults from ctx', () => {
-    const t = toolByName.memory_save;
+  it('memory-save injects project + defaults from ctx', () => {
+    const t = toolByName['memory-save'];
     const out = t.toCommand({ title: 'T', content: 'C' }, { project: 'myproj' });
     expect(out.cmd).toBe('save');
     expect(out.args.project).toBe('myproj');
@@ -89,8 +89,8 @@ describe('MCP tool catalog', () => {
     expect(out.args.scope).toBe('project'); // Default
   });
 
-  it('memory_save forwards optional kebab-case flags', () => {
-    const t = toolByName.memory_save;
+  it('memory-save forwards optional kebab-case flags', () => {
+    const t = toolByName['memory-save'];
     const out = t.toCommand(
       { title: 'T', content: 'C', topic_key: 'auth', force: true, expires_in: '7d' },
       { project: 'p' },
@@ -100,14 +100,14 @@ describe('MCP tool catalog', () => {
     expect(out.args['expires-in']).toBe('7d');
   });
 
-  it('memory_code callers/callees map to call-hierarchy with direction', () => {
-    const t = toolByName.memory_code;
+  it('memory-code callers/callees map to call-hierarchy with direction', () => {
+    const t = toolByName['memory-code'];
     expect(t.toCommand({ mode: 'callers', repo: 'r', symbol: 's' }, { project: 'p' }).args.direction).toBe('callers');
     expect(t.toCommand({ mode: 'callees', repo: 'r', symbol: 's' }, { project: 'p' }).args.direction).toBe('callees');
   });
 
-  it('memory_code search uses max-results instead of top', () => {
-    const t = toolByName.memory_code;
+  it('memory-code search uses max-results instead of top', () => {
+    const t = toolByName['memory-code'];
     const out = t.toCommand({ mode: 'search', repo: 'r', query: 'q', top: 3 }, { project: 'p' });
     expect(out.args['max-results']).toBe('3');
     expect(out.args.top).toBeUndefined();
@@ -180,7 +180,7 @@ describe('translate-result', () => {
 // --- end-to-end through SDK InMemoryTransport ---
 
 describe('MCP server end-to-end (InMemoryTransport)', () => {
-  it('lists all tools and calls memory_save → dispatch → result', async () => {
+  it('lists all tools and calls memory-save → dispatch → result', async () => {
     vi.resetModules();
 
     // Fake dispatch: records calls, returns canned responses keyed by cmd.
@@ -208,13 +208,13 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
     // Tools/list
     const toolsList = await client.listTools();
     const toolNames = toolsList.tools.map((t) => t.name);
-    expect(toolNames).toContain('memory_save');
-    expect(toolNames).toContain('memory_search');
-    expect(toolsList.tools.find((t) => t.name === 'memory_save').inputSchema.type).toBe('object');
+    expect(toolNames).toContain('memory-save');
+    expect(toolNames).toContain('memory-search');
+    expect(toolsList.tools.find((t) => t.name === 'memory-save').inputSchema.type).toBe('object');
 
     // Tools/call — save
     const saveResult = await client.callTool({
-      name: 'memory_save',
+      name: 'memory-save',
       arguments: { title: 'My Decision', content: 'Use X because Y' },
     });
     expect(saveResult.isError).toBeUndefined();
@@ -227,7 +227,7 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
     expect(calls[0].args.project).toBe('e2e-project');
 
     // Tools/call — search returns serialized object
-    const searchResult = await client.callTool({ name: 'memory_search', arguments: { query: 'decisions' } });
+    const searchResult = await client.callTool({ name: 'memory-search', arguments: { query: 'decisions' } });
     const searchParsed = JSON.parse(searchResult.content[0].text);
     expect(searchParsed.results[0].id).toBe(42);
 
@@ -236,8 +236,8 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
     expect(unknownResult.isError).toBe(true);
     expect(unknownResult.content[0].text).toMatch(/Unknown tool/);
 
-    // Unknown memory_code mode → error
-    const badMode = await client.callTool({ name: 'memory_code', arguments: { mode: 'not-a-mode' } });
+    // Unknown memory-code mode → error
+    const badMode = await client.callTool({ name: 'memory-code', arguments: { mode: 'not-a-mode' } });
     expect(badMode.isError).toBe(true);
 
     server.close?.();
@@ -256,7 +256,7 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
 
-    const result = await client.callTool({ name: 'memory_search', arguments: { query: 'x' } });
+    const result = await client.callTool({ name: 'memory-search', arguments: { query: 'x' } });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/repo not indexed/);
 
@@ -275,25 +275,25 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
 
 function sampleParams(name) {
   switch (name) {
-    case 'memory_save':
+    case 'memory-save':
       return { title: 'T', content: 'C' };
-    case 'memory_search':
+    case 'memory-search':
       return { query: 'q' };
-    case 'memory_get':
-    case 'memory_delete':
-    case 'memory_related':
+    case 'memory-get':
+    case 'memory-delete':
+    case 'memory-related':
       return { id: 1 };
-    case 'memory_update':
+    case 'memory-update':
       return { id: 1, title: 'T' };
-    case 'memory_load_context':
+    case 'memory-load-context':
       return { query: 'q' };
-    case 'memory_code':
+    case 'memory-code':
       return { mode: 'outline', repo: 'r', file: 'src/foo.ts' };
-    case 'memory_doc':
+    case 'memory-doc':
       return { mode: 'search', repo: 'r', query: 'q' };
-    case 'memory_sync_code_trust':
+    case 'memory-sync-code-trust':
       return { repo: 'r' };
-    case 'index_status':
+    case 'index-status':
       return { job: 'j1' };
     default:
       return {};

--- a/test/mcp-tools-catalog.test.js
+++ b/test/mcp-tools-catalog.test.js
@@ -22,29 +22,37 @@ describe('MCP ↔ Pi extension tool parity', () => {
   const { tools, CODE_MODE_TO_COMMAND, DOC_MODE_TO_COMMAND } = require('../src/mcp/tools');
   const mcpNames = new Set(tools.map((t) => t.name));
 
-  it('MCP exposes every tool the Pi extension registers', () => {
-    // Tool names registered in extensions/memory-layer/tools/*.ts via pi.registerTool.
-    // Sourced from memory-tools.ts, code-tools.ts, doc-tools.ts.
-    // If the Pi extension gains a registerTool call, add it here — that's the point.
-    const piToolNames = [
-      'memory_save',
-      'memory_search',
-      'memory_get',
-      'memory_update',
-      'memory_delete',
-      'memory_related',
-      'memory_load_context',
-      'memory_sync_code_trust',
-      'index_status',
-      'memory_code', // Code-tools.ts
-      'memory_doc', // Doc-tools.ts
+  // Tool names registered in extensions/memory-layer/tools/*.ts via pi.registerTool.
+  // Extracted statically from the TS source (no TS compiler) so the parity guard
+  // Breaks loudly if either adapter adds/removes a tool. Names must match exactly:
+  // The Pi extension uses kebab-case, so the MCP catalog mirrors it (src/mcp/tools.js).
+  function piRegisteredToolNames() {
+    const files = [
+      'extensions/memory-layer/tools/memory-tools.ts',
+      'extensions/memory-layer/tools/code-tools.ts',
+      'extensions/memory-layer/tools/doc-tools.ts',
     ];
+    const names = [];
+    for (const rel of files) {
+      const src = read(rel);
+      const re = /registerTool\(\s*\{\s*name:\s*['"]([^'"]+)['"]/g;
+      let m;
+      while ((m = re.exec(src)) !== null) {
+        names.push(m[1]);
+      }
+    }
+    return names;
+  }
+
+  it('MCP exposes every tool the Pi extension registers (names match exactly)', () => {
+    const piToolNames = piRegisteredToolNames();
+    expect(piToolNames.length, 'found no registerTool names in Pi extension source').toBeGreaterThan(0);
     for (const name of piToolNames) {
-      expect(mcpNames.has(name), `MCP missing tool "${name}" present in Pi extension`).toBe(true);
+      expect(mcpNames.has(name), `MCP missing tool "${name}" registered in Pi extension`).toBe(true);
     }
   });
 
-  it('MCP memory_code mode list matches the enum in code-tools.ts', () => {
+  it('MCP memory-code mode list matches the enum in code-tools.ts', () => {
     const codeToolsSrc = read('extensions/memory-layer/tools/code-tools.ts');
     // Extract the enum array from: enum: [ 'search', 'callers', ... ]
     const enumMatch = codeToolsSrc.match(/mode:\s*Type\.Optional\([\s\S]*?enum:\s*\[([\s\S]*?)\]/);
@@ -57,7 +65,7 @@ describe('MCP ↔ Pi extension tool parity', () => {
     expect([...piModes].sort()).toEqual([...mcpModes].sort());
   });
 
-  it('MCP memory_doc mode list matches the enum in doc-tools.ts', () => {
+  it('MCP memory-doc mode list matches the enum in doc-tools.ts', () => {
     const docToolsSrc = read('extensions/memory-layer/tools/doc-tools.ts');
     const enumMatch = docToolsSrc.match(/mode:\s*Type\.Optional\([\s\S]*?enum:\s*\[([\s\S]*?)\]/);
     expect(enumMatch, 'could not find mode enum in doc-tools.ts').not.toBeNull();

--- a/test/mcp-tools-catalog.test.js
+++ b/test/mcp-tools-catalog.test.js
@@ -1,0 +1,105 @@
+// Parity guard: the MCP catalog must mirror the Pi extension's tool surface.
+// Parses the TS source statically (no TS compiler needed) so a drift between
+// Extensions/memory-layer/tools/*.ts and src/mcp/tools.js fails loudly here
+// Before it ships.
+//
+// This test exists because the two adapters are intentionally separate code
+// Paths (Pi uses registerTool+renderResult; MCP uses raw JSON schemas). If
+// Someone adds a tool/mode to one adapter and forgets the other, this catches
+// It. Pattern follows test/memory-client-dispatch.test.ts (static source-text
+// Regression test). Uses vitest globals — no import needed.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+describe('MCP ↔ Pi extension tool parity', () => {
+  const { tools, CODE_MODE_TO_COMMAND, DOC_MODE_TO_COMMAND } = require('../src/mcp/tools');
+  const mcpNames = new Set(tools.map((t) => t.name));
+
+  it('MCP exposes every tool the Pi extension registers', () => {
+    // Tool names registered in extensions/memory-layer/tools/*.ts via pi.registerTool.
+    // Sourced from memory-tools.ts, code-tools.ts, doc-tools.ts.
+    // If the Pi extension gains a registerTool call, add it here — that's the point.
+    const piToolNames = [
+      'memory_save',
+      'memory_search',
+      'memory_get',
+      'memory_update',
+      'memory_delete',
+      'memory_related',
+      'memory_load_context',
+      'memory_sync_code_trust',
+      'index_status',
+      'memory_code', // Code-tools.ts
+      'memory_doc', // Doc-tools.ts
+    ];
+    for (const name of piToolNames) {
+      expect(mcpNames.has(name), `MCP missing tool "${name}" present in Pi extension`).toBe(true);
+    }
+  });
+
+  it('MCP memory_code mode list matches the enum in code-tools.ts', () => {
+    const codeToolsSrc = read('extensions/memory-layer/tools/code-tools.ts');
+    // Extract the enum array from: enum: [ 'search', 'callers', ... ]
+    const enumMatch = codeToolsSrc.match(/mode:\s*Type\.Optional\([\s\S]*?enum:\s*\[([\s\S]*?)\]/);
+    expect(enumMatch, 'could not find mode enum in code-tools.ts').not.toBeNull();
+    const piModes = enumMatch[1]
+      .split(',')
+      .map((s) => s.trim().replace(/['"`]/g, ''))
+      .filter(Boolean);
+    const mcpModes = Object.keys(CODE_MODE_TO_COMMAND);
+    expect([...piModes].sort()).toEqual([...mcpModes].sort());
+  });
+
+  it('MCP memory_doc mode list matches the enum in doc-tools.ts', () => {
+    const docToolsSrc = read('extensions/memory-layer/tools/doc-tools.ts');
+    const enumMatch = docToolsSrc.match(/mode:\s*Type\.Optional\([\s\S]*?enum:\s*\[([\s\S]*?)\]/);
+    expect(enumMatch, 'could not find mode enum in doc-tools.ts').not.toBeNull();
+    const piModes = enumMatch[1]
+      .split(',')
+      .map((s) => s.trim().replace(/['"`]/g, ''))
+      .filter(Boolean);
+    const mcpModes = Object.keys(DOC_MODE_TO_COMMAND);
+    expect([...piModes].sort()).toEqual([...mcpModes].sort());
+  });
+
+  it('every MCP code mode maps to the same command as code-tools.ts cmdMap', () => {
+    const codeToolsSrc = read('extensions/memory-layer/tools/code-tools.ts');
+    // Extract cmdMap entries: search: 'search-code', and 'blast-radius': 'blast-radius',
+    const cmdMapBlock = codeToolsSrc.match(/const cmdMap[^{]*\{([\s\S]*?)\};/);
+    expect(cmdMapBlock, 'could not find cmdMap in code-tools.ts').not.toBeNull();
+    const piMap = {};
+    // Match both bare (search:) and quoted ('blast-radius':) keys.
+    const entryRe = /['"]?([a-z-]+)['"]?\s*:\s*['"]([a-z-]+)['"]/g;
+    let m;
+    while ((m = entryRe.exec(cmdMapBlock[1])) !== null) {
+      piMap[m[1]] = m[2];
+    }
+    for (const [mode, cmd] of Object.entries(CODE_MODE_TO_COMMAND)) {
+      expect(piMap[mode], `Pi cmdMap missing mode "${mode}"`).toBeDefined();
+      expect(piMap[mode], `mode "${mode}" diverges: MCP=${cmd} Pi=${piMap[mode]}`).toBe(cmd);
+    }
+  });
+
+  it('every MCP doc mode maps to the same command as doc-tools.ts cmdMap', () => {
+    const docToolsSrc = read('extensions/memory-layer/tools/doc-tools.ts');
+    const cmdMapBlock = docToolsSrc.match(/const cmdMap[^{]*\{([\s\S]*?)\};/);
+    expect(cmdMapBlock, 'could not find cmdMap in doc-tools.ts').not.toBeNull();
+    const piMap = {};
+    const entryRe = /['"]?([a-z-]+)['"]?\s*:\s*['"]([a-z-]+)['"]/g;
+    let m;
+    while ((m = entryRe.exec(cmdMapBlock[1])) !== null) {
+      piMap[m[1]] = m[2];
+    }
+    for (const [mode, cmd] of Object.entries(DOC_MODE_TO_COMMAND)) {
+      expect(piMap[mode], `Pi cmdMap missing mode "${mode}"`).toBeDefined();
+      expect(piMap[mode], `mode "${mode}" diverges: MCP=${cmd} Pi=${piMap[mode]}`).toBe(cmd);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `lapis mcp` — a Model Context Protocol server that exposes the LaPis memory engine to any MCP client (Claude Desktop, Cursor, VS Code, etc.). LaPis is now usable from MCP hosts **and** Pi, with the Pi extension remaining the primary, first-class integration.

## Why

LaPis already had a transport-agnostic core: `src/cli/gateway.js:dispatch(cmd, args)` is pure JSON-in/JSON-out with no Pi coupling (the module comment explicitly forbids it). This PR adds MCP as a **second adapter** alongside the Pi extension, calling the same `dispatch` the Pi extension uses — zero business-logic duplication.

The natural boundary: MCP gets the **tool surface only**. The Pi extension keeps everything MCP has no concept of — hooks (auto-context-injection, passive capture, guardrails, trust sync, dream cycle), TUI rendering, and session lifecycle.

## How

- `src/mcp/server.js` — stdio MCP server using the SDK's low-level `Server` class (accepts raw JSON schemas, no Zod dependency). A thin adapter: tool calls → `gateway.dispatch()` → MCP `CallToolResult`.
- `src/mcp/tools.js` — tool catalog mirroring the 9 Pi extension tools. Reuses the exact `mode → command` mappings from `extensions/memory-layer/tools/code-tools.ts` and `doc-tools.ts`.
- `src/mcp/translate-result.js` — normalizes `dispatch()` output into MCP shape; strips leading TUI icons, truncates huge payloads.
- `cli.js` — 5-line `mcp` branch right after `serve` (identical pattern).
- `package.json` — adds `@modelcontextprotocol/sdk` + `lapis-mcp` bin alias.

Project scoping uses `process.cwd()`, matching the Pi extension's `state.currentProject`.

## Tool surface (mirrors Pi extension)

| Tool | Dispatches |
|---|---|
| `memory-save` | `save` |
| `memory-search` | `search` |
| `memory-get` | `get` |
| `memory-update` | `update` |
| `memory-delete` | `delete` |
| `memory-related` | `related` |
| `memory-load-context` | `context` |
| `memory-code` | 25 code modes (search, callers, outline, dead-code, index-repo, …) |
| `memory-doc` | 12 doc modes (search, outline, backlinks, index-docs, …) |
| `memory-sync-code-trust` | `sync-code-trust` |
| `index-status` | `index-status` |

## Usage

```json
{
  "mcpServers": {
    "lapis": {
      "command": "npx",
      "args": ["-y", "@genegulanesjr/lapis", "mcp"]
    }
  }
}
```

## Verification

- ✅ Full suite: **97 files / 1524 tests** passing
- ✅ New MCP tests: **46 tests** (catalog sanity, result translation, end-to-end via `InMemoryTransport`, parity guard against Pi extension TS source)
- ✅ `oxlint` 0 warnings / 0 errors; `oxfmt` clean
- ✅ Stdio smoke test: `initialize` → `tools/list` → `save` → `search` → `delete` round-trip confirmed

The parity test (`test/mcp-tools-catalog.test.js`) parses the Pi extension's `.ts` source and fails loudly if someone adds a tool/mode to one adapter but not the other.

## Out of scope (deliberately)

- **No hooks** — MCP has no host-hook concept. Pi-only features stay Pi-only.
- **No TUI rendering** — MCP clients render results themselves.
- **No streaming progress for indexing** — MCP tool calls are request/response. Can add `notifications/progress` later if needed.
