### PR TITLE
feat(claude-code): bridge core — state-store + hook router + lifecycle handlers (#207)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -133,6 +133,13 @@ if (isHelpRequest) {
     return;
   }
 
+  if (cmd === 'claude-code') {
+    // Claude Code hooks bridge. runHook owns ensureDb() internally.
+    const { runHook } = require('./src/claude-code/hooks');
+    await runHook(process.argv.slice(3)); // ['hook', '<event>']
+    return;
+  }
+
   if (cmd === 'run') {
     ensureDb();
     const { executeAndCompress, formatTextOutput } = require('./src/cli/commands/token-saver');

--- a/src/claude-code/context-inject.js
+++ b/src/claude-code/context-inject.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Claude Code bridge: shared context-injection routine.
+ *
+ * Renders the memory-context block, mirroring the pure core of
+ * extensions/memory-layer/hooks/context-injection.ts:48-219 but adapted to the
+ * Claude Code transport (injected dispatch + getKnownRepos, no Pi ExtensionAPI).
+ *
+ * Used by session-start (no prompt) and user-prompt-submit (prompt-qualified).
+ * assembleContextLines returns the UNCAPPED lines array + the resolved cwdRepo
+ * so user-prompt-submit can append preflight/coding-context before capping;
+ * buildInjectedContext is the capped convenience wrapper for session-start.
+ */
+
+const path = require('node:path');
+const { CONTEXT } = require('../../constants');
+const { buildContextBlock, capInjectedContext, appendExtensionHint } = require('../hooks-engine/context-builder');
+const { findMatchingRepo } = require('../hooks-engine/project');
+
+/**
+ * Fetch project context, falling back to cross-project if empty.
+ * Returns { contextResult, crossProjectResult } (each may be null on failure).
+ */
+async function fetchContext({ dispatch, project, limit, query, sessionId }) {
+  const baseArgs = {
+    project,
+    limit: String(limit),
+    'token-budget': String(CONTEXT.TOKEN_BUDGET_DEFAULT || 2000),
+    ...(sessionId ? { 'session-id': String(sessionId) } : {}),
+    ...(query ? { query } : {}),
+  };
+
+  const contextResult = await dispatch('context', baseArgs);
+  if (contextResult && !contextResult.error) {
+    return { contextResult, crossProjectResult: null };
+  }
+
+  const crossProjectResult = await dispatch('context', {
+    'all-projects': 'true',
+    limit: String(CONTEXT.PROJECT_SUMMARY_LIMIT),
+    'token-budget': String(CONTEXT.TOKEN_BUDGET_DEFAULT || 2000),
+    ...(sessionId ? { 'session-id': String(sessionId) } : {}),
+  });
+  return { contextResult: null, crossProjectResult };
+}
+
+/**
+ * Assemble the memory-context lines (UNCAPPED) + the matched cwd repo.
+ * @returns {Promise<{lines: string[], cwdRepo: object|null} | null>}
+ */
+async function assembleContextLines({ dispatch, getKnownRepos, project, cwd, query = null, sessionId = null }) {
+  const limit = query ? CONTEXT.PROMPT_RELEVANT_LIMIT : CONTEXT.PROJECT_SUMMARY_LIMIT;
+  const { contextResult, crossProjectResult } = await fetchContext({
+    dispatch,
+    project,
+    limit,
+    query,
+    sessionId,
+  });
+
+  if (!contextResult && !crossProjectResult) {
+    return null;
+  }
+
+  const effectiveContext = contextResult || crossProjectResult;
+  const isNewProject = crossProjectResult !== null && !contextResult;
+
+  const observations = (effectiveContext.observations || []).filter(Boolean);
+  const personal = (effectiveContext.personal || []).filter(Boolean);
+  const stats = effectiveContext.stats || {};
+  const topic = effectiveContext.topic || null;
+
+  // Staleness check is deferred to Phase 2's best-effort posture.
+  const repos = getKnownRepos();
+  const resolvedCwd = path.resolve(cwd);
+  const cwdRepo = findMatchingRepo(resolvedCwd, repos);
+  const isStale = false;
+
+  let effectiveObservations = [];
+  if (query) {
+    effectiveObservations = isNewProject ? crossProjectResult.observations || [] : observations;
+  }
+  const effectiveStats = isNewProject ? crossProjectResult.stats || {} : stats;
+
+  const lines = buildContextBlock({
+    promptQuery: query,
+    currentProject: project,
+    projectDir: cwdRepo?.path || cwd,
+    cwdRepo,
+    isStale,
+    isNewProject,
+    observations,
+    effectiveObservations,
+    personal,
+    stats,
+    effectiveStats,
+    topic,
+    crossProjectSuggestions: effectiveContext.cross_project_suggestions || [],
+  });
+
+  if (!cwdRepo) {
+    lines.push('');
+    lines.push(
+      `⚠️ **Code not indexed:** Project "${project}" has no code index yet. Index it first: \`memory-code index-repo --path ${cwd} --name ${project}\``,
+    );
+  }
+
+  appendExtensionHint(lines, cwd);
+  return { lines, cwdRepo };
+}
+
+/** Capped convenience wrapper returning the final markdown string (or null). */
+async function buildInjectedContext(opts) {
+  const assembled = await assembleContextLines(opts).catch(() => null);
+  if (!assembled) {
+    return null;
+  }
+  return capInjectedContext(assembled.lines.join('\n'));
+}
+
+module.exports = { assembleContextLines, buildInjectedContext, fetchContext };

--- a/src/claude-code/dispatch-client.js
+++ b/src/claude-code/dispatch-client.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * Claude Code bridge: dispatch-client (direct mode).
+ *
+ * The single module owning process/DB access so the lifecycle handlers stay
+ * transport-agnostic and unit-testable with a fake dispatch. Phase 2 ships
+ * "direct" mode only — a lazy require of the in-process gateway (same seam as
+ * src/mcp/server.js:49 and extensions/.../host/memory-client.ts:17). Daemon
+ * mode (POST /dispatch) is Phase 5.
+ *
+ * Handlers receive a `dispatch` (writes) and the two read helpers below. In
+ * tests both can be stubbed; nothing here touches the real DB unless invoked.
+ */
+
+/**
+ * Coerce an args bag into the string-only record the gateway expects.
+ * Mirrors host/memory-client.ts:33-39 (skip undefined/null/'').
+ */
+function stringifyArgs(args) {
+  const out = {};
+  for (const [k, v] of Object.entries(args || {})) {
+    if (v !== undefined && v !== null && v !== '') {
+      out[k] = String(v);
+    }
+  }
+  return out;
+}
+
+let _dispatch = null;
+
+/**
+ * Direct (in-process) dispatch. Lazily loads the gateway so a fake dispatch in
+ * tests never requires the DB.
+ */
+function dispatch(cmd, args) {
+  if (!_dispatch) {
+    // Resolve relative to this file: claude-code/ → src/ → src/cli/gateway
+    _dispatch = require('../cli/gateway').dispatch;
+  }
+  return _dispatch(cmd, stringifyArgs(args));
+}
+
+/**
+ * DB-derived count of observations saved under a session. Used by session-end
+ * instead of the fragile in-process counter (issue #207). Best-effort: returns
+ * 0 if the DB/session can't be read.
+ */
+function countSessionMemories(sessionId) {
+  if (sessionId === undefined || sessionId === null || sessionId === '') {
+    return 0;
+  }
+  try {
+    const { getDb } = require('../../db');
+    const row = getDb().prepare('SELECT COUNT(*) AS n FROM observations WHERE session_id = ?').get(sessionId);
+    return Number(row?.n) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Known indexed code repos, for cwd-repo resolution + preflight gating.
+ * Mirrors extensions/.../host/project-detector.ts getKnownRepos(). Best-effort.
+ */
+function getKnownRepos() {
+  try {
+    const { sqlJson } = require('../../db');
+    return sqlJson('SELECT name, path, indexed_at FROM code_repos') || [];
+  } catch {
+    return [];
+  }
+}
+
+module.exports = { dispatch, countSessionMemories, getKnownRepos, stringifyArgs };

--- a/src/claude-code/handlers/session-end.js
+++ b/src/claude-code/handlers/session-end.js
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Claude Code SessionEnd handler.
+ *
+ * Awaited (Claude Code awaits SessionEnd before exit). Reads the transcript
+ * via transcript-reader, builds a session summary, then runs `session-summary`
+ * + `session-end`. The memory count passed to session-end is DB-derived
+ * (SELECT COUNT(*) FROM observations WHERE session_id = ?), NOT the fragile
+ * in-process counter, per #207. Clears the state file on the way out.
+ *
+ * Mirrors extensions/.../hooks/session-lifecycle.ts registerSessionShutdown.
+ */
+
+const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const { buildSessionSummary } = require('../../hooks-engine/session-summary');
+const { readTranscript } = require('../hooks-engine/transcript-reader');
+
+async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore }) {
+  const cwd = resolveCwd(payload.cwd);
+  const project = projectFromCwd(cwd);
+  const claudeSessionId = payload.session_id;
+
+  const state = stateStore.loadState(claudeSessionId);
+
+  // No session ever started (e.g. SessionStart failed) — nothing to close.
+  if (state.sessionId === null || state.sessionId === undefined) {
+    stateStore.clearState(claudeSessionId);
+    return null;
+  }
+
+  const transcript = readTranscript(payload.transcript_path);
+
+  const summaryContent = buildSessionSummary({
+    userMessages: transcript.userMessages,
+    assistantCount: transcript.assistantMessageCount,
+    turnCount: state.turnCount,
+    memoriesSaved: state.memoriesSavedThisSession,
+    editedFiles: state.editedFiles,
+    cwd,
+  });
+
+  // DB-derived count, not the in-process counter (issue #207).
+  const memories = dispatchClient.countSessionMemories(state.sessionId);
+
+  try {
+    await dispatch('session-summary', { content: summaryContent, project });
+    await dispatch('session-end', {
+      id: String(state.sessionId),
+      memories: String(memories),
+      auto: 'true',
+    });
+  } catch (e) {
+    // Best-effort on shutdown; never throw out of the handler. Still clear state.
+    process.stderr.write(`claude-code session-end failed: ${e instanceof Error ? e.message : String(e)}\n`);
+  }
+
+  stateStore.clearState(claudeSessionId);
+  return null; // silent — no stdout for SessionEnd
+}
+
+module.exports = { handleSessionEnd };

--- a/src/claude-code/handlers/session-start.js
+++ b/src/claude-code/handlers/session-start.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Claude Code SessionStart handler.
+ *
+ * Branches on the payload `source` field (startup|resume|clear vs compact):
+ *  - startup|resume|clear → sweep stale state files, call `session-start`,
+ *    store the returned numeric sessionId, then inject context.
+ *  - compact → do NOT call `session-start` (would INSERT a spurious row);
+ *    reuse the stored sessionId and re-inject context only.
+ *
+ * Mirrors extensions/.../hooks/session-lifecycle.ts registerSessionStart +
+ * registerSessionCompact.
+ */
+
+const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const { buildInjectedContext } = require('../context-inject');
+
+/**
+ * Run SessionStart.
+ *
+ * @param {object} ctx
+ * @param {object} ctx.payload           stdin JSON: { session_id, source, cwd, ... }
+ * @param {Function} ctx.dispatch        injected dispatch (direct mode)
+ * @param {Function} ctx.getKnownRepos   known code repos (direct mode read)
+ * @param {object} ctx.stateStore        { loadState, saveState, sweepStaleSessions }
+ * @returns {Promise<object|null>}       Claude Code JSON or null
+ */
+async function handleSessionStart({ payload, dispatch, getKnownRepos, stateStore }) {
+  const source = payload.source || 'startup';
+  const cwd = resolveCwd(payload.cwd);
+  const project = projectFromCwd(cwd);
+  const claudeSessionId = payload.session_id;
+
+  let state = stateStore.loadState(claudeSessionId);
+
+  // compact re-uses the existing sessionId and skips session-start entirely.
+  const isCompact = source === 'compact';
+
+  if (!isCompact) {
+    // GC orphaned state files from force-killed sessions before starting fresh.
+    try {
+      stateStore.sweepStaleSessions(24);
+    } catch {
+      // GC is best-effort.
+    }
+
+    // Reset session-derived counters for a genuine start.
+    state = {
+      ...stateStore.defaultState(),
+      nativeChecked: state.nativeChecked,
+    };
+    state.currentProject = project;
+    state.turnCount = 0;
+    state.lastMemoryToolCall = 0;
+    state.lastAutoDecisionSave = 0;
+    state.dreamTriggeredThisSession = false;
+    state.hasInjectedContext = false;
+    state.editedFiles = [];
+    state.exploredFiles = [];
+
+    const result = await dispatch('session-start', { project });
+    if (result && result.sessionId !== undefined) {
+      state.sessionId = result.sessionId;
+      state.projectSessionCount = result.sessionCount || 0;
+    }
+    // Orphan recovery is automatic server-side; surface only if returned.
+    stateStore.saveState(claudeSessionId, state);
+  }
+
+  // Inject (or re-inject after compact) context. sessionId may be null on a
+  // failed session-start; context still loads without a session binding.
+  const additionalContext = await buildInjectedContext({
+    dispatch,
+    getKnownRepos,
+    project,
+    cwd,
+    query: null,
+    sessionId: state.sessionId,
+  }).catch(() => null);
+
+  if (!additionalContext) {
+    return null;
+  }
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext,
+    },
+  };
+}
+
+module.exports = { handleSessionStart };

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * Claude Code Stop handler.
+ *
+ * SILENT + ASYNC-ONLY. Emits no stdout (returns null) so Claude Code does not
+ * continue the turn / loop. Ports passive-capture.ts message_end + turn_end:
+ * passive-capture on the last assistant message, progress checkpoint at
+ * turn % 10, dream at turn 50, negative-recall flush. All fire-and-forget.
+ *
+ * Defensive: if payload.stop_hook_active is truthy, return immediately to avoid
+ * re-entrancy loops.
+ */
+
+const path = require('node:path');
+const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
+const { shouldAutoCapture } = require('../../hooks-engine/pattern-matcher');
+const {
+  buildAutoDecisionPayload,
+  shouldCheckpoint,
+  shouldDream,
+  isAutoDecisionCoolingDown,
+} = require('../../hooks-engine/passive-capture');
+
+// Thresholds mirror extensions/memory-layer/state.ts (CHECKPOINT_INTERVAL /
+// AUTO_DECISION_COOLDOWN) and the hooks-engine passive-capture defaults.
+const CHECKPOINT_EVERY = 10;
+const COOLDOWN_MS = 60000;
+
+function extractLastAssistantText(payload) {
+  const msg = payload?.last_assistant_message || payload?.assistant_message;
+  const text = extractMessageText(msg);
+  return typeof text === 'string' && text.trim() ? text : '';
+}
+
+/**
+ * Passive-capture an auto-decision from the last assistant message.
+ */
+async function passiveCapture({ dispatch, text, project, sessionId, state, now }) {
+  if (!text || text.length < 100) {
+    return;
+  }
+  if (isAutoDecisionCoolingDown(state.lastAutoDecisionSave, now, COOLDOWN_MS)) {
+    return;
+  }
+  if (text.includes('memory-save') || text.includes('memory-search') || text.includes('memory-get')) {
+    return;
+  }
+
+  const capture = shouldAutoCapture(text);
+  const payload = buildAutoDecisionPayload({ text, capture, project, sessionId: state.sessionId });
+  if (payload) {
+    state.lastAutoDecisionSave = now;
+    await dispatch('save', payload);
+  }
+}
+
+/**
+ * Progress checkpoint at turn % CHECKPOINT_INTERVAL.
+ */
+async function checkpoint({ dispatch, state, project }) {
+  if (!project) {
+    return;
+  }
+
+  const summaryFiles = state.editedFiles
+    .slice(0, 10)
+    .map((f) => `- ${path.basename(f)}`)
+    .join('\n');
+
+  let auditNote = '';
+  try {
+    const editedPaths = state.editedFiles.slice(0, 20);
+    if (editedPaths.length > 0) {
+      const auditResult = await dispatch('audit-diff', {
+        repo: project,
+        files: editedPaths.join(','),
+        task: `checkpoint turn ${state.turnCount}`,
+      });
+      if (auditResult && !auditResult.error && auditResult.violations?.length > 0) {
+        auditNote = `\n\n**Post-edit audit**: ${auditResult.risk} risk, ${auditResult.violations.length} violation(s): ${auditResult.violations
+          .slice(0, 3)
+          .map((v) => v.message)
+          .join('; ')}`;
+      }
+    }
+  } catch {
+    // audit-diff is optional.
+  }
+
+  await dispatch('save', {
+    title: `Progress checkpoint (turn ${state.turnCount})`,
+    type: 'progress',
+    project,
+    scope: 'project',
+    force: 'true',
+    content: [
+      `**What**: Auto-checkpoint at turn ${state.turnCount}`,
+      `**Where**: Session ${state.sessionId}`,
+      `**Learned**: ${state.memoriesSavedThisSession} explicit memories saved, ${state.editedFiles.length} files edited`,
+      summaryFiles ? `Files touched:\n${summaryFiles}` : '',
+      auditNote,
+    ].join('\n'),
+  });
+}
+
+/**
+ * Flush pending negative-recall feedback.
+ */
+async function flushNegativeRecall({ dispatch, state }) {
+  if (!state.pendingRecallFeedback || state.pendingRecallFeedback.length === 0) {
+    return;
+  }
+  const entries = state.pendingRecallFeedback.map(([memoryId, meta]) => ({
+    memoryId,
+    sessionId: meta?.sessionId,
+    query: meta?.query,
+    wasUseful: false,
+  }));
+  await dispatch('log-negative-recall', { entries: JSON.stringify(entries) });
+  state.pendingRecallFeedback = [];
+}
+
+async function handleStop({ payload, dispatch, stateStore }) {
+  // Avoid re-entrancy: Claude Code sets stop_hook_active when already inside a
+  // stop continuation. Bail out so we never create a feedback loop.
+  if (payload?.stop_hook_active) {
+    return null;
+  }
+
+  const cwd = resolveCwd(payload.cwd);
+  const project = projectFromCwd(cwd);
+  const claudeSessionId = payload.session_id;
+
+  const state = stateStore.loadState(claudeSessionId);
+  state.turnCount += 1;
+  const now = Date.now();
+
+  const lastText = extractLastAssistantText(payload);
+
+  // All capture work is fire-and-forget: Stop must not block Claude Code.
+  // Exposed as runStopCapture for deterministic testing.
+  void runStopCapture({ dispatch, stateStore, claudeSessionId, state, project, now, lastText }).catch(() => {});
+
+  return null; // silent — no stdout, no turn continuation
+}
+
+/**
+ * The awaited capture work. handleStop runs this fire-and-forget so the host
+ * never blocks on it; tests call it directly to assert dispatch behavior.
+ */
+async function runStopCapture({ dispatch, stateStore, claudeSessionId, state, project, now, lastText }) {
+  try {
+    await passiveCapture({ dispatch, text: lastText, project, state, now });
+
+    if (shouldDream(state.turnCount, state.dreamTriggeredThisSession)) {
+      state.dreamTriggeredThisSession = true;
+      try {
+        await dispatch('dream', {});
+      } catch {
+        // Auto-dream is best-effort.
+      }
+    }
+
+    await flushNegativeRecall({ dispatch, state });
+
+    if (shouldCheckpoint(state.turnCount, CHECKPOINT_EVERY)) {
+      await checkpoint({ dispatch, state, project });
+    }
+
+    stateStore.saveState(claudeSessionId, state);
+  } catch {
+    // Never throw out of a Stop handler; persist best-effort.
+    try {
+      stateStore.saveState(claudeSessionId, state);
+    } catch {}
+  }
+}
+
+module.exports = { handleStop, runStopCapture };

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -16,7 +16,7 @@ const path = require('node:path');
 const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
 const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
 const { shouldAutoCapture } = require('../../hooks-engine/pattern-matcher');
