### PR TITLE
fix(memory-ttl): make 1m expiry deterministic at 30 days

### DIFF
--- a/src/memory-domain/ttl.js
+++ b/src/memory-domain/ttl.js
@@ -23,7 +23,11 @@ function parseExpiresIn(duration) {
   } else if (unit === 'w') {
     now.setUTCDate(now.getUTCDate() + n * 7);
   } else if (unit === 'm') {
-    now.setUTCMonth(now.getUTCMonth() + n);
+    // Fixed 30-day month. Calendar-month arithmetic (setUTCMonth) varies 28-31
+    // Days by month, making expiry non-deterministic (e.g. 1m set on Jul 1
+    // Expired in 31 days). A TTL unit should be deterministic, matching the
+    // Documented "1m = 30 days" contract (see test/memory-ttl.test.js).
+    now.setUTCDate(now.getUTCDate() + n * 30);
   } else {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes a **date-dependent CI failure** in `test/memory-ttl.test.js` that started failing on **Jul 1** (and would recur every 1st of a 31-day month).

`parseExpiresIn('1m')` used calendar-month arithmetic (`setUTCMonth`), which varies 28–31 days by month. The test asserts the documented contract **`1m = 30 days`** (bounds `29.5–30.5`):
- Jun 30 → Jul 30 = 30 days ✓ (why CI was green)
- Jul 1 → Aug 1 = 31 days ✗ (the failure)

## Fix

Switch the `m` unit to a **fixed 30-day period** (`setUTCDate(now + n*30)`). This:
- Matches the test's documented `1m = 30 days` contract.
- Makes TTL expiry **deterministic year-round** (calendar months are a poor TTL choice precisely because of this non-determinism).

One-line behavioral change, isolated to `src/memory-domain/ttl.js` (+5/−1).

## Test plan

- [x] `npx vitest run test/memory-ttl.test.js` — 22/22 pass, including `parses months (1m = 30 days)` on Jul 1.
- [x] `oxlint` — 0 errors, 0 new warnings (2 pre-existing `prefer-named-capture-group` on the unchanged line-9 regex).
- [x] `oxfmt --check` — clean.

> Note: this is unrelated to PR #214 (hooks-engine). Once merged to `main`, #214's CI will go green again (its red run today is caused solely by this date flake, not by the refactor).