### PR TITLE
Set up dev environment on Node 26.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,26 @@ Pi's footer shows `cache` usage — but this is **NOT** the persistent memory la
 **Why the confusion?** The `PI_CACHE_RENTENTION` name suggests it controls Pi's memory retention, but it only controls the LLM API's prompt cache (a cost-saving feature). The memory layer has no retention setting — it's permanent by design.
 
 > **Bottom line:** The `cache` stat in the footer is transient API optimization. The memory layer (`memory-*` tools) is your permanent knowledge base that grows across sessions.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for developing LaPis in the Cursor Cloud VM. The startup update script already ran `npm install` (which builds the native `better-sqlite3` binding), so you do not need to reinstall.
+
+### Node runtime (pinned to 26.4.0)
+
+- The dev runtime is **Node 26.4.0** (nvm default: `nvm alias default 26.4.0`). Older nvm Node 22 has been removed.
+- Gotcha: the base image's `~/.bashrc` sources nvm and then prepends Pi's bundled Node (`~/.local/share/pi-node/.../v22.23.1/bin`), which would otherwise win. A trailing line in `~/.bashrc` re-prepends `~/.nvm/versions/node/v26.4.0/bin` so **login/interactive shells resolve to 26.4.0**. Verify with `bash -lc 'node -v'` → `v26.4.0`.
+- Two Node 22 binaries intentionally remain and must **not** be deleted: `/exec-daemon/node` (backs the agent shell/tooling) and `~/.local/share/pi-node/...v22.23.1` (Pi's bundled runtime + the `pi` launcher). They are overridden on `PATH`, not removed.
+- `better-sqlite3` is a native module. If the Node major version changes, run `npm install` again so the binding matches the running ABI (empirically the prebuilt binary loads across Node 22 and 26, but reinstalling is the safe path).
+
+### Running / testing (standard commands — see `CONTRIBUTING.md` and `docs/API.md`)
+
+- Lint / tests / smoke: `npm run lint`, `npm test`, `node test/smoke-cli.js` (all green on Node 26.4.0).
+- `npm run format:check` (oxfmt) currently reports pre-existing formatting diffs across the repo; it is **not** part of CI (`test.yml` runs lint + test + smoke only), so don't mass-reformat untouched files.
+- Run the app (CLI): `node memory-store.js <subcommand>` (e.g. `save`, `search`, `index-repo`, `search-code`). Data lives in `~/.pi/memory/memory.db`.
+- Run the HTTP server: `node memory-store.js serve [--host 127.0.0.1] [--port 9100]` (`GET /health`, Aurex domain + code endpoints).
+
+### Pi extension
+
+- Install/refresh into Pi with `pi install git:github.com/GeneGulanesJr/LaPis`; `pi list` shows it as a user package. Pi is configured with the `minimax` provider.
+- Pi launches the extension via `#!/usr/bin/env node`, so with the `PATH` setup above it runs on Node 26.4.0. Non-interactive runs use `pi --print --mode json` (text `--print` buffers output until the turn completes, so a killed/timed-out run prints nothing — prefer `--mode json` for streaming/inspection).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,9 +98,9 @@ Durable, non-obvious notes for developing LaPis in the Cursor Cloud VM. The star
 
 ### Node runtime (pinned to 26.4.0)
 
-- The dev runtime is **Node 26.4.0** (nvm default: `nvm alias default 26.4.0`). Older nvm Node 22 has been removed.
-- Gotcha: the base image's `~/.bashrc` sources nvm and then prepends Pi's bundled Node (`~/.local/share/pi-node/.../v22.23.1/bin`), which would otherwise win. A trailing line in `~/.bashrc` re-prepends `~/.nvm/versions/node/v26.4.0/bin` so **login/interactive shells resolve to 26.4.0**. Verify with `bash -lc 'node -v'` → `v26.4.0`.
-- Two Node 22 binaries intentionally remain and must **not** be deleted: `/exec-daemon/node` (backs the agent shell/tooling) and `~/.local/share/pi-node/...v22.23.1` (Pi's bundled runtime + the `pi` launcher). They are overridden on `PATH`, not removed.
+- The dev runtime is **Node 26.4.0** (nvm default: `nvm alias default 26.4.0`). The older nvm Node 22 and Pi's bundled Node `v22.23.1` have both been removed.
+- A trailing line in `~/.bashrc` prepends `~/.nvm/versions/node/v26.4.0/bin` so **login/interactive shells resolve to 26.4.0** regardless of other node shims. Verify with `bash -lc 'node -v'` → `v26.4.0`.
+- One Node 22 binary intentionally remains and must **not** be deleted: `/exec-daemon/node` (v22.14.0) backs the agent shell/tooling. It is owned by another uid and is overridden on `PATH`, not removed. (`nvm ls` reports it as `system`.)
 - `better-sqlite3` is a native module. If the Node major version changes, run `npm install` again so the binding matches the running ABI (empirically the prebuilt binary loads across Node 22 and 26, but reinstalling is the safe path).
 
 ### Running / testing (standard commands — see `CONTRIBUTING.md` and `docs/API.md`)
@@ -112,5 +112,6 @@ Durable, non-obvious notes for developing LaPis in the Cursor Cloud VM. The star
 
 ### Pi extension
 
-- Install/refresh into Pi with `pi install git:github.com/GeneGulanesJr/LaPis`; `pi list` shows it as a user package. Pi is configured with the `minimax` provider.
-- Pi launches the extension via `#!/usr/bin/env node`, so with the `PATH` setup above it runs on Node 26.4.0. Non-interactive runs use `pi --print --mode json` (text `--print` buffers output until the turn completes, so a killed/timed-out run prints nothing — prefer `--mode json` for streaming/inspection).
+- Pi (`@earendil-works/pi-coding-agent`) is installed **globally under Node 26** (`~/.nvm/versions/node/v26.4.0/bin/pi`), not via the removed bundled `pi-node` runtime. Reinstall with `npm i -g @earendil-works/pi-coding-agent` if needed.
+- Install/refresh the LaPis extension into Pi with `pi install git:github.com/GeneGulanesJr/LaPis`; `pi list` shows it as a user package. Pi is configured with the `minimax` provider.
+- Pi launches via `#!/usr/bin/env node`, so it runs on Node 26.4.0. Non-interactive runs use `pi --print --mode json` (text `--print` buffers output until the turn completes, so a killed/timed-out run prints nothing — prefer `--mode json` for streaming/inspection).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the LaPis development environment and pins the dev runtime to **Node 26.4.0** (per request). Both older Node 22 installs that could be removed are gone: nvm's Node 22.22.2 and Pi's bundled `v22.23.1`. Pi was relocated to a Node 26 global install so the `pi` command keeps working. Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable, non-obvious setup notes.

The only code/repo change is `AGENTS.md`. Runtime selection (nvm default + `~/.bashrc`), dependency install, and the Pi relocation are VM-environment changes captured by the snapshot / startup update script, not repo edits.

## What was done

- **Node 26.4.0** made the nvm default; removed nvm's `v22.22.2`.
- Removed Pi's bundled runtime `~/.local/share/pi-node/...v22.23.1`. First reinstalled Pi globally under Node 26 (`npm i -g @earendil-works/pi-coding-agent@0.80.3`) so `pi` now lives at `~/.nvm/versions/node/v26.4.0/bin/pi`, and removed the `~/.bashrc` line that prepended the old Pi-node bin.
- `/exec-daemon/node` (v22.14.0) is left in place — it backs the agent shell/tooling, is owned by another uid, and is overridden on `PATH` (shows as nvm `system`).
- Reinstalled deps under Node 26 so the native `better-sqlite3` binding matches the runtime.

## Update script (startup)

```
. "$HOME/.nvm/nvm.sh"
nvm use 26.4.0 > /dev/null
npm install
```

## Testing (Node 26.4.0)

- ✅ `npm run lint` — 0 errors (658 warnings)
- ✅ `npm test` — 1604 passed (104 files)
- ✅ `node test/smoke-cli.js` — 143 passed, 0 failed
- ✅ CLI: `node memory-store.js save/search/index-repo/search-code`
- ✅ HTTP: `node memory-store.js serve` → `/health` ok, created + listed a mission
- ✅ Pi extension (before and after removing Node 22.23.1): `pi --print --mode json` called `memory-save` and `memory-search` end-to-end on Node 26.4.0

[pi_lapis_tool_demo.log](https://cursor.com/agents/bc-9ea8d88e-6a6e-455d-bc9d-0e87d757f9e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpi_lapis_tool_demo.log)
[node22_removal_verification.log](https://cursor.com/agents/bc-9ea8d88e-6a6e-455d-bc9d-0e87d757f9e2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnode22_removal_verification.log)

Note: `npm run format:check` reports pre-existing formatting diffs repo-wide; it is not part of CI (`test.yml` runs lint + test + smoke), so untouched files were not reformatted.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ea8d88e-6a6e-455d-bc9d-0e87d757f9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ea8d88e-6a6e-455d-bc9d-0e87d757f9e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