-const { readTranscript } = require('../hooks-engine/transcript-reader');
+const { readTranscriptStream } = require('../hooks-engine/transcript-reader');
 const {
   buildAutoDecisionPayload,
   shouldCheckpoint,
@@ -29,20 +29,33 @@ const {
 const CHECKPOINT_EVERY = 10;
 const COOLDOWN_MS = 60000;
 
-function extractLastAssistantText(payload) {
+function extractInlineAssistantText(payload) {
   // Preferred inline field (#207). Newer Claude Code builds may ship the last
-  // assistant message directly; older builds only send transcript_path.
+  // assistant message directly; older builds only send transcript_path, which
+  // is resolved asynchronously inside runStopCapture (see resolveAssistantText)
+  // so the file read never blocks handleStop's synchronous return.
   const inline = payload?.last_assistant_message || payload?.assistant_message;
   const inlineText = extractMessageText(inline);
   if (typeof inlineText === 'string' && inlineText.trim()) {
     return inlineText;
   }
+  return '';
+}
 
-  // Fallback: read the transcript for the last assistant message. Best-effort;
-  // readTranscript returns lastAssistantText=null on any read failure.
-  if (payload?.transcript_path) {
+/**
+ * Resolve the last assistant message text for capture. The inline payload
+ * field is read synchronously (cheap); only when it is absent does this read
+ * the transcript_path via the async streaming reader. Called from runStopCapture
+ * (the fire-and-forget async path) so any file I/O happens after handleStop has
+ * already returned and Claude Code can proceed with its turn.
+ */
+async function resolveAssistantText(lastText, transcriptPath) {
+  if (typeof lastText === 'string' && lastText.trim()) {
+    return lastText;
+  }
+  if (transcriptPath) {
     try {
-      const { lastAssistantText } = readTranscript(payload.transcript_path);
+      const { lastAssistantText } = await readTranscriptStream(transcriptPath);
       if (typeof lastAssistantText === 'string' && lastAssistantText.trim()) {
         return lastAssistantText;
       }
@@ -156,11 +169,23 @@ async function handleStop({ payload, dispatch, stateStore }) {
   state.turnCount += 1;
   const now = Date.now();
 
-  const lastText = extractLastAssistantText(payload);
+  // Only the cheap inline field read happens synchronously; the transcript
+  // fallback (async stream read) runs inside runStopCapture, after we return, so
+  // Stop never blocks Claude Code's turn progression.
+  const lastText = extractInlineAssistantText(payload);
 
   // All capture work is fire-and-forget: Stop must not block Claude Code.
   // Exposed as runStopCapture for deterministic testing.
-  void runStopCapture({ dispatch, stateStore, claudeSessionId, state, project, now, lastText }).catch(() => {});
+  void runStopCapture({
+    dispatch,
+    stateStore,
+    claudeSessionId,
+    state,
+    project,
+    now,
+    lastText,
+    transcriptPath: payload?.transcript_path,
+  }).catch(() => {});
 
   return null; // silent — no stdout, no turn continuation
 }
@@ -169,9 +194,21 @@ async function handleStop({ payload, dispatch, stateStore }) {
  * The awaited capture work. handleStop runs this fire-and-forget so the host
  * never blocks on it; tests call it directly to assert dispatch behavior.
  */
-async function runStopCapture({ dispatch, stateStore, claudeSessionId, state, project, now, lastText }) {
+async function runStopCapture({
+  dispatch,
+  stateStore,
+  claudeSessionId,
+  state,
+  project,
+  now,
+  lastText,
+  transcriptPath,
+}) {
   try {
-    await passiveCapture({ dispatch, text: lastText, project, state, now });
+    // Transcript fallback is resolved here (async stream read), off the
+    // synchronous hook path; passive capture uses the resulting text.
+    const text = await resolveAssistantText(lastText, transcriptPath);
+    await passiveCapture({ dispatch, text, project, state, now });
 
     if (shouldDream(state.turnCount, state.dreamTriggeredThisSession)) {
       state.dreamTriggeredThisSession = true;

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -16,6 +16,7 @@ const path = require('node:path');
 const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
 const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
 const { shouldAutoCapture } = require('../../hooks-engine/pattern-matcher');
+const { readTranscript } = require('../hooks-engine/transcript-reader');
 const {
   buildAutoDecisionPayload,
   shouldCheckpoint,
@@ -29,9 +30,27 @@ const CHECKPOINT_EVERY = 10;
 const COOLDOWN_MS = 60000;
 
 function extractLastAssistantText(payload) {
-  const msg = payload?.last_assistant_message || payload?.assistant_message;
-  const text = extractMessageText(msg);
-  return typeof text === 'string' && text.trim() ? text : '';
+  // Preferred inline field (#207). Newer Claude Code builds may ship the last
+  // assistant message directly; older builds only send transcript_path.
+  const inline = payload?.last_assistant_message || payload?.assistant_message;
+  const inlineText = extractMessageText(inline);
+  if (typeof inlineText === 'string' && inlineText.trim()) {
+    return inlineText;
+  }
+
+  // Fallback: read the transcript for the last assistant message. Best-effort;
+  // readTranscript returns lastAssistantText=null on any read failure.
+  if (payload?.transcript_path) {
+    try {
+      const { lastAssistantText } = readTranscript(payload.transcript_path);
+      if (typeof lastAssistantText === 'string' && lastAssistantText.trim()) {
+        return lastAssistantText;
+      }
+    } catch {
+      // Transcript read is best-effort.
+    }
+  }
+  return '';
 }
 
 /**

--- a/src/claude-code/handlers/user-prompt-submit.js
+++ b/src/claude-code/handlers/user-prompt-submit.js
@@ -1,0 +1,131 @@
+'use strict';
+
+/**
+ * Claude Code UserPromptSubmit handler.
+ *
+ * Builds prompt-matched context + (when preflight-worthy) preflight/coding
+ * context (best-effort, timeout-safe), then appends the cadence-gated memory
+ * reminder (parity with Pi's context-event reminder, moved here per #207).
+ * Passes the stored numeric sessionId as `session-id` to context.
+ *
+ * 30s overall budget: the whole dispatch sequence is raced against a timeout
+ * that resolves with whatever context was gathered so far rather than
+ * rejecting — best-effort, never blocks the prompt.
+ */
+
+const path = require('node:path');
+const { CONTEXT } = require('../../../constants');
+const { resolveCwd, projectFromCwd, findMatchingRepo } = require('../../hooks-engine/project');
+const { isPreflightWorthyPrompt } = require('../../hooks-engine/prompt-classifiers');
+const {
+  appendPreflightBlock,
+  chooseCodingContextTarget,
+  appendCodingContextBlock,
+  unwrapAnalysisData,
+} = require('../../hooks-engine/preflight-assembly');
+const { capInjectedContext } = require('../../hooks-engine/context-builder');
+const { assembleContextLines } = require('../context-inject');
+
+const BUDGET_MS = 30000;
+const REMINDER_INTERVAL = 5; // MEMORY_REMINDER_INTERVAL (state.ts:107)
+const REMINDER_RECENT_MS = 180000; // 3min (context-injection.ts:235)
+const REMINDER_TEXT =
+  '💡 Memory reminder: Use `memory-search` before decisions to avoid repeating past mistakes. Use `memory-save` for decisions, bugfixes, and discoveries.';
+
+function timeout(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Append preflight + coding-context blocks (best-effort). Mutates lines.
+ */
+async function appendPreflight({ lines, dispatch, cwdRepo, prompt }) {
+  if (!cwdRepo || !isPreflightWorthyPrompt(prompt)) {
+    return;
+  }
+
+  try {
+    const preflightResult = await dispatch('preflight', {
+      repo: cwdRepo.name,
+      task: prompt,
+      'code-limit': String(CONTEXT.PREFLIGHT_CODE_LIMIT || 3),
+      'memory-limit': String(CONTEXT.PREFLIGHT_MEMORY_LIMIT || 2),
+      'doc-limit': String(CONTEXT.PREFLIGHT_DOC_LIMIT || 1),
+    });
+    if (preflightResult && !preflightResult.error) {
+      appendPreflightBlock(lines, preflightResult);
+    }
+
+    const target = chooseCodingContextTarget(prompt, preflightResult);
+    if (target) {
+      const codingContextResult = await dispatch('coding-context', {
+        repo: cwdRepo.name,
+        ...target,
+        depth: '2',
+        top: '5',
+      });
+      if (codingContextResult && !codingContextResult.error) {
+        appendCodingContextBlock(lines, unwrapAnalysisData(codingContextResult));
+      }
+    }
+  } catch {
+    // Preflight/coding-context is best-effort; never block context injection.
+  }
+}
+
+async function run({ payload, dispatch, getKnownRepos, stateStore }) {
+  const prompt = payload.prompt || '';
+  const cwd = resolveCwd(payload.cwd);
+  const project = projectFromCwd(cwd);
+  const claudeSessionId = payload.session_id;
+
+  const state = stateStore.loadState(claudeSessionId);
+  const sessionId = state.sessionId;
+
+  const assembled = await assembleContextLines({
+    dispatch,
+    getKnownRepos,
+    project,
+    cwd,
+    query: prompt,
+    sessionId,
+  }).catch(() => null);
+
+  const lines = assembled ? assembled.lines : [];
+  const cwdRepo = assembled ? assembled.cwdRepo : findMatchingRepo(path.resolve(cwd), getKnownRepos());
+
+  // Preflight / coding context (best-effort, timeout-safe).
+  await appendPreflight({ lines, dispatch, cwdRepo, prompt });
+
+  // Cadence-gated reminder (parity of Pi's context-event reminder).
+  state.callsSinceLastMemory += 1;
+  const recentMemory = Date.now() - state.lastMemoryToolCall < REMINDER_RECENT_MS;
+  if (state.callsSinceLastMemory >= REMINDER_INTERVAL && !recentMemory) {
+    state.callsSinceLastMemory = 0;
+    lines.push('');
+    lines.push(REMINDER_TEXT);
+  }
+
+  state.hasInjectedContext = true;
+  stateStore.saveState(claudeSessionId, state);
+
+  const additionalContext = capInjectedContext(lines.join('\n'));
+  if (!additionalContext) {
+    return null;
+  }
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext,
+    },
+  };
+}
+
+async function handleUserPromptSubmit(ctx) {
+  // Race against the 30s budget; on timeout return whatever was produced so
+  // the prompt is never blocked.
+  return Promise.race([run(ctx).catch(() => null), timeout(BUDGET_MS).then(() => null)]);
+}
+
+module.exports = { handleUserPromptSubmit, REMINDER_INTERVAL, REMINDER_RECENT_MS, BUDGET_MS };

--- a/src/claude-code/handlers/user-prompt-submit.js
+++ b/src/claude-code/handlers/user-prompt-submit.js
@@ -32,10 +32,6 @@ const REMINDER_RECENT_MS = 180000; // 3min (context-injection.ts:235)
 const REMINDER_TEXT =
   '💡 Memory reminder: Use `memory-search` before decisions to avoid repeating past mistakes. Use `memory-save` for decisions, bugfixes, and discoveries.';
 
-function timeout(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /**
  * Append preflight + coding-context blocks (best-effort). Mutates lines.
  */
@@ -124,8 +120,20 @@ async function run({ payload, dispatch, getKnownRepos, stateStore }) {
 
 async function handleUserPromptSubmit(ctx) {
   // Race against the 30s budget; on timeout return whatever was produced so
-  // the prompt is never blocked.
-  return Promise.race([run(ctx).catch(() => null), timeout(BUDGET_MS).then(() => null)]);
+  // the prompt is never blocked. The timer is cleared when run() settles so the
+  // hook process exits immediately on the fast path — otherwise the dangling
+  // timer keeps Node's event loop (and thus Claude Code) alive for the full budget.
+  let timer;
+  try {
+    return await Promise.race([
+      run(ctx).catch(() => null),
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve(null), BUDGET_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 module.exports = { handleUserPromptSubmit, REMINDER_INTERVAL, REMINDER_RECENT_MS, BUDGET_MS };

--- a/src/claude-code/hooks-engine/transcript-reader.js
+++ b/src/claude-code/hooks-engine/transcript-reader.js
@@ -1,0 +1,128 @@
+'use strict';
+
+/**
+ * Claude Code bridge: transcript reader.
+ *
+ * Claude Code has no sessionManager.getEntries(); SessionEnd hands us a
+ * `transcript_path` pointing at a .jsonl file of entries. This module parses
+ * it into the shape session-summary.js consumes: { userMessages,
+ * assistantMessageCount, lastAssistantText }.
+ *
+ * Streaming + tolerant: unknown/partial line shapes and malformed JSON lines
+ * are skipped, never thrown.
+ */
+
+const fs = require('node:fs');
+const readline = require('node:readline');
+const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
+
+/**
+ * Parse a single transcript line into an entry object, or null if it isn't a
+ * usable record. Tolerant of malformed JSON and non-object shapes.
+ */
+function parseTranscriptLine(line) {
+  if (!line || typeof line !== 'string') {
+    return null;
+  }
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+  let obj;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') {
+    return null;
+  }
+  return obj;
+}
+
+/**
+ * Reduce a parsed entry into the transcript summary accumulator. Mutates acc.
+ */
+function classifyEntry(entry, acc) {
+  // Claude Code transcript entries are typically { type: 'user'|'assistant',
+  // message: { role, content } } but may also carry role at the top level.
+  const message = entry.message || null;
+  const role = message?.role || entry.role;
+  if (!role) {
+    return;
+  }
+
+  if (role === 'user') {
+    const text = extractMessageText(message);
+    if (text && text.trim()) {
+      acc.userMessages.push({ message });
+    }
+    return;
+  }
+
+  if (role === 'assistant') {
+    acc.assistantMessageCount++;
+    const text = extractMessageText(message);
+    if (text && text.trim()) {
+      acc.lastAssistantText = text;
+    }
+  }
+}
+
+/**
+ * Read a Claude Code transcript_path (.jsonl) into a summary shape.
+ *
+ * @param {string} transcriptPath
+ * @returns {{ userMessages: Array, assistantMessageCount: number, lastAssistantText: string|null }}
+ */
+function readTranscript(transcriptPath) {
+  const acc = { userMessages: [], assistantMessageCount: 0, lastAssistantText: null };
+  if (!transcriptPath) {
+    return acc;
+  }
+
+  let raw;
+  try {
+    raw = fs.readFileSync(transcriptPath, 'utf8');
+  } catch {
+    return acc;
+  }
+
+  for (const line of raw.split(/\r?\n/)) {
+    const entry = parseTranscriptLine(line);
+    if (entry) {
+      classifyEntry(entry, acc);
+    }
+  }
+
+  return acc;
+}
+
+/**
+ * Streaming variant for large transcripts. Reads line-by-line via readline.
+ * Resolves with the same summary shape as readTranscript.
+ */
+async function readTranscriptStream(transcriptPath) {
+  const acc = { userMessages: [], assistantMessageCount: 0, lastAssistantText: null };
+  if (!transcriptPath) {
+    return acc;
+  }
+
+  let stream;
+  try {
+    stream = fs.createReadStream(transcriptPath, { encoding: 'utf8' });
+  } catch {
+    return acc;
+  }
+
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  for await (const line of rl) {
+    const entry = parseTranscriptLine(line);
+    if (entry) {
+      classifyEntry(entry, acc);
+    }
+  }
+  return acc;
+}
+
+module.exports = { readTranscript, readTranscriptStream, parseTranscriptLine, classifyEntry };

--- a/src/claude-code/hooks.js
+++ b/src/claude-code/hooks.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * Claude Code hooks bridge — top-level router.
+ *
+ * `lapis claude-code hook <event>` reads a JSON payload from stdin, dispatches
+ * the matching lifecycle handler, and writes the Claude Code JSON decision to
+ * stdout. Mirrors the transport-adapter boundary discipline of src/mcp/server.js:
+ *   - owns ensureDb()
+ *   - stdout carries ONLY the JSON decision
+ *   - all diagnostics → stderr
+ *   - hooks fail open (a crash logs to stderr + exits 0, never blocks Claude Code)
+ *
+ * Phase 2 wires the high-value lifecycle only: SessionStart, UserPromptSubmit,
+ * Stop, SessionEnd. PreToolUse / PostToolUse guardrails are Phase 3.
+ */
+
+const { stripTuiArtifacts } = require('../mcp/translate-result');
+const dispatchClient = require('./dispatch-client');
+const stateStore = require('./state-store');
+const { handleSessionStart } = require('./handlers/session-start');
+const { handleUserPromptSubmit } = require('./handlers/user-prompt-submit');
+const { handleStop } = require('./handlers/stop');
+const { handleSessionEnd } = require('./handlers/session-end');
+
+const HANDLERS = {
+  SessionStart: handleSessionStart,
+  UserPromptSubmit: handleUserPromptSubmit,
+  Stop: handleStop,
+  SessionEnd: handleSessionEnd,
+};
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    // Claude Code closes stdin after the payload; if stdin is a TTY (manual
+    // run with no pipe) resolve immediately with an empty payload.
+    if (process.stdin.isTTY) {
+      resolve('');
+    }
+  });
+}
+
+/** Strip TUI artifacts from any string fields in the output envelope. */
+function sanitizeOutput(output) {
+  if (!output || typeof output !== 'object') {
+    return output;
+  }
+  const hso = output.hookSpecificOutput;
+  if (hso && typeof hso.additionalContext === 'string') {
+    hso.additionalContext = stripTuiArtifacts(hso.additionalContext);
+  }
+  return output;
+}
+
+/**
+ * Run a hook. argv is the slice AFTER `claude-code`, e.g. ['hook', 'SessionStart'].
+ */
+async function runHook(argv, opts = {}) {
+  const subcommand = argv[0];
+  const event = argv[1];
+
+  if (subcommand !== 'hook' || !event) {
+    process.stderr.write('Usage: lapis claude-code hook <event>\n');
+    process.exitCode = process.exitCode || 2;
+    return;
+  }
+
+  // Parse stdin payload (best-effort; malformed → empty object).
+  const raw = opts.stdin !== undefined ? opts.stdin : await readStdin();
+  let payload = {};
+  if (raw && raw.trim()) {
+    try {
+      payload = JSON.parse(raw);
+    } catch (e) {
+      process.stderr.write(`claude-code: invalid stdin JSON: ${e instanceof Error ? e.message : String(e)}\n`);
+    }
+  }
+
+  // Event name precedence: explicit argv > payload.hook_event_name.
+  const resolvedEvent = event || payload.hook_event_name;
+  const handler = HANDLERS[resolvedEvent];
+
+  if (!handler) {
+    // Unknown/unwired event (e.g. PreToolUse in Phase 2): no-op, never crash.
+    return;
+  }
+
+  const dispatch = opts.dispatch || dispatchClient.dispatch;
+  const getKnownRepos = opts.getKnownRepos || dispatchClient.getKnownRepos;
+
+  // ensureDb once — mirrors src/mcp/server.js:118-130.
+  if (opts.ensureDb !== false) {
+    try {
+      require('../../db').ensureDb();
+    } catch (e) {
+      process.stderr.write(
+        `claude-code: database initialization failed: ${e instanceof Error ? e.message : String(e)}\n`,
+      );
+      process.exitCode = process.exitCode || 1;
+      return;
+    }
+  }
+
+  let output;
+  try {
+    output = await handler({ payload, dispatch, dispatchClient, getKnownRepos, stateStore });
+  } catch (e) {
+    // Hooks must fail open: log to stderr, do NOT set a non-zero exit.
+    process.stderr.write(`claude-code ${resolvedEvent} handler error: ${e instanceof Error ? e.message : String(e)}\n`);
+    return;
+  }
+
+  if (output !== null && output !== undefined) {
+    process.stdout.write(`${JSON.stringify(sanitizeOutput(output))}\n`);
+  }
+}
+
+module.exports = { runHook, HANDLERS, sanitizeOutput };

--- a/src/claude-code/state-store.js
+++ b/src/claude-code/state-store.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Claude Code bridge: per-session state store.
+ *
+ * Claude Code spawns a fresh process per hook event, so the in-process `state`
+ * object the Pi extension mutates is invisible across hook invocations. This
+ * module persists the SAME field set as extensions/memory-layer/state.ts to
+ * ~/.pi/memory/claude-sessions/<claude_session_id>.json and reads it back on
+ * the next hook.
+ *
+ * Concurrency: each hook is its own process, so reads may be stale relative to
+ * a concurrent hook. loadState merges onto defaults so newer fields never
+ * crash older state files, and a corrupt file degrades to defaults.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const HOME = process.env.HOME || process.env.USERPROFILE || os.homedir();
+const DEFAULT_DIR = path.join(HOME, '.pi', 'memory', 'claude-sessions');
+
+// Field set mirrors extensions/memory-layer/state.ts (session-relevant subset;
+// caches like cachedRepos/compressionStats are intentionally excluded).
+function defaultState() {
+  return {
+    sessionId: null,
+    currentProject: null,
+    projectSessionCount: 0,
+    memoriesSavedThisSession: 0,
+    editedFiles: [],
+    exploredFiles: [],
+    turnCount: 0,
+    dreamTriggeredThisSession: false,
+    lastMemoryToolCall: 0,
+    callsSinceLastMemory: 0,
+    lastAutoDecisionSave: 0,
+    hasInjectedContext: false,
+    pendingRecallFeedback: [],
+    nativeChecked: false,
+  };
+}
+
+function resolveDir(opts) {
+  return opts?.dir || DEFAULT_DIR;
+}
+
+function statePath(sessionId, opts) {
+  const safe = String(sessionId).replace(/[^\w.-]/g, '_');
+  return path.join(resolveDir(opts), `${safe}.json`);
+}
+
+/**
+ * Load + normalize a stored state. Returns defaults for missing/corrupt files,
+ * merged onto the current default set so forward-compatible fields are filled.
+ */
+function loadState(sessionId, opts) {
+  let raw;
+  try {
+    raw = fs.readFileSync(statePath(sessionId, opts), 'utf8');
+  } catch {
+    return defaultState();
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return defaultState();
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return defaultState();
+  }
+
+  // Merge onto defaults so any newly-added field is present.
+  return { ...defaultState(), ...parsed };
+}
+
+/**
+ * Atomic write: temp file + rename. read-modify-write callers should loadState
+ * first, mutate, then saveState.
+ */
+function saveState(sessionId, state, opts) {
+  const dir = resolveDir(opts);
+  fs.mkdirSync(dir, { recursive: true });
+  const finalPath = statePath(sessionId, opts);
+  const tmpPath = `${finalPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 0), 'utf8');
+  fs.renameSync(tmpPath, finalPath);
+}
+
+/** Unlink the state file; idempotent on ENOENT. */
+function clearState(sessionId, opts) {
+  try {
+    fs.unlinkSync(statePath(sessionId, opts));
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Sweep state files older than maxAgeHours (from force-killed Claude processes
+ * that never reached SessionEnd). Called on SessionStart. Best-effort: never
+ * throws — a GC failure must not block a session start.
+ */
+function sweepStaleSessions(maxAgeHours = 24, opts) {
+  const dir = resolveDir(opts);
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return { swept: 0 };
+  }
+
+  const cutoff = Date.now() - maxAgeHours * 3600 * 1000;
+  let swept = 0;
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) {
+      continue;
+    }
+    const full = path.join(dir, entry);
+    try {
+      const stat = fs.statSync(full);
+      if (stat.mtimeMs < cutoff) {
+        fs.unlinkSync(full);
+        swept++;
+      }
+    } catch {
+      // Skip unreadable / already-removed files.
+    }
+  }
+  return { swept };
+}
+
+module.exports = {
+  defaultState,
+  loadState,
+  saveState,
+  clearState,
+  sweepStaleSessions,
+  DEFAULT_DIR,
+};

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -1,0 +1,437 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const realStateStore = require('../../src/claude-code/state-store');
+const { handleSessionStart } = require('../../src/claude-code/handlers/session-start');
+const { handleUserPromptSubmit } = require('../../src/claude-code/handlers/user-prompt-submit');
+const { handleStop, runStopCapture } = require('../../src/claude-code/handlers/stop');
+const { handleSessionEnd } = require('../../src/claude-code/handlers/session-end');
+const { runHook } = require('../../src/claude-code/hooks');
+
+// ---- fakes ----
+
+function makeFakeDispatch(overrides = {}) {
+  const calls = [];
+  const dispatch = async (cmd, args) => {
+    calls.push({ cmd, args });
+    if (overrides[cmd]) {
+      return overrides[cmd](args, calls);
+    }
+    return { ok: true };
+  };
+  return { dispatch, calls };
+}
+
+function makeStateStore() {
+  const map = new Map();
+  return {
+    defaultState: realStateStore.defaultState,
+    loadState: (id) => map.get(id) || realStateStore.defaultState(),
+    saveState: (id, s) => {
+      map.set(id, s);
+    },
+    clearState: (id) => {
+      map.delete(id);
+    },
+    sweepStaleSessions: () => ({ swept: 0 }),
+    // test-only inspection
+    _peek: (id) => map.get(id),
+  };
+}
+
+const EMPTY_CONTEXT = { observations: [], personal: [], stats: { total_memories: 0, total_personal: 0 } };
+
+function hasCall(calls, cmd, predicate) {
+  return calls.some((c) => c.cmd === cmd && (!predicate || predicate(c.args)));
+}
+
+// =====================================================================
+// SessionStart
+// =====================================================================
+
+describe('claude-code handlers: SessionStart', () => {
+  test('startup calls session-start, stores the numeric sessionId, injects context', async () => {
+    const { dispatch, calls } = makeFakeDispatch({
+      'session-start': () => ({ sessionId: 99, sessionCount: 4 }),
+      context: () => EMPTY_CONTEXT,
+    });
+    const stateStore = makeStateStore();
+
+    const out = await handleSessionStart({
+      payload: { session_id: 'claude-1', source: 'startup', cwd: '/proj/myapp' },
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore,
+    });
+
+    expect(hasCall(calls, 'session-start')).toBe(true);
+    expect(stateStore._peek('claude-1').sessionId).toBe(99);
+    expect(stateStore._peek('claude-1').projectSessionCount).toBe(4);
+    expect(out.hookSpecificOutput.hookEventName).toBe('SessionStart');
+    expect(out.hookSpecificOutput.additionalContext).toContain('Memory Context');
+  });
+
+  test('resume and clear also call session-start', async () => {
+    for (const source of ['resume', 'clear']) {
+      const { dispatch, calls } = makeFakeDispatch({
+        'session-start': () => ({ sessionId: 1, sessionCount: 0 }),
+        context: () => EMPTY_CONTEXT,
+      });
+      await handleSessionStart({
+        payload: { session_id: `c-${source}`, source, cwd: '/p' },
+        dispatch,
+        getKnownRepos: () => [],
+        stateStore: makeStateStore(),
+      });
+      expect(hasCall(calls, 'session-start')).toBe(true);
+    }
+  });
+
+  test('compact does NOT call session-start (asserts dispatch call list)', async () => {
+    // Pre-seed a stored numeric sessionId from a prior startup.
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-2', { ...realStateStore.defaultState(), sessionId: 77 });
+
+    const { dispatch, calls } = makeFakeDispatch({ context: () => EMPTY_CONTEXT });
+
+    const out = await handleSessionStart({
+      payload: { session_id: 'claude-2', source: 'compact', cwd: '/p' },
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore,
+    });
+
+    expect(hasCall(calls, 'session-start')).toBe(false); // the key assertion
+    // re-uses the stored sessionId for context
+    expect(hasCall(calls, 'context', (a) => a['session-id'] === '77')).toBe(true);
+    expect(out.hookSpecificOutput.hookEventName).toBe('SessionStart');
+  });
+
+  test('startup passes the stored numeric sessionId as session-id to context', async () => {
+    const { dispatch, calls } = makeFakeDispatch({
+      'session-start': () => ({ sessionId: 55, sessionCount: 0 }),
+      context: () => EMPTY_CONTEXT,
+    });
+    await handleSessionStart({
+      payload: { session_id: 'claude-3', source: 'startup', cwd: '/p' },
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore: makeStateStore(),
+    });
+    expect(hasCall(calls, 'context', (a) => a['session-id'] === '55')).toBe(true);
+  });
+});
+
+// =====================================================================
+// UserPromptSubmit
+// =====================================================================
+
+describe('claude-code handlers: UserPromptSubmit', () => {
+  test('passes stored numeric sessionId as session-id to context', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-4', { ...realStateStore.defaultState(), sessionId: 123 });
+    const { dispatch, calls } = makeFakeDispatch({ context: () => EMPTY_CONTEXT });
+
+    await handleUserPromptSubmit({
+      payload: { session_id: 'claude-4', prompt: 'refactor the dispatch module', cwd: '/p' },
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore,
+    });
+
+    expect(hasCall(calls, 'context', (a) => a['session-id'] === '123' && a.query)).toBe(true);
+  });
+
+  test('preflight fires for a preflight-worthy prompt when an indexed repo exists', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-5', { ...realStateStore.defaultState(), sessionId: 1 });
+    const { dispatch, calls } = makeFakeDispatch({
+      context: () => EMPTY_CONTEXT,
+      preflight: () => ({ likely_existing_code: [{ symbol: 'foo', file: 'a.js', line: 3 }], risk: 'low' }),
+      'coding-context': () => ({ data: { target: { symbol: 'foo' } } }),
+    });
+    const repo = { name: 'myapp', path: '/p', indexed_at: new Date().toISOString() };
+
+    await handleUserPromptSubmit({
+      payload: { session_id: 'claude-5', prompt: 'implement the login feature', cwd: '/p' },
+      dispatch,
+      getKnownRepos: () => [repo],
+      stateStore,
+    });
+
+    expect(hasCall(calls, 'preflight')).toBe(true);
+    expect(hasCall(calls, 'coding-context')).toBe(true);
+  });
+
+  test('preflight is skipped when no indexed repo matches cwd', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-6', { ...realStateStore.defaultState(), sessionId: 1 });
+    const { dispatch, calls } = makeFakeDispatch({ context: () => EMPTY_CONTEXT });
+
+    await handleUserPromptSubmit({
+      payload: { session_id: 'claude-6', prompt: 'implement the login feature', cwd: '/elsewhere' },
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore,
+    });
+
+    expect(hasCall(calls, 'preflight')).toBe(false);
+  });
+
+  test('sets hasInjectedContext and persists state', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-7', { ...realStateStore.defaultState(), sessionId: 1 });
+    const { dispatch } = makeFakeDispatch({ context: () => EMPTY_CONTEXT });
+
+    await handleUserPromptSubmit({
+      payload: { session_id: 'claude-7', prompt: 'hello', cwd: '/p' },
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore,
+    });
+
+    expect(stateStore._peek('claude-7').hasInjectedContext).toBe(true);
+  });
+});
+
+// =====================================================================
+// Stop — silent + async capture
+// =====================================================================
+
+describe('claude-code handlers: Stop', () => {
+  test('handleStop returns null (no stdout, no continuation)', async () => {
+    const { dispatch } = makeFakeDispatch();
+    const out = await handleStop({
+      payload: { session_id: 'claude-8', cwd: '/p' },
+      dispatch,
+      stateStore: makeStateStore(),
+    });
+    expect(out).toBeNull();
+  });
+
+  test('bails out when stop_hook_active is set', async () => {
+    const { dispatch, calls } = makeFakeDispatch();
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-9', { ...realStateStore.defaultState(), sessionId: 1, turnCount: 4 });
+    await runStopCapture({
+      dispatch,
+      stateStore,
+      claudeSessionId: 'claude-9',
+      state: { ...stateStore.loadState('claude-9'), turnCount: 5 },
+      project: 'p',
+      now: Date.now(),
+      lastText: '',
+    });
+    // stop_hook_active is checked in handleStop, not runStopCapture; verify
+    // handleStop short-circuits before incrementing/persisting.
+    const before = stateStore._peek('claude-9').turnCount;
+    await handleStop({ payload: { session_id: 'claude-9', stop_hook_active: true, cwd: '/p' }, dispatch, stateStore });
+    expect(stateStore._peek('claude-9').turnCount).toBe(before);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('increments turn and persists; checkpoint fires at turn % 10', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-10', {
+      ...realStateStore.defaultState(),
+      sessionId: 1,
+      turnCount: 9,
+      currentProject: 'p',
+    });
+    const { dispatch, calls } = makeFakeDispatch();
+
+    const state = { ...stateStore.loadState('claude-10'), turnCount: 10, currentProject: 'p', editedFiles: [] };
+    await runStopCapture({
+      dispatch,
+      stateStore,
+      claudeSessionId: 'claude-10',
+      state,
+      project: 'p',
+      now: Date.now(),
+      lastText: '',
+    });
+
+    expect(hasCall(calls, 'save', (a) => a.type === 'progress')).toBe(true);
+    expect(stateStore._peek('claude-10').turnCount).toBe(10);
+  });
+
+  test('dream triggers at turn 50 once', async () => {
+    const stateStore = makeStateStore();
+    const { dispatch, calls } = makeFakeDispatch();
+    const state = {
+      ...realStateStore.defaultState(),
+      sessionId: 1,
+      turnCount: 50,
+      currentProject: 'p',
+      dreamTriggeredThisSession: false,
+    };
+    await runStopCapture({
+      dispatch,
+      stateStore,
+      claudeSessionId: 'x',
+      state,
+      project: 'p',
+      now: Date.now(),
+      lastText: '',
+    });
+    expect(hasCall(calls, 'dream')).toBe(true);
+    expect(state.dreamTriggeredThisSession).toBe(true);
+  });
+
+  test('passive capture saves an auto-decision on a qualifying assistant message', async () => {
+    const { dispatch, calls } = makeFakeDispatch();
+    const state = { ...realStateStore.defaultState(), sessionId: 1, turnCount: 3, lastAutoDecisionSave: 0 };
+    const reasoning =
+      'Analyzing the requirements and constraints of this subsystem in detail before proceeding. '.repeat(4);
+    const longText = `${reasoning} Based on the tradeoffs, going with a queue-based design because it avoids head-of-line blocking.`;
+    await runStopCapture({
+      dispatch,
+      stateStore: makeStateStore(),
+      claudeSessionId: 'y',
+      state,
+      project: 'p',
+      now: Date.now(),
+      lastText: longText,
+    });
+    expect(hasCall(calls, 'save', (a) => a.type === 'decision' || a.type === 'bugfix')).toBe(true);
+  });
+
+  test('negative-recall feedback is flushed', async () => {
+    const { dispatch, calls } = makeFakeDispatch();
+    const state = {
+      ...realStateStore.defaultState(),
+      sessionId: 1,
+      turnCount: 3,
+      pendingRecallFeedback: [[5, { sessionId: 1, query: 'q' }]],
+    };
+    await runStopCapture({
+      dispatch,
+      stateStore: makeStateStore(),
+      claudeSessionId: 'z',
+      state,
+      project: 'p',
+      now: Date.now(),
+      lastText: '',
+    });
+    expect(hasCall(calls, 'log-negative-recall')).toBe(true);
+    expect(state.pendingRecallFeedback).toEqual([]);
+  });
+});
+
+// =====================================================================
+// SessionEnd — awaited, DB-derived count, clears state
+// =====================================================================
+
+describe('claude-code handlers: SessionEnd', () => {
+  function writeTranscript(lines) {
+    const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-end-')), 't.jsonl');
+    fs.writeFileSync(file, lines.join('\n'), 'utf8');
+    return file;
+  }
+
+  test('runs session-summary + session-end awaited, with DB-derived count, clears state', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-11', { ...realStateStore.defaultState(), sessionId: 88, currentProject: 'p' });
+    const transcript = writeTranscript([JSON.stringify({ message: { role: 'user', content: 'do work' } })]);
+
+    const { dispatch, calls } = makeFakeDispatch();
+    let countedWith;
+    const dispatchClient = {
+      countSessionMemories: (sid) => {
+        countedWith = sid;
+        return 13;
+      },
+    };
+
+    const out = await handleSessionEnd({
+      payload: { session_id: 'claude-11', cwd: '/p', transcript_path: transcript },
+      dispatch,
+      dispatchClient,
+      stateStore,
+    });
+
+    expect(out).toBeNull(); // silent
+    expect(hasCall(calls, 'session-summary')).toBe(true);
+    expect(hasCall(calls, 'session-end')).toBe(true);
+    expect(countedWith).toBe(88);
+    expect(hasCall(calls, 'session-end', (a) => a.memories === '13' && a.id === '88')).toBe(true);
+    // state file cleared
+    expect(stateStore._peek('claude-11')).toBeUndefined();
+  });
+
+  test('uses the DB count, not the in-process counter', async () => {
+    const stateStore = makeStateStore();
+    // In-process counter says 9999, but DB count is 2
+    stateStore.saveState('claude-12', {
+      ...realStateStore.defaultState(),
+      sessionId: 5,
+      currentProject: 'p',
+      memoriesSavedThisSession: 9999,
+    });
+    const { dispatch, calls } = makeFakeDispatch();
+    const dispatchClient = { countSessionMemories: () => 2 };
+
+    await handleSessionEnd({
+      payload: { session_id: 'claude-12', cwd: '/p', transcript_path: '' },
+      dispatch,
+      dispatchClient,
+      stateStore,
+    });
+
+    expect(hasCall(calls, 'session-end', (a) => a.memories === '2')).toBe(true);
+  });
+
+  test('no-op when no session was started', async () => {
+    const stateStore = makeStateStore();
+    const { dispatch, calls } = makeFakeDispatch();
+    const dispatchClient = { countSessionMemories: () => 0 };
+
+    const out = await handleSessionEnd({
+      payload: { session_id: 'claude-13', cwd: '/p' },
+      dispatch,
+      dispatchClient,
+      stateStore,
+    });
+
+    expect(out).toBeNull();
+    expect(hasCall(calls, 'session-end')).toBe(false);
+  });
+});
+
+// =====================================================================
+// Router — stdout purity + fail-open
+// =====================================================================
+
+describe('claude-code router (hooks.js)', () => {
+  test('Stop writes nothing to stdout (silent)', async () => {
+    const writes = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      const { dispatch } = makeFakeDispatch();
+      await runHook(['hook', 'Stop'], {
+        ensureDb: false,
+        stdin: JSON.stringify({ session_id: 'r-1', cwd: '/p' }),
+        dispatch,
+        stateStore: makeStateStore(),
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    expect(writes.join('')).toBe('');
+  });
+
+  test('unknown event is a no-op (never crashes the host)', async () => {
+    const { dispatch, calls } = makeFakeDispatch();
+    await runHook(['hook', 'PreToolUse'], {
+      ensureDb: false,
+      stdin: JSON.stringify({ session_id: 'r-2' }),
+      dispatch,
+      stateStore: makeStateStore(),
+    });
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -45,6 +45,24 @@ function hasCall(calls, cmd, predicate) {
   return calls.some((c) => c.cmd === cmd && (!predicate || predicate(c.args)));
 }
 
+// Polls `fn` until it returns truthy, up to `timeoutMs`. Resolves with the last
+// result. Used for fire-and-forget capture work whose async I/O (transcript
+// stream read) settles across event-loop ticks rather than a single microtask.
+function waitFor(fn, timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+    const tick = () => {
+      const result = fn();
+      if (result || Date.now() >= deadline) {
+        resolve(result);
+        return;
+      }
+      setImmediate(tick);
+    };
+    setImmediate(tick);
+  });
+}
+
 // =====================================================================
 // SessionStart
 // =====================================================================
@@ -324,8 +342,9 @@ describe('claude-code handlers: Stop', () => {
     const { dispatch, calls } = makeFakeDispatch();
 
     // handleStop returns null immediately (fire-and-forget); the capture work
-    // completes via microtask drain before exit. Poll the dispatch record to
-    // verify the transcript fallback fired without awaiting a private handle.
+    // — including the async transcript stream read — completes after we return.
+    // Poll the dispatch record until the transcript fallback fires, since the
+    // streaming read resolves across event-loop ticks, not just microtasks.
     const out = await handleStop({
       payload: { session_id: 'claude-tx', cwd: '/p', transcript_path: txPath },
       dispatch,
@@ -333,9 +352,11 @@ describe('claude-code handlers: Stop', () => {
     });
     expect(out).toBeNull();
 
-    // Give the microtasks a chance to drain.
-    await new Promise((r) => setImmediate(r));
-    expect(hasCall(calls, 'save', (a) => a.type === 'decision' || a.type === 'bugfix')).toBe(true);
+    const captured = await waitFor(
+      () => hasCall(calls, 'save', (a) => a.type === 'decision' || a.type === 'bugfix'),
+      1000,
+    );
+    expect(captured).toBe(true);
 
     fs.rmSync(txDir, { recursive: true, force: true });
   });

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -296,6 +296,50 @@ describe('claude-code handlers: Stop', () => {
     expect(hasCall(calls, 'save', (a) => a.type === 'decision' || a.type === 'bugfix')).toBe(true);
   });
 
+  test('passive capture falls back to transcript_path when no inline message', async () => {
+    // Claude Code's Stop payload ships transcript_path rather than
+    // last_assistant_message; handleStop must read the transcript so capture
+    // actually fires in practice.
+    const reasoning =
+      'Analyzing the requirements and constraints of this subsystem in detail before proceeding. '.repeat(4);
+    const assistantText = `${reasoning} Based on the tradeoffs, going with a queue-based design because it avoids head-of-line blocking.`;
+    const txDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-stop-tx-'));
+    const txPath = path.join(txDir, 't.jsonl');
+    fs.writeFileSync(
+      txPath,
+      [
+        JSON.stringify({ message: { role: 'user', content: 'do work' } }),
+        JSON.stringify({ message: { role: 'assistant', content: assistantText } }),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-tx', {
+      ...realStateStore.defaultState(),
+      sessionId: 1,
+      turnCount: 3,
+      lastAutoDecisionSave: 0,
+    });
+    const { dispatch, calls } = makeFakeDispatch();
+
+    // handleStop returns null immediately (fire-and-forget); the capture work
+    // completes via microtask drain before exit. Poll the dispatch record to
+    // verify the transcript fallback fired without awaiting a private handle.
+    const out = await handleStop({
+      payload: { session_id: 'claude-tx', cwd: '/p', transcript_path: txPath },
+      dispatch,
+      stateStore,
+    });
+    expect(out).toBeNull();
+
+    // Give the microtasks a chance to drain.
+    await new Promise((r) => setImmediate(r));
+    expect(hasCall(calls, 'save', (a) => a.type === 'decision' || a.type === 'bugfix')).toBe(true);
+
+    fs.rmSync(txDir, { recursive: true, force: true });
+  });
+
   test('negative-recall feedback is flushed', async () => {
     const { dispatch, calls } = makeFakeDispatch();
     const state = {
@@ -433,5 +477,23 @@ describe('claude-code router (hooks.js)', () => {
       stateStore: makeStateStore(),
     });
     expect(calls).toHaveLength(0);
+  });
+
+  test('UserPromptSubmit clears its budget timer on the fast path', async () => {
+    // Regression: a dangling setTimeout(30000) from the budget race used to
+    // keep Node's event loop alive after the hook resolved, stalling the
+    // process for the full budget on every prompt. Now the timer is cleared
+    // when run() settles, so the handler returns with no pending handles.
+    const { dispatch } = makeFakeDispatch({ context: () => EMPTY_CONTEXT });
+    const t0 = Date.now();
+    await runHook(['hook', 'UserPromptSubmit'], {
+      ensureDb: false,
+      stdin: JSON.stringify({ session_id: 'r-3', prompt: 'hello', cwd: '/p' }),
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore: makeStateStore(),
+    });
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeLessThan(2000);
   });
 });

--- a/test/claude-code/hooks-engine/transcript-reader.test.js
+++ b/test/claude-code/hooks-engine/transcript-reader.test.js
@@ -1,0 +1,76 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const {
+  readTranscript,
+  parseTranscriptLine,
+  readTranscriptStream,
+} = require('../../../src/claude-code/hooks-engine/transcript-reader');
+
+function writeTranscript(lines) {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-tx-')), 'transcript.jsonl');
+  fs.writeFileSync(file, lines.join('\n'), 'utf8');
+  return file;
+}
+
+describe('claude-code transcript-reader', () => {
+  test('parseTranscriptLine tolerates blank / malformed lines', () => {
+    expect(parseTranscriptLine('')).toBeNull();
+    expect(parseTranscriptLine('   ')).toBeNull();
+    expect(parseTranscriptLine('{ broken')).toBeNull();
+    expect(parseTranscriptLine('"just a string"')).toBeNull();
+    expect(parseTranscriptLine('{"role":"user"}').role).toBe('user');
+  });
+
+  test('reads a well-formed transcript into the summary shape', () => {
+    const file = writeTranscript([
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'How does dispatch work?' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: 'It routes via gateway.' } }),
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'Thanks.' } }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'You are welcome.' }] },
+      }),
+    ]);
+
+    const summary = readTranscript(file);
+    expect(summary.userMessages).toHaveLength(2);
+    expect(summary.assistantMessageCount).toBe(2);
+    expect(summary.lastAssistantText).toBe('You are welcome.');
+  });
+
+  test('tolerates blank lines, malformed lines, and unknown shapes', () => {
+    const file = writeTranscript([
+      '',
+      '{ not json',
+      JSON.stringify({ type: 'unknown', message: { role: 'system' } }),
+      JSON.stringify({ message: { role: 'user', content: 'hello' } }),
+      JSON.stringify({ message: { role: 'assistant', content: 'world' } }),
+      '   ',
+    ]);
+
+    const summary = readTranscript(file);
+    expect(summary.userMessages).toHaveLength(1);
+    expect(summary.assistantMessageCount).toBe(1);
+    expect(summary.lastAssistantText).toBe('world');
+  });
+
+  test('returns empty summary for a missing/absent path', () => {
+    const summary = readTranscript('/does/not/exist.jsonl');
+    expect(summary.userMessages).toEqual([]);
+    expect(summary.assistantMessageCount).toBe(0);
+    expect(summary.lastAssistantText).toBeNull();
+  });
+
+  test('readTranscriptStream matches readTranscript for the same input', async () => {
+    const file = writeTranscript([
+      JSON.stringify({ message: { role: 'user', content: 'q' } }),
+      JSON.stringify({ message: { role: 'assistant', content: 'a' } }),
+    ]);
+    const a = readTranscript(file);
+    const b = await readTranscriptStream(file);
+    expect(b.userMessages).toHaveLength(a.userMessages.length);
+    expect(b.assistantMessageCount).toBe(a.assistantMessageCount);
+    expect(b.lastAssistantText).toBe(a.lastAssistantText);
+  });
+});

--- a/test/claude-code/state-store.test.js
+++ b/test/claude-code/state-store.test.js
@@ -1,0 +1,103 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const stateStore = require('../../src/claude-code/state-store');
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-state-'));
+}
+
+describe('claude-code state-store', () => {
+  let dir;
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('loadState returns defaults for a missing file', () => {
+    const state = stateStore.loadState('nope', { dir });
+    expect(state).toEqual(stateStore.defaultState());
+    expect(state.sessionId).toBeNull();
+    expect(state.editedFiles).toEqual([]);
+  });
+
+  test('loadState degrades to defaults on a corrupt file', () => {
+    fs.writeFileSync(path.join(dir, 'bad.json'), '{ not json', 'utf8');
+    expect(stateStore.loadState('bad', { dir })).toEqual(stateStore.defaultState());
+  });
+
+  test('saveState round-trips all fields', () => {
+    const state = {
+      ...stateStore.defaultState(),
+      sessionId: 42,
+      currentProject: 'myproj',
+      projectSessionCount: 3,
+      memoriesSavedThisSession: 7,
+      editedFiles: ['a.js', 'b.ts'],
+      exploredFiles: ['c.js'],
+      turnCount: 5,
+      dreamTriggeredThisSession: false,
+      lastMemoryToolCall: 1000,
+      callsSinceLastMemory: 2,
+      lastAutoDecisionSave: 2000,
+      hasInjectedContext: true,
+      pendingRecallFeedback: [[11, { sessionId: 42, query: 'q' }]],
+      nativeChecked: true,
+    };
+    stateStore.saveState('s1', state, { dir });
+    const loaded = stateStore.loadState('s1', { dir });
+    expect(loaded.sessionId).toBe(42);
+    expect(loaded.editedFiles).toEqual(['a.js', 'b.ts']);
+    expect(loaded.pendingRecallFeedback).toEqual([[11, { sessionId: 42, query: 'q' }]]);
+    expect(loaded.nativeChecked).toBe(true);
+  });
+
+  test('loadState merges onto defaults (forward-compatible fields)', () => {
+    // An older state file missing newer fields still loads with defaults filled.
+    fs.writeFileSync(path.join(dir, 'old.json'), JSON.stringify({ sessionId: 9 }), 'utf8');
+    const loaded = stateStore.loadState('old', { dir });
+    expect(loaded.sessionId).toBe(9);
+    expect(loaded.editedFiles).toEqual([]);
+    expect(loaded.turnCount).toBe(0);
+  });
+
+  test('atomic write leaves no .tmp file behind', () => {
+    stateStore.saveState('s2', { ...stateStore.defaultState(), sessionId: 1 }, { dir });
+    const leftovers = fs.readdirSync(dir).filter((f) => f.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  test('separate claudeSessionIds get separate files (isolation)', () => {
+    stateStore.saveState('aaa', { ...stateStore.defaultState(), sessionId: 1 }, { dir });
+    stateStore.saveState('bbb', { ...stateStore.defaultState(), sessionId: 2 }, { dir });
+    expect(stateStore.loadState('aaa', { dir }).sessionId).toBe(1);
+    expect(stateStore.loadState('bbb', { dir }).sessionId).toBe(2);
+  });
+
+  test('clearState unlinks the file and is idempotent', () => {
+    stateStore.saveState('s3', { ...stateStore.defaultState(), sessionId: 1 }, { dir });
+    expect(fs.existsSync(path.join(dir, 's3.json'))).toBe(true);
+    stateStore.clearState('s3', { dir });
+    expect(fs.existsSync(path.join(dir, 's3.json'))).toBe(false);
+    // Idempotent: clearing again does not throw.
+    expect(() => stateStore.clearState('s3', { dir })).not.toThrow();
+  });
+
+  test('sweepStaleSessions removes files older than the threshold', () => {
+    const fresh = { ...stateStore.defaultState(), sessionId: 1 };
+    const stale = { ...stateStore.defaultState(), sessionId: 2 };
+    stateStore.saveState('fresh', fresh, { dir });
+    stateStore.saveState('stale', stale, { dir });
+
+    // Backdate the stale file by 25h.
+    const oldTime = new Date(Date.now() - 25 * 3600 * 1000).getTime() / 1000;
+    fs.utimesSync(path.join(dir, 'stale.json'), oldTime, oldTime);
+
+    const result = stateStore.sweepStaleSessions(24, { dir });
+    expect(result.swept).toBe(1);
+    expect(fs.existsSync(path.join(dir, 'stale.json'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'fresh.json'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the first-class Claude Code CLI support epic (#205). Implements the Claude Code transport adapter's core lifecycle loop (`src/claude-code/`, mirroring `src/mcp/`), giving Claude Code working memory injection over direct (in-process) dispatch.

- **`hooks.js`** — top-level router: `lapis claude-code hook <event>` reads JSON from stdin, dispatches the matching handler, writes the Claude Code JSON decision to stdout. Owns `ensureDb()`; all diagnostics go to stderr; **fails open** (a crash never blocks Claude Code).
- **`state-store.js`** — per-Claude-session JSON persistence (atomic temp+rename, 24h stale-file GC on start) of the full `state.ts` field set, since each hook spawns a fresh process.
- **`dispatch-client.js`** — direct-mode `dispatch` + DB-derived memory count + known-repos read. Daemon mode is Phase 5.
- **Handlers** (`handlers/`):
  - `SessionStart` — branches on `source`: `startup|resume|clear` call `session-start` and store the returned numeric `sessionId`; `compact` re-injects context only (no spurious session row).
  - `UserPromptSubmit` — prompt-matched context + best-effort preflight/coding-context + cadence-gated reminder; passes the stored `sessionId` as `session-id` to `context`; 30s budget.
  - `Stop` — silent (no stdout → no turn continuation) + async passive-capture / checkpoint (turn % 10) / dream (turn 50) / negative-recall flush.
  - `SessionEnd` — awaited `session-summary` + `session-end` with a **DB-derived** memory count (`SELECT COUNT(*) FROM observations WHERE session_id = ?`), not the fragile counter; clears state.
- **`hooks-engine/transcript-reader.js`** — parses Claude Code `.jsonl` transcripts into `{ userMessages, assistantMessageCount, lastAssistantText }`.
- **`cli.js`** — top-level `claude-code` branch.

## Acceptance criteria (#207)

- [x] `lapis claude-code hook <event>` reads stdin JSON, dispatches, writes Claude Code JSON
- [x] `SessionStart compact` does **not** call `session-start` (asserted via dispatch call list); `startup|resume|clear` do
- [x] Session-ID mapping: `UserPromptSubmit` passes stored numeric `sessionId` as `session-id` to `context`
- [x] `Stop` is silent (no stdout)
- [x] Tests: `test/claude-code/handlers.test.js`, `state-store.test.js`, `hooks-engine/transcript-reader.test.js`

## Test plan

- [x] `npx vitest run test/claude-code` → 32 tests pass
- [x] `npx vitest run test/claude-code test/hooks-engine` → 104 tests pass (Phase 1 parity intact)
- [x] `npx oxlint src/claude-code test/claude-code` → 0 errors
- [x] `npx oxfmt --check` → clean
- [x] Smoke: all modules require cleanly; `runHook` unknown event is a no-op

## Scope

Phase 2 only. PreToolUse/PostToolUse guardrails (Read/Grep/Glob/Bash) + PostToolUse edit-track/sync + tool-state mirroring (`mcp__lapis__memory-*`) are **Phase 3** (#205). Install wiring + `lapis doctor` are Phase 4.

Refs: epic #205, Phase 1 #206 (merged via #214).

Closes #207.