### PR TITLE
fix(cli): report only missing args in save; add --help/-h

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ const obsDA = require('./data-access/observations');
 
 const fs = require('fs');
 
-const { buildCommandMap, ANALYSIS_TOOLS, _wrapAnalysis } = require('./src/cli/gateway');
+const { buildCommandMap, getAllUsage, ANALYSIS_TOOLS, _wrapAnalysis } = require('./src/cli/gateway');
 const { createRepositories } = require('./src/platform/storage/repositories');
 
 const TOOL_TIERS = {
@@ -89,6 +89,32 @@ const commands = buildCommandMap({
 
 const args = parseArgs(process.argv);
 const cmd = process.argv[2];
+
+function printHelp(targetCmd) {
+  const usage = getAllUsage();
+  if (targetCmd && usage[targetCmd] !== undefined) {
+    const spec = usage[targetCmd];
+    process.stdout.write(`Usage: lapis ${targetCmd}${spec ? ` ${spec}` : ''}\n`);
+    return;
+  }
+  if (targetCmd) {
+    process.stdout.write(`Usage: lapis ${targetCmd} [options]\n`);
+    return;
+  }
+  const subcommands = [...Object.keys(commands), 'run'].sort();
+  process.stdout.write(
+    `Usage: lapis <subcommand> [--option value ...]\n` +
+      `       lapis run [--raw] [--text] [--remember] <command...>\n` +
+      `Subcommands: ${subcommands.join(', ')}\n`,
+  );
+}
+
+const isHelpRequest = cmd === 'help' || cmd === '--help' || cmd === '-h' || args.help === true || args._.includes('-h');
+
+if (isHelpRequest) {
+  printHelp(commands[cmd] ? cmd : null);
+  process.exit(0);
+}
 
 (async () => {
   if (cmd === 'serve') {

--- a/src/cli/commands/memory.js
+++ b/src/cli/commands/memory.js
@@ -2,7 +2,23 @@ const obsCmd = require('../../../commands/observation');
 const searchCmd = require('../../../commands/search');
 const codeSearchService = require('../../../services/code-search');
 
-const USAGE = {};
+const USAGE = {
+  save: '--title <title> --content <content> [--type TYPE] [--project NAME] [--scope SCOPE] [--topic-key KEY] [--force] [--expires-in DUR] [--session-id ID]',
+  get: '--id ID',
+  update:
+    '--id ID [--title T] [--content C] [--type T] [--project P] [--scope S] [--topic-key K] [--expires-in DUR] [--expires-at TS] [--clear-expiry]',
+  delete: '--id ID [--hard]',
+  timeline: '--id ID [--before N] [--after N]',
+  search: '--query <text> [--project NAME] [--type TYPE] [--limit N] [--repo NAME]',
+  context: '--query <text> [--project NAME] [--limit N] [--deep]',
+  'suggest-topic-key': '[--title T] [--content C]',
+  'save-prompt': '--content <text> [--project NAME] [--session-id ID]',
+  'capture-passive': '--content <text>',
+  stats: '',
+  'check-dup': '--title T [--type TYPE] [--project NAME] [--topic-key KEY]',
+  'mark-dup': '--source ID --target ID [--confidence N]',
+  'log-negative-recall': '--entries <json-array>',
+};
 
 function register(commands, deps) {
   const { sqlJson, sqlRun, sqlRaw, jsonErrNoExit, repositories } = deps;

--- a/src/cli/commands/memory.js
+++ b/src/cli/commands/memory.js
@@ -9,8 +9,9 @@ const USAGE = {
     '--id ID [--title T] [--content C] [--type T] [--project P] [--scope S] [--topic-key K] [--expires-in DUR] [--expires-at TS] [--clear-expiry]',
   delete: '--id ID [--hard]',
   timeline: '--id ID [--before N] [--after N]',
-  search: '--query <text> [--project NAME] [--type TYPE] [--limit N] [--repo NAME]',
-  context: '--query <text> [--project NAME] [--limit N] [--deep]',
+  search: '--query <text> [--project NAME] [--type TYPE] [--scope SCOPE] [--limit N]',
+  context:
+    '--query <text> [--project NAME] [--limit N] [--token-budget N] [--session-id ID] [--topic-key KEY] [--deep] [--all-projects]',
   'suggest-topic-key': '[--title T] [--content C]',
   'save-prompt': '--content <text> [--project NAME] [--session-id ID]',
   'capture-passive': '--content <text>',

--- a/src/memory-domain/observations.js
+++ b/src/memory-domain/observations.js
@@ -30,8 +30,11 @@ function save(deps, args) {
     }
   }
 
-  if (!title || !content) {
-    return jsonErrNoExit('Missing --title and --content');
+  const missing = [];
+  if (!title) missing.push('--title');
+  if (!content) missing.push('--content');
+  if (missing.length > 0) {
+    return jsonErrNoExit(`Missing ${missing.join(' and ')}`);
   }
 
   if (!force) {

--- a/test/gateway-dispatch.test.js
+++ b/test/gateway-dispatch.test.js
@@ -61,7 +61,15 @@ describe('dashboard CLI command router', () => {
     // verify the integration by calling the function with controlled deps.
     const dashboardRouter = require('../src/cli/commands/dashboard');
     const mockGetDashboard = vi.fn(() => ({
-      overview: { totalMemories: 5, totalProjects: 1, thisWeekSaved: 1, thisWeekCleaned: 0, avgTrust: 0.9, neverRecalled: 0, expiringSoon: 0 },
+      overview: {
+        totalMemories: 5,
+        totalProjects: 1,
+        thisWeekSaved: 1,
+        thisWeekCleaned: 0,
+        avgTrust: 0.9,
+        neverRecalled: 0,
+        expiringSoon: 0,
+      },
       byType: [],
       trust: { avg: 0.9, lowTrustCount: 0, distribution: { high: 5, medium: 0, low: 0, none: 0 } },
       recall: { totalRecalls: 10, usefulRate: 0.8, uniqueMemoriesHit: 5 },
@@ -81,5 +89,15 @@ describe('dashboard CLI command router', () => {
     expect(typeof commands.dashboard).toBe('function');
     // The actual getDashboard call will use the real implementation,
     // but we just verify the router registered successfully
+  });
+});
+
+describe('gateway getAllUsage', () => {
+  it('should expose usage entries for memory commands including save', () => {
+    const { getAllUsage } = require('../src/cli/gateway');
+    const usage = getAllUsage();
+    expect(usage.save).toBeDefined();
+    expect(usage.save).toContain('--title');
+    expect(usage.save).toContain('--content');
   });
 });

--- a/test/services-observations.test.js
+++ b/test/services-observations.test.js
@@ -45,6 +45,7 @@ describe('services/observations', () => {
       };
       const result = obsService.save(deps, { content: 'hello' });
       expect(result.error).toContain('title');
+      expect(result.error).not.toContain('content');
     });
 
     it('should return error when content is missing', () => {
@@ -58,6 +59,20 @@ describe('services/observations', () => {
       };
       const result = obsService.save(deps, { title: 'hello' });
       expect(result.error).toContain('content');
+      expect(result.error).not.toContain('title');
+    });
+
+    it('should report both --title and --content when both are missing', () => {
+      const deps = {
+        jsonErrNoExit: vi.fn((msg) => ({ error: msg })),
+        insertObservation: vi.fn(),
+        insertObservationRelation: vi.fn(),
+        softDeleteObservation: vi.fn(),
+        checkDuplicate: vi.fn(),
+        findLatestSession: vi.fn(),
+      };
+      const result = obsService.save(deps, {});
+      expect(result.error).toBe('Missing --title and --content');
     });
 
     it('should insert observation when valid and no duplicates', () => {

--- a/test/smoke-cli.js
+++ b/test/smoke-cli.js
@@ -98,11 +98,16 @@ function run(cmd, opts = {}) {
 
 console.log('\nSmoke CLI Tests\n');
 
-// --- Group 1: Help output (exits 1, that's normal for --help) ---
+// --- Group 1: Help output (--help exits 0 and prints usage to stdout) ---
 console.log('Help output:');
 smokeTest('--help lists subcommands', `${CLI} --help`, {
-  expectExit0: false,
   expectContains: 'Subcommands:',
+});
+smokeTest('save --help prints save usage', `${CLI} save --help`, {
+  expectContains: 'Usage: lapis save',
+});
+smokeTest('save -h prints save usage', `${CLI} save -h`, {
+  expectContains: '--title',
 });
 
 // Verify key subcommands are listed
@@ -115,7 +120,7 @@ const helpOutput = (() => {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
   } catch (e) {
-    // --help exits 1 but outputs text to stderr
+    // Fallback: capture from combined streams if exit code differs
     return (e.stdout || '') + (e.stderr || '');
   }
 })();


### PR DESCRIPTION
Closes #202

## Summary

- **Accurate missing-arg message**: `save` previously reported both `--title and --content` as missing even when only one was absent. It now lists only the actually-missing flag(s) (`Missing --title`, `Missing --content`, or `Missing --title and --content` when both are gone).
- **`--help`/`-h` support**: added centralized help handling that applies to every subcommand. `<cmd> --help` / `<cmd> -h` prints the command's usage to stdout and exits 0 (no DB required); a bare `lapis --help`/`-h`/`help` prints the top-level subcommand list.
- **Populated `USAGE`** for all memory subcommands (it was an empty map), so `save` and its peers surface real flag documentation via `getAllUsage`.

## Changes

- `src/memory-domain/observations.js` — build the missing-arg list dynamically instead of a hard-coded combined message.
- `cli.js` — `printHelp()` + early `--help`/`-h`/`help` short-circuit before `ensureDb()`.
- `src/cli/commands/memory.js` — fill the previously empty `USAGE` map.

## Tests

- `test/services-observations.test.js` — strengthened the two existing `save` validation cases and added a both-missing case.
- `test/gateway-dispatch.test.js` — assert `getAllUsage()` exposes `save` with `--title`/`--content`.
- `test/smoke-cli.js` — added `save --help` / `save -h` smoke checks and updated the existing `--help` expectation (it now exits 0 to stdout instead of exit 1 to stderr).

## Verification

- `npx vitest run test/services-observations.test.js` → 18 passed
- `npx vitest run test/gateway-dispatch.test.js` → all pass except one **pre-existing, environment-dependent** test (`gateway dispatch > unknown command`) that requires the `better-sqlite3` native binary; it fails identically on the unmodified baseline in this sandbox (no `make` toolchain) and is unrelated to this change.
- `node test/smoke-cli.js` → help section passes (incl. new `save --help`/`save -h`); DB-dependent cases need the native SQLite backend to build.
- `npx oxlint` → 0 errors on changed files; `npx oxfmt --check` → clean.