### PR TITLE
fix(memory): self-heal stale cached project key from path-resolved repo

### DIFF
--- a/extensions/memory-layer/hooks/context-injection.ts
+++ b/extensions/memory-layer/hooks/context-injection.ts
@@ -102,6 +102,19 @@ export function registerBeforeAgentStart(pi: ExtensionAPI, deps: ContextDeps) {
       repos.find((r) => r.name.toLowerCase() === deps.state.currentProject?.toLowerCase());
     const isStale = cwdRepo ? deps.isRepoStale(cwdRepo) : false;
 
+    // Self-heal a stale cached project key. `state.currentProject` is set once at
+    // session_start and never refreshed; `cwdRepo` above is resolved fresh each
+    // turn by path-prefix match against code_repos.path. When a repo is renamed in
+    // code_repos mid-session (or the session started under a parent dir that was a
+    // stale knownProjects basename match — see detectProject fallback), the cached
+    // key and the path-resolved truth diverge. Trust the path match: without this,
+    // every memory saved for the rest of the session silently lands in the wrong
+    // project bucket, and the banner reports the stale key while the code-index
+    // line already shows the corrected name.
+    if (cwdRepo && cwdRepo.name.toLowerCase() !== (deps.state.currentProject || '').toLowerCase()) {
+      deps.state.currentProject = cwdRepo.name;
+    }
+
     const isNewProject = crossProjectResult !== null && !projectContext;
     let effectiveObservations: any[] = [];
     if (promptQuery) {


### PR DESCRIPTION
## Summary

`state.currentProject` is set once at `session_start` and never refreshed for the lifetime of the session. `buildContextBlock` already resolves the authoritative repo **fresh each turn** by path-prefix match against `code_repos.path` (`cwdRepo`), but only uses that fresh name for the `Code index:` line — the `Project:` line and all downstream memory saves still use the stale cached key. When the two diverge mid-session, every memory saved for the rest of the session silently lands in the wrong project bucket.

## The bug

`extensions/memory-layer/hooks/session-lifecycle.ts:36`:
```ts
pi.on('session_start', async (event, ctx) => {
  deps.state.currentProject = await deps.detectProject(ctx.cwd);  // set once, never re-derived
```

`extensions/memory-layer/hooks/context-injection.ts` already computes the fresh truth each turn:
```ts
const cwdRepo =
  repos.find((r) => resolvedCwd.startsWith(path.resolve(r.path))) ||    // path-prefix match — authoritative
  repos.find((r) => r.name.toLowerCase() === deps.state.currentProject?.toLowerCase());
...
lines.push(`Project: **${deps.state.currentProject}** | ...`);           // ← stale cached key
lines.push(`- Code index: \`${cwdRepo.name}\` ...`);                     // ← fresh name (diverges!)
```

## When it triggers

Two observed cases (both happened to me this week in a multi-shell setup with ~10 Pi shells across different repos):

1. **Repo renamed in `code_repos` mid-session.** I had netcrawl registered under name `work`, migrated it to `netcrawl` via `UPDATE code_repos SET name='netcrawl'`. Every Pi shell that was already running continued to save memories to `work` for the rest of its session — even though the next-turn `Code index:` line immediately read `netcrawl`. The cached key never self-healed, causing a quiet stream of cross-bucket contamination that I had to clean up after the fact.

2. **`detectProject` basename-walk fallback mis-resolves at session start.** When a session starts in a cwd that isn't a registered `code_repos.path`, `detectProject` walks up the tree basename-matching `knownProjects`. If a parent directory name happens to equal a known project key (e.g. repo under `/Users/jrimmer/work/*` where `work` was a registered project key from an unrelated repo), the session caches the wrong key for its entire lifetime — with no path-trigger to correct it, since the basename walk doesn't re-run either. Registering the correct repo later in the session doesn't help until restart.

## Symptoms

- The `## Memory Context (auto-loaded)` banner's `Project:` field shows a stale key while the `Code index:` field already shows the corrected name — a visible inconsistency in the same block.
- `memory-save` calls during the session write to the stale project bucket, producing invisible memories (they don't surface in searches scoped to the correct project).
- Requires manual cleanup migrations on the DB to reattribute the leaked memories.

## The fix

Trust the path-resolved `cwdRepo.name` when it differs from the cached key — it was already computed fresh this turn by an exact path-prefix match:

```ts
if (cwdRepo && cwdRepo.name.toLowerCase() !== (deps.state.currentProject || '').toLowerCase()) {
  deps.state.currentProject = cwdRepo.name;
}
```

Inserted right after `cwdRepo`/`isStale` are resolved, before the `Project:` line is emitted. The `|| ''` guard mirrors the existing `?.toLowerCase()` defensiveness against a null `currentProject` in the `cwdRepo` fallback on the line above.

## Why this is safe

- `cwdRepo` is the result of `resolvedCwd.startsWith(path.resolve(r.path))` — an exact path-prefix match against a registered repo's canonical path. This is strictly more authoritative than the session-start basename-walk heuristic, which `detectProject` itself only uses as a fallback.
- The self-heal is gated on `cwdRepo` being truthy, so it never fires for sessions in unregistered directories (those keep whatever `detectProject` cached at start).
- It does not change `session_log` rows or re-fetch stats within the same turn — only corrects the in-memory key so that (a) the banner's `Project:` line is accurate and (b) subsequent `memory-save`/lookup calls in the same turn use the right project. Stats counts catch up on the next turn.
- No behavioral change when keys already agree (the common case).

## Alternatives considered

- **Re-run `detectProject` every turn** — heavier (a DB round-trip + tree walk per turn) and not needed; `cwdRepo` is already the fresh authoritative answer for the registered-repo case, which is the only case that diverges in a way that matters for memory bucketing.

- **Just surface the mismatch in the banner** (diagnostic only) — leaves the data-integrity bug in place; memories still leak into the stale bucket. The self-heal is strictly better and uses data that's already computed.

- **Refresh `state.currentProject` at every `cwd` change** — requires a new hook into Pi's cwd-change events, which is a larger surface and not extension-side. This fix is local to the existing context-injection path.

## Testing

Validated the failure mode end-to-end against the live DB before patching (found and reattributed ~5,100 leaked `work`-scoped observations). After this patch, a session that started with a stale cached key will self-heal on the next turn's context injection rather than leaking for the rest of the session.

Locally the change transpiles cleanly (no local TS toolchain to run the full `oxlint`/`tsc` suite); happy to add a unit test in `extensions/memory-layer/hooks/__tests__/context-injection.test.ts` if the maintainers can point me at the test harness conventions — the test would assert that when `getKnownRepos()` returns a repo matching `ctx.cwd` whose `name` differs from a pre-seeded `state.currentProject`, the function mutates `state.currentProject` to `cwdRepo.name` before returning.