### PR TITLE
feat(claude-code): Phase 3 — guardrails + tracking + tool-state mirroring (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+### Added
+- **Phase 3 — Claude Code guardrails + tracking + tool-state mirroring (#208)**
+  - `PreToolUse` handler: Read, Grep (primary), Glob, and Bash search guardrails with actionable `memory-code` guidance; no auto-index on miss (manual `index-repo` guidance instead).
+  - `PostToolUse` handler: edit tracking, async git-trust sync, and MCP tool-state mirroring (`memoriesSavedThisSession`, `pendingRecallFeedback`, `exploredFiles`).
+  - New modules: `src/hooks-engine/tool-response-parse.js`, `src/claude-code/tool-map.js`, `src/claude-code/state-mutations.js`, `src/claude-code/handlers/pre-tool-use.js`, `src/claude-code/handlers/post-tool-use.js`.
+  - Tests: `test/hooks-engine/tool-response-parse.test.js`, `test/claude-code/pre-post-tool-use.test.js`.

--- a/src/claude-code/handlers/post-tool-use.js
+++ b/src/claude-code/handlers/post-tool-use.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Claude Code PostToolUse handler.
+ *
+ * SYNC state-store writes for edit tracking, git-trust sync (async dispatch),
+ * and MCP tool-state mirroring (process-boundary fix for recall feedback).
+ */
+
+const { createGitTrustSyncAdapter } = require('../../trust-sync/change-detector');
+const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const {
+  extractResponseText,
+  parseSearchResultIds,
+  wasSaveSuccessful,
+} = require('../../hooks-engine/tool-response-parse');
+const { mcpShortName } = require('../tool-map');
+const {
+  addEditedFile,
+  addExploredFile,
+  harvestExploredFilesFromText,
+  resetMemoryReminder,
+  upsertRecallFeedback,
+  removeRecallFeedback,
+} = require('../state-mutations');
+const { GIT_TRUST_RE } = require('./pre-tool-use');
+
+const EDIT_TOOLS = new Set(['Write', 'MultiEdit', 'Edit']);
+
+/**
+ * Run PostToolUse tracking + mirroring. Always silent (returns null).
+ */
+async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore }) {
+  const toolName = payload.tool_name;
+  const toolInput = payload.tool_input || {};
+  const toolResponse = payload.tool_response;
+  const claudeSessionId = payload.session_id;
+
+  const state = stateStore.loadState(claudeSessionId);
+  let changed = false;
+
+  if (EDIT_TOOLS.has(toolName) && toolInput.file_path) {
+    addEditedFile(state, toolInput.file_path);
+    changed = true;
+  }
+
+  if (toolName === 'Bash' && GIT_TRUST_RE.test(toolInput.command || '')) {
+    void runGitTrustSync({ dispatch, getKnownRepos, state, cwd: payload.cwd }).catch(() => {});
+  }
+
+  const short = mcpShortName(toolName);
+  if (short && short.startsWith('memory-')) {
+    resetMemoryReminder(state);
+    changed = true;
+
+    const responseText = extractResponseText(toolResponse);
+
+    if (short === 'memory-save' && wasSaveSuccessful(responseText)) {
+      state.memoriesSavedThisSession = (state.memoriesSavedThisSession || 0) + 1;
+      changed = true;
+    }
+
+    if (short === 'memory-search') {
+      const ids = parseSearchResultIds(responseText);
+      const query = toolInput.query || '';
+      for (const id of ids) {
+        upsertRecallFeedback(state, id, { sessionId: state.sessionId || 0, query });
+      }
+      changed = true;
+    }
+
+    if (short === 'memory-get' || short === 'memory-delete') {
+      if (toolInput.id != null) {
+        removeRecallFeedback(state, Number(toolInput.id));
+        changed = true;
+      }
+    }
+
+    if (short === 'memory-code') {
+      if (toolInput.file) {
+        addExploredFile(state, toolInput.file);
+      }
+      harvestExploredFilesFromText(state, responseText);
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    stateStore.saveState(claudeSessionId, state);
+  }
+
+  return null;
+}
+
+async function runGitTrustSync({ dispatch, getKnownRepos, state, cwd }) {
+  const project = state.currentProject || projectFromCwd(resolveCwd(cwd));
+  if (!project) {
+    return;
+  }
+
+  const repos = await getKnownRepos();
+  const repo = repos.find((r) => r.name.toLowerCase() === project.toLowerCase());
+  if (!repo) {
+    return;
+  }
+
+  const sync = createGitTrustSyncAdapter((cmd, args) => dispatch(cmd, args));
+  await sync(repo.name);
+}
+
+module.exports = { handlePostToolUse, runGitTrustSync };

--- a/src/claude-code/handlers/pre-tool-use.js
+++ b/src/claude-code/handlers/pre-tool-use.js
@@ -1,0 +1,228 @@
+'use strict';
+
+/**
+ * Claude Code PreToolUse handler.
+ *
+ * Guardrails for Read, Grep (primary), Glob, Bash (secondary), and
+ * mcp__lapis__* memory tools. Auto-index on miss is intentionally NOT done
+ * here (hook timeout risk); guidance points to manual memory-code index-repo.
+ */
+
+const path = require('node:path');
+const { isCodeFile } = require('../../code-index/scanner');
+const { resolveCwd, projectFromCwd, findMatchingRepo } = require('../../hooks-engine/project');
+const {
+  CONFIG_FILENAMES,
+  RAW_CODE_DISCOVERY_RE,
+  CODE_PATH_HINT_RE,
+  isPipedOutputFilter,
+  isTargetedSymbolLookup,
+  isTargetedGrepLookup,
+  isBroadGlobDiscovery,
+} = require('../../hooks-engine/guardrail-utils');
+const { mcpShortName } = require('../tool-map');
+const { addExploredFile, hasExploredFile, resetMemoryReminder } = require('../state-mutations');
+
+const GIT_TRUST_RE = /\bgit\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/;
+
+function deny(reason) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+function memoryCodeGuidance(repoName, extras = '') {
+  return (
+    `Use \`memory-code\` instead:\n` +
+    `• \`memory-code search --repo ${repoName} --query <query>\` — find code symbols\n` +
+    `• \`memory-code outline --repo ${repoName} --file <path>\` — file structure\n` +
+    `• \`memory-code callers --repo ${repoName} --symbol <name>\` — call hierarchy\n` +
+    `• \`memory-code deps --repo ${repoName}\` — dependency graph\n` +
+    `• \`memory-code importance --repo ${repoName}\` — hotspots & churn` +
+    (extras ? `\n${extras}` : '')
+  );
+}
+
+function findRepoForCwd(repos, cwd, project) {
+  const resolvedCwd = path.resolve(cwd);
+  return (
+    repos.find((r) => resolvedCwd.startsWith(path.resolve(r.path))) ||
+    repos.find((r) => project && project.toLowerCase() === r.name.toLowerCase()) ||
+    findMatchingRepo(resolvedCwd, repos)
+  );
+}
+
+function handleReadGuardrail({ toolInput, repos, cwd, state }) {
+  const filePath = toolInput.file_path;
+  if (!filePath || typeof filePath !== 'string') {
+    return null;
+  }
+  if (!isCodeFile(filePath)) {
+    return null;
+  }
+  if (typeof toolInput.offset === 'number' || typeof toolInput.limit === 'number') {
+    return null;
+  }
+  const basename = path.basename(filePath);
+  if (CONFIG_FILENAMES.has(basename)) {
+    return null;
+  }
+  if (filePath.includes('node_modules')) {
+    return null;
+  }
+
+  const absPath = path.resolve(filePath);
+  const resolvedCwd = path.resolve(cwd);
+  if (absPath !== resolvedCwd && !absPath.startsWith(`${resolvedCwd}${path.sep}`)) {
+    return null;
+  }
+
+  const matchedRepo = findMatchingRepo(absPath, repos);
+  if (!matchedRepo) {
+    const projectDir = absPath.startsWith(resolvedCwd) ? resolvedCwd : path.dirname(absPath);
+    const projectName = state.currentProject || projectFromCwd(projectDir);
+    return deny(
+      `Cannot read "${basename}" — project is not indexed.\n` +
+        `Index manually: \`memory-code index-repo --path ${projectDir} --name ${projectName}\`\n` +
+        `Then use \`memory-code outline --repo ${projectName} --file <path>\` before reading.`,
+    );
+  }
+
+  if (hasExploredFile(state, filePath, matchedRepo.path)) {
+    return null;
+  }
+
+  const relPath = path.relative(matchedRepo.path, absPath);
+  return deny(
+    `Use \`memory-code\` first to understand "${basename}" before reading it:\n` +
+      `• \`memory-code outline --repo ${matchedRepo.name} --file ${relPath || basename}\` — file structure & symbols\n` +
+      `• \`memory-code callers --repo ${matchedRepo.name} --symbol <name>\` — who calls what\n` +
+      `• \`memory-code deps --repo ${matchedRepo.name}\` — dependency graph\n` +
+      `After reviewing the outline, use \`read\` with \`offset\`/\`limit\` for targeted editing.`,
+  );
+}
+
+function handleGrepGuardrail({ toolInput, repos, cwd, project }) {
+  const pattern = toolInput.pattern;
+  const searchPath = toolInput.path || cwd;
+
+  if (isTargetedGrepLookup(pattern, searchPath)) {
+    return null;
+  }
+
+  const matchedRepo = findRepoForCwd(repos, cwd, project);
+  if (!matchedRepo) {
+    return null;
+  }
+
+  const searchHint = CODE_PATH_HINT_RE.test(String(pattern)) ? 'Code search' : 'Raw repository search';
+  return deny(`${searchHint} detected in indexed repo "${matchedRepo.name}". ${memoryCodeGuidance(matchedRepo.name)}`);
+}
+
+function handleGlobGuardrail({ toolInput, repos, cwd, project }) {
+  const pattern = toolInput.pattern;
+  if (!isBroadGlobDiscovery(pattern)) {
+    return null;
+  }
+
+  const matchedRepo = findRepoForCwd(repos, cwd, project);
+  if (!matchedRepo) {
+    return null;
+  }
+
+  return deny(
+    `Broad file discovery (\`${pattern}\`) in indexed repo "${matchedRepo.name}". ` +
+      `Use \`memory-code search --repo ${matchedRepo.name} --query <query>\` or ` +
+      `\`memory-code outline --repo ${matchedRepo.name} --file <path>\` instead of Glob.`,
+  );
+}
+
+function handleBashGuardrail({ toolInput, repos, cwd, project }) {
+  const cmd = toolInput.command;
+  if (!cmd || typeof cmd !== 'string' || !RAW_CODE_DISCOVERY_RE.test(cmd)) {
+    return null;
+  }
+
+  const matchedRepo = findRepoForCwd(repos, cwd, project);
+  if (!matchedRepo) {
+    return null;
+  }
+
+  if (isPipedOutputFilter(cmd)) {
+    return null;
+  }
+  if (isTargetedSymbolLookup(cmd)) {
+    return null;
+  }
+
+  const searchHint = CODE_PATH_HINT_RE.test(cmd) ? 'Code search' : 'Raw repository search';
+  return deny(`${searchHint} detected in indexed repo "${matchedRepo.name}". ${memoryCodeGuidance(matchedRepo.name)}`);
+}
+
+function handleMcpMemoryCodePre({ toolInput, state }) {
+  resetMemoryReminder(state);
+  const file = toolInput.file;
+  if (file) {
+    addExploredFile(state, file);
+  }
+  return null;
+}
+
+function handleMcpMemoryPre({ state }) {
+  resetMemoryReminder(state);
+  return null;
+}
+
+/**
+ * Run PreToolUse guardrails.
+ *
+ * @returns {Promise<object|null>} deny envelope or null (allow)
+ */
+async function handlePreToolUse({ payload, getKnownRepos, stateStore }) {
+  const toolName = payload.tool_name;
+  const toolInput = payload.tool_input || {};
+  const claudeSessionId = payload.session_id;
+  const cwd = resolveCwd(payload.cwd);
+  const project = projectFromCwd(cwd);
+
+  const state = stateStore.loadState(claudeSessionId);
+
+  const short = mcpShortName(toolName);
+  if (short === 'memory-code') {
+    handleMcpMemoryCodePre({ toolInput, state });
+    stateStore.saveState(claudeSessionId, state);
+    return null;
+  }
+  if (short && short.startsWith('memory-')) {
+    handleMcpMemoryPre({ state });
+    stateStore.saveState(claudeSessionId, state);
+    return null;
+  }
+
+  const repos = await getKnownRepos();
+
+  let decision = null;
+  if (toolName === 'Read') {
+    decision = handleReadGuardrail({ toolInput, repos, cwd, state });
+  } else if (toolName === 'Grep') {
+    decision = handleGrepGuardrail({ toolInput, repos, cwd, project });
+  } else if (toolName === 'Glob') {
+    decision = handleGlobGuardrail({ toolInput, repos, cwd, project });
+  } else if (toolName === 'Bash') {
+    if (!GIT_TRUST_RE.test(toolInput.command || '')) {
+      decision = handleBashGuardrail({ toolInput, repos, cwd, project });
+    }
+  }
+
+  return decision;
+}
+
+module.exports = {
+  handlePreToolUse,
+  deny,
+  GIT_TRUST_RE,
+};

--- a/src/claude-code/hooks.js
+++ b/src/claude-code/hooks.js
@@ -11,8 +11,8 @@
  *   - all diagnostics → stderr
  *   - hooks fail open (a crash logs to stderr + exits 0, never blocks Claude Code)
  *
- * Phase 2 wires the high-value lifecycle only: SessionStart, UserPromptSubmit,
- * Stop, SessionEnd. PreToolUse / PostToolUse guardrails are Phase 3.
+ * Phase 2 wires the high-value lifecycle: SessionStart, UserPromptSubmit,
+ * Stop, SessionEnd. Phase 3 adds PreToolUse / PostToolUse guardrails + mirroring.
  */
 
 const { stripTuiArtifacts } = require('../mcp/translate-result');
@@ -22,12 +22,16 @@ const { handleSessionStart } = require('./handlers/session-start');
 const { handleUserPromptSubmit } = require('./handlers/user-prompt-submit');
 const { handleStop } = require('./handlers/stop');
 const { handleSessionEnd } = require('./handlers/session-end');
+const { handlePreToolUse } = require('./handlers/pre-tool-use');
+const { handlePostToolUse } = require('./handlers/post-tool-use');
 
 const HANDLERS = {
   SessionStart: handleSessionStart,
   UserPromptSubmit: handleUserPromptSubmit,
   Stop: handleStop,
   SessionEnd: handleSessionEnd,
+  PreToolUse: handlePreToolUse,
+  PostToolUse: handlePostToolUse,
 };
 
 function readStdin() {
@@ -87,7 +91,7 @@ async function runHook(argv, opts = {}) {
   const handler = HANDLERS[resolvedEvent];
 
   if (!handler) {
-    // Unknown/unwired event (e.g. PreToolUse in Phase 2): no-op, never crash.
+    // Unknown/unwired event: no-op, never crash.
     return;
   }
 

--- a/src/claude-code/state-mutations.js
+++ b/src/claude-code/state-mutations.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * Claude Code bridge: helpers for mutating persisted session state fields.
+ *
+ * State-store uses JSON-serializable arrays (not Sets/Maps) for exploredFiles,
+ * editedFiles, and pendingRecallFeedback.
+ */
+
+const path = require('node:path');
+
+function normalizeExploredKey(value) {
+  return String(value || '').toLowerCase();
+}
+
+function hasExploredFile(state, filePath, repoPath) {
+  const explored = state.exploredFiles || [];
+  const absPath = path.resolve(filePath);
+  const fileBase = path.basename(filePath).toLowerCase();
+  const relPath = repoPath ? path.relative(repoPath, absPath).toLowerCase() : '';
+  const absLower = absPath.toLowerCase();
+
+  return explored.some(
+    (entry) =>
+      entry === fileBase || entry === relPath || entry === absLower || entry === normalizeExploredKey(filePath),
+  );
+}
+
+function addExploredFile(state, filePath) {
+  if (!filePath) {
+    return;
+  }
+  const explored = state.exploredFiles || [];
+  const next = new Set(explored);
+  next.add(normalizeExploredKey(filePath));
+  next.add(path.basename(filePath).toLowerCase());
+  state.exploredFiles = [...next];
+}
+
+function harvestExploredFilesFromText(state, text) {
+  if (!text || typeof text !== 'string') {
+    return;
+  }
+  const filePaths = text.match(/[\w/.-]+\.(ts|js|tsx|jsx|mjs|cjs|py|go|rs)/gi) || [];
+  for (const fp of filePaths) {
+    addExploredFile(state, fp);
+  }
+}
+
+function addEditedFile(state, filePath) {
+  if (!filePath) {
+    return;
+  }
+  const edited = state.editedFiles || [];
+  if (!edited.includes(filePath)) {
+    state.editedFiles = [...edited, filePath];
+  }
+}
+
+function resetMemoryReminder(state) {
+  state.lastMemoryToolCall = Date.now();
+  state.callsSinceLastMemory = 0;
+}
+
+function upsertRecallFeedback(state, memoryId, meta) {
+  const entries = state.pendingRecallFeedback || [];
+  const filtered = entries.filter(([id]) => id !== memoryId);
+  filtered.push([memoryId, meta]);
+  state.pendingRecallFeedback = filtered;
+}
+
+function removeRecallFeedback(state, memoryId) {
+  const entries = state.pendingRecallFeedback || [];
+  state.pendingRecallFeedback = entries.filter(([id]) => id !== memoryId);
+}
+
+module.exports = {
+  hasExploredFile,
+  addExploredFile,
+  harvestExploredFilesFromText,
+  addEditedFile,
+  resetMemoryReminder,
+  upsertRecallFeedback,
+  removeRecallFeedback,
+};

--- a/src/claude-code/tool-map.js
+++ b/src/claude-code/tool-map.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Claude Code bridge: tool → handler category map.
+ *
+ * Documents which PreToolUse / PostToolUse behaviors apply per tool name.
+ * Used by handlers for routing and by tests for coverage checks.
+ */
+
+const MCP_PREFIX = 'mcp__lapis__';
+
+const PRE_TOOL_MAP = {
+  Read: 'read-guardrail',
+  Grep: 'search-guardrail',
+  Glob: 'search-guardrail',
+  Bash: 'search-guardrail',
+};
+
+const POST_TOOL_MAP = {
+  Write: 'edit-track',
+  MultiEdit: 'edit-track',
+  Edit: 'edit-track',
+  Bash: 'git-trust',
+};
+
+function mcpShortName(toolName) {
+  if (!toolName || typeof toolName !== 'string') {
+    return null;
+  }
+  if (!toolName.startsWith(MCP_PREFIX)) {
+    return null;
+  }
+  return toolName.slice(MCP_PREFIX.length);
+}
+
+function preCategory(toolName) {
+  if (toolName === 'Bash') {
+    return PRE_TOOL_MAP.Bash;
+  }
+  if (PRE_TOOL_MAP[toolName]) {
+    return PRE_TOOL_MAP[toolName];
+  }
+  const short = mcpShortName(toolName);
+  if (short === 'memory-code') {
+    return 'explored-seed';
+  }
+  if (short && short.startsWith('memory-')) {
+    return 'reminder-reset';
+  }
+  return null;
+}
+
+function postCategory(toolName) {
+  if (POST_TOOL_MAP[toolName]) {
+    return POST_TOOL_MAP[toolName];
+  }
+  const short = mcpShortName(toolName);
+  if (short && short.startsWith('memory-')) {
+    return 'tool-state-mirror';
+  }
+  return null;
+}
+
+function isMcpLapisTool(toolName) {
+  return typeof toolName === 'string' && toolName.startsWith(MCP_PREFIX);
+}
+
+module.exports = {
+  MCP_PREFIX,
+  PRE_TOOL_MAP,
+  POST_TOOL_MAP,
+  mcpShortName,
+  preCategory,
+  postCategory,
+  isMcpLapisTool,
+};

--- a/src/hooks-engine/guardrail-utils.js
+++ b/src/hooks-engine/guardrail-utils.js
@@ -162,10 +162,45 @@ const RAW_CODE_DISCOVERY_RE = /\b(rg|grep|ag|ack|find)\b/i;
 const CODE_PATH_HINT_RE =
   /\.(ts|js|tsx|jsx|mjs|cjs|py|go|rs|java)\b|(^|\s)(src|lib|app|test|tests|extensions|commands|data-access|services)\b/i;
 
+const SINGLE_FILE_SCOPE_RE = /\.(ts|js|tsx|jsx|mjs|cjs|py|go|rs|java|rb|swift|kt)$/i;
+const REGEX_METACHAR_RE = /[.*+?|^$()\[\]{}\\|]/;
+
+/**
+ * Adapt isTargetedSymbolLookup for Claude Code's native Grep tool.
+ * Targeted = identifier-length pattern, no regex metachars, or single-file scope.
+ */
+function isTargetedGrepLookup(pattern, searchPath) {
+  if (!pattern || typeof pattern !== 'string') {
+    return false;
+  }
+  if (pattern.length < MIN_SYMBOL_LENGTH) {
+    return false;
+  }
+  if (REGEX_METACHAR_RE.test(pattern)) {
+    return false;
+  }
+  if (searchPath && SINGLE_FILE_SCOPE_RE.test(searchPath)) {
+    return true;
+  }
+  const cmd = `grep -rn "${pattern}" ${searchPath || 'src/'}`;
+  return isTargetedSymbolLookup(cmd);
+}
+
+/** Broad file-discovery glob patterns that should use memory-code instead. */
+function isBroadGlobDiscovery(pattern) {
+  if (!pattern || typeof pattern !== 'string') {
+    return false;
+  }
+  const p = pattern.trim();
+  return p === '**' || p === '**/*' || p === '**/*.*' || /^\*\*\/\*$/.test(p);
+}
+
 module.exports = {
   splitPipeline,
   isPipedOutputFilter,
   isTargetedSymbolLookup,
+  isTargetedGrepLookup,
+  isBroadGlobDiscovery,
   CONFIG_FILENAMES,
   RAW_CODE_DISCOVERY_RE,
   CODE_PATH_HINT_RE,

--- a/src/hooks-engine/index.js
+++ b/src/hooks-engine/index.js
@@ -20,4 +20,5 @@ module.exports = {
   ...require('./session-summary'),
   ...require('./guardrail-utils'),
   ...require('./project'),
+  ...require('./tool-response-parse'),
 };

--- a/src/hooks-engine/tool-response-parse.js
+++ b/src/hooks-engine/tool-response-parse.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/**
+ * hooks-engine: tool-response-parse
+ *
+ * Parses rendered MCP tool_response text for Claude Code PostToolUse mirroring.
+ * Marker format `[#<id>]` is owned here so render/parse stay in sync across the
+ * Pi extension, MCP adapter, and Claude Code bridge.
+ */
+
+const MEMORY_ID_MARKER_RE = /\[#(\d+)\]/g;
+
+/**
+ * Normalize a PostToolUse tool_response into plain text for parsing.
+ * Handles MCP content blocks, JSON envelopes, and raw strings.
+ */
+function extractResponseText(toolResponse) {
+  if (toolResponse == null) {
+    return '';
+  }
+  if (typeof toolResponse === 'string') {
+    return toolResponse;
+  }
+  if (typeof toolResponse !== 'object') {
+    return String(toolResponse);
+  }
+
+  if (Array.isArray(toolResponse.content)) {
+    return toolResponse.content
+      .filter((c) => c && c.type === 'text' && typeof c.text === 'string')
+      .map((c) => c.text)
+      .join('\n');
+  }
+
+  if (typeof toolResponse.text === 'string') {
+    return toolResponse.text;
+  }
+
+  try {
+    return JSON.stringify(toolResponse);
+  } catch {
+    return String(toolResponse);
+  }
+}
+
+/**
+ * Extract all `[#id]` markers from text.
+ */
+function parseMemoryIds(text) {
+  if (!text || typeof text !== 'string') {
+    return [];
+  }
+  const ids = new Set();
+  let m;
+  MEMORY_ID_MARKER_RE.lastIndex = 0;
+  while ((m = MEMORY_ID_MARKER_RE.exec(text)) !== null) {
+    const id = Number(m[1]);
+    if (Number.isFinite(id)) {
+      ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+/**
+ * Parse memory IDs from a memory-search tool response.
+ * Accepts formatted lines (`- [#42] ...`) and JSON `{ results: [{ id }] }`.
+ */
+function parseSearchResultIds(text) {
+  if (!text || typeof text !== 'string') {
+    return [];
+  }
+
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      const results = parsed?.results;
+      if (Array.isArray(results)) {
+        return results.map((r) => Number(r?.id)).filter((id) => Number.isFinite(id));
+      }
+    } catch {
+      // Fall through to marker parsing.
+    }
+  }
+
+  return parseMemoryIds(text);
+}
+
+/**
+ * True when memory-save succeeded (saved or auto-merged), false for duplicates/errors.
+ */
+function wasSaveSuccessful(text) {
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
+
+  const trimmed = text.trim();
+  if (/potential duplicate/i.test(trimmed)) {
+    return false;
+  }
+  if (/^error:/i.test(trimmed) || /failed to save/i.test(trimmed)) {
+    return false;
+  }
+
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed?.status === 'potential_duplicate' || parsed?.error) {
+        return false;
+      }
+      if (parsed?.id != null || parsed?.auto_merged) {
+        return true;
+      }
+    } catch {
+      // Fall through.
+    }
+  }
+
+  return /memory saved/i.test(trimmed) && parseMemoryIds(trimmed).length > 0;
+}
+
+module.exports = {
+  MEMORY_ID_MARKER_RE,
+  extractResponseText,
+  parseMemoryIds,
+  parseSearchResultIds,
+  wasSaveSuccessful,
+};

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -491,7 +491,7 @@ describe('claude-code router (hooks.js)', () => {
 
   test('unknown event is a no-op (never crashes the host)', async () => {
     const { dispatch, calls } = makeFakeDispatch();
-    await runHook(['hook', 'PreToolUse'], {
+    await runHook(['hook', 'PermissionRequest'], {
       ensureDb: false,
       stdin: JSON.stringify({ session_id: 'r-2' }),
       dispatch,

--- a/test/claude-code/pre-post-tool-use.test.js
+++ b/test/claude-code/pre-post-tool-use.test.js
@@ -1,0 +1,417 @@
+const realStateStore = require('../../src/claude-code/state-store');
+const { handlePreToolUse } = require('../../src/claude-code/handlers/pre-tool-use');
+const { handlePostToolUse, runGitTrustSync } = require('../../src/claude-code/handlers/post-tool-use');
+const { preCategory, postCategory, isMcpLapisTool } = require('../../src/claude-code/tool-map');
+const { runHook } = require('../../src/claude-code/hooks');
+
+function makeStateStore() {
+  const map = new Map();
+  return {
+    defaultState: realStateStore.defaultState,
+    loadState: (id) => map.get(id) || realStateStore.defaultState(),
+    saveState: (id, s) => {
+      map.set(id, structuredClone(s));
+    },
+    clearState: (id) => {
+      map.delete(id);
+    },
+    sweepStaleSessions: () => ({ swept: 0 }),
+    _peek: (id) => map.get(id),
+  };
+}
+
+function makeFakeDispatch(overrides = {}) {
+  const calls = [];
+  const dispatch = async (cmd, args) => {
+    calls.push({ cmd, args });
+    if (overrides[cmd]) {
+      return overrides[cmd](args, calls);
+    }
+    return { ok: true };
+  };
+  return { dispatch, calls };
+}
+
+const INDEXED_REPO = { name: 'myapp', path: '/proj/myapp', indexed_at: new Date().toISOString() };
+
+// =====================================================================
+// tool-map
+// =====================================================================
+
+describe('claude-code tool-map', () => {
+  test('preCategory routes native and MCP tools', () => {
+    expect(preCategory('Read')).toBe('read-guardrail');
+    expect(preCategory('Grep')).toBe('search-guardrail');
+    expect(preCategory('mcp__lapis__memory-code')).toBe('explored-seed');
+    expect(preCategory('mcp__lapis__memory-search')).toBe('reminder-reset');
+    expect(preCategory('WebFetch')).toBeNull();
+  });
+
+  test('postCategory routes edit, git, and MCP mirror tools', () => {
+    expect(postCategory('Write')).toBe('edit-track');
+    expect(postCategory('Edit')).toBe('edit-track');
+    expect(postCategory('Bash')).toBe('git-trust');
+    expect(postCategory('mcp__lapis__memory-save')).toBe('tool-state-mirror');
+    expect(isMcpLapisTool('mcp__lapis__memory-get')).toBe(true);
+  });
+});
+
+// =====================================================================
+// PreToolUse
+// =====================================================================
+
+describe('claude-code handlers: PreToolUse', () => {
+  test('denies whole-file Read of indexed code without outline', async () => {
+    const stateStore = makeStateStore();
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's1',
+        cwd: '/proj/myapp',
+        tool_name: 'Read',
+        tool_input: { file_path: '/proj/myapp/src/index.ts' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore,
+    });
+
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny');
+    expect(out.hookSpecificOutput.permissionDecisionReason).toMatch(/memory-code/);
+  });
+
+  test('allows Read with offset/limit', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's2',
+        cwd: '/proj/myapp',
+        tool_name: 'Read',
+        tool_input: { file_path: '/proj/myapp/src/index.ts', offset: 1, limit: 50 },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out).toBeNull();
+  });
+
+  test('allows Read of config files', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's3',
+        cwd: '/proj/myapp',
+        tool_name: 'Read',
+        tool_input: { file_path: '/proj/myapp/package.json' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out).toBeNull();
+  });
+
+  test('allows Read when file is in exploredFiles', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('s4', {
+      ...realStateStore.defaultState(),
+      exploredFiles: ['src/index.ts'],
+    });
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's4',
+        cwd: '/proj/myapp',
+        tool_name: 'Read',
+        tool_input: { file_path: '/proj/myapp/src/index.ts' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore,
+    });
+    expect(out).toBeNull();
+  });
+
+  test('denies broad Grep in indexed repo', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's5',
+        cwd: '/proj/myapp',
+        tool_name: 'Grep',
+        tool_input: { pattern: 'context.*inject', path: '/proj/myapp/src' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  test('allows targeted Grep symbol lookup', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's6',
+        cwd: '/proj/myapp',
+        tool_name: 'Grep',
+        tool_input: { pattern: 'rankObservations', path: '/proj/myapp/src' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out).toBeNull();
+  });
+
+  test('denies broad Glob **/* in indexed repo', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's7',
+        cwd: '/proj/myapp',
+        tool_name: 'Glob',
+        tool_input: { pattern: '**/*', path: '/proj/myapp' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  test('denies bash rg in indexed repo', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's8',
+        cwd: '/proj/myapp',
+        tool_name: 'Bash',
+        tool_input: { command: 'rg context src/' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  test('allows bash targeted grep', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's9',
+        cwd: '/proj/myapp',
+        tool_name: 'Bash',
+        tool_input: { command: 'grep -rn "rankObservations" src/' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out).toBeNull();
+  });
+
+  test('does not apply bash search guardrail to git ops', async () => {
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's10',
+        cwd: '/proj/myapp',
+        tool_name: 'Bash',
+        tool_input: { command: 'git pull origin main' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore: makeStateStore(),
+    });
+    expect(out).toBeNull();
+  });
+
+  test('mcp memory-code seeds exploredFiles and resets reminder', async () => {
+    const stateStore = makeStateStore();
+    const out = await handlePreToolUse({
+      payload: {
+        session_id: 's11',
+        cwd: '/proj/myapp',
+        tool_name: 'mcp__lapis__memory-code',
+        tool_input: { mode: 'outline', repo: 'myapp', file: 'src/foo.ts' },
+      },
+      getKnownRepos: () => [INDEXED_REPO],
+      stateStore,
+    });
+    expect(out).toBeNull();
+    const state = stateStore._peek('s11');
+    expect(state.exploredFiles).toContain('src/foo.ts');
+    expect(state.callsSinceLastMemory).toBe(0);
+    expect(state.lastMemoryToolCall).toBeGreaterThan(0);
+  });
+});
+
+// =====================================================================
+// PostToolUse
+// =====================================================================
+
+describe('claude-code handlers: PostToolUse', () => {
+  test('tracks edited files from Write', async () => {
+    const stateStore = makeStateStore();
+    await handlePostToolUse({
+      payload: {
+        session_id: 'p1',
+        tool_name: 'Write',
+        tool_input: { file_path: '/proj/myapp/src/new.ts' },
+        tool_response: { success: true },
+      },
+      dispatch: async () => ({}),
+      getKnownRepos: () => [],
+      stateStore,
+    });
+    expect(stateStore._peek('p1').editedFiles).toContain('/proj/myapp/src/new.ts');
+  });
+
+  test('mirrors memory-save success counter', async () => {
+    const stateStore = makeStateStore();
+    await handlePostToolUse({
+      payload: {
+        session_id: 'p2',
+        tool_name: 'mcp__lapis__memory-save',
+        tool_input: { title: 'T', content: 'C' },
+        tool_response: { content: [{ type: 'text', text: 'Memory saved: [#42] Title' }] },
+      },
+      dispatch: async () => ({}),
+      getKnownRepos: () => [],
+      stateStore,
+    });
+    expect(stateStore._peek('p2').memoriesSavedThisSession).toBe(1);
+  });
+
+  test('does not increment counter on duplicate warning', async () => {
+    const stateStore = makeStateStore();
+    await handlePostToolUse({
+      payload: {
+        session_id: 'p3',
+        tool_name: 'mcp__lapis__memory-save',
+        tool_input: { title: 'T', content: 'C' },
+        tool_response: {
+          content: [{ type: 'text', text: 'Potential duplicate detected:\n  - [#5] Similar' }],
+        },
+      },
+      dispatch: async () => ({}),
+      getKnownRepos: () => [],
+      stateStore,
+    });
+    expect(stateStore._peek('p3').memoriesSavedThisSession).toBe(0);
+  });
+
+  test('mirrors memory-search into pendingRecallFeedback', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('p4', { ...realStateStore.defaultState(), sessionId: 77 });
+    await handlePostToolUse({
+      payload: {
+        session_id: 'p4',
+        tool_name: 'mcp__lapis__memory-search',
+        tool_input: { query: 'auth flow' },
+        tool_response: {
+          content: [{ type: 'text', text: 'Found 1 memories:\n- [#9] [decision] Auth' }],
+        },
+      },
+      dispatch: async () => ({}),
+      getKnownRepos: () => [],
+      stateStore,
+    });
+    expect(stateStore._peek('p4').pendingRecallFeedback).toEqual([[9, { sessionId: 77, query: 'auth flow' }]]);
+  });
+
+  test('mirrors memory-get by removing recall feedback entry', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('p5', {
+      ...realStateStore.defaultState(),
+      pendingRecallFeedback: [[9, { sessionId: 1, query: 'q' }]],
+    });
+    await handlePostToolUse({
+      payload: {
+        session_id: 'p5',
+        tool_name: 'mcp__lapis__memory-get',
+        tool_input: { id: 9 },
+        tool_response: { content: [{ type: 'text', text: '## #9 — Title' }] },
+      },
+      dispatch: async () => ({}),
+      getKnownRepos: () => [],
+      stateStore,
+    });
+    expect(stateStore._peek('p5').pendingRecallFeedback).toEqual([]);
+  });
+
+  test('harvests explored files from memory-code response', async () => {
+    const stateStore = makeStateStore();
+    await handlePostToolUse({
+      payload: {
+        session_id: 'p6',
+        tool_name: 'mcp__lapis__memory-code',
+        tool_input: { mode: 'callers', repo: 'myapp', symbol: 'foo' },
+        tool_response: {
+          content: [{ type: 'text', text: 'Callers of foo in extensions/memory-layer/hooks/tool-guardrails.ts' }],
+        },
+      },
+      dispatch: async () => ({}),
+      getKnownRepos: () => [],
+      stateStore,
+    });
+    const explored = stateStore._peek('p6').exploredFiles;
+    expect(explored.some((f) => f.includes('tool-guardrails.ts'))).toBe(true);
+  });
+
+  test('git-trust sync fires on git pull', async () => {
+    const { dispatch, calls } = makeFakeDispatch();
+    const stateStore = makeStateStore();
+    stateStore.saveState('p7', { ...realStateStore.defaultState(), currentProject: 'myapp' });
+
+    await runGitTrustSync({
+      dispatch,
+      getKnownRepos: () => [INDEXED_REPO],
+      state: stateStore._peek('p7'),
+      cwd: '/proj/myapp',
+    });
+
+    expect(calls.some((c) => c.cmd === 'sync-code-trust')).toBe(true);
+  });
+});
+
+// =====================================================================
+// Router integration
+// =====================================================================
+
+describe('claude-code router: PreToolUse/PostToolUse wired', () => {
+  test('PreToolUse returns deny JSON on stdout for blocked Read', async () => {
+    const writes = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      await runHook(['hook', 'PreToolUse'], {
+        ensureDb: false,
+        stdin: JSON.stringify({
+          session_id: 'r-pre',
+          cwd: '/proj/myapp',
+          tool_name: 'Read',
+          tool_input: { file_path: '/proj/myapp/src/index.ts' },
+        }),
+        getKnownRepos: () => [INDEXED_REPO],
+        stateStore: makeStateStore(),
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const out = JSON.parse(writes.join('').trim());
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny');
+  });
+
+  test('PostToolUse is silent on stdout', async () => {
+    const writes = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      await runHook(['hook', 'PostToolUse'], {
+        ensureDb: false,
+        stdin: JSON.stringify({
+          session_id: 'r-post',
+          tool_name: 'Write',
+          tool_input: { file_path: '/p/f.ts' },
+          tool_response: {},
+        }),
+        dispatch: async () => ({}),
+        getKnownRepos: () => [],
+        stateStore: makeStateStore(),
+      });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    expect(writes.join('')).toBe('');
+  });
+});

--- a/test/hooks-engine/guardrail-utils.test.js
+++ b/test/hooks-engine/guardrail-utils.test.js
@@ -32,6 +32,27 @@ describe('hooks-engine guardrail-utils: isTargetedSymbolLookup', () => {
   });
 });
 
+describe('hooks-engine guardrail-utils: isTargetedGrepLookup', () => {
+  const { isTargetedGrepLookup, isBroadGlobDiscovery } = require('../../src/hooks-engine/guardrail-utils');
+
+  test('allows targeted Grep symbol', () => {
+    expect(isTargetedGrepLookup('rankObservations', '/proj/src')).toBe(true);
+  });
+
+  test('blocks regex metachar patterns', () => {
+    expect(isTargetedGrepLookup('context.*', '/proj/src')).toBe(false);
+  });
+
+  test('allows single-file scope', () => {
+    expect(isTargetedGrepLookup('foobar', '/proj/src/foo.ts')).toBe(true);
+  });
+
+  test('isBroadGlobDiscovery flags **/*', () => {
+    expect(isBroadGlobDiscovery('**/*')).toBe(true);
+    expect(isBroadGlobDiscovery('**/*.test.js')).toBe(false);
+  });
+});
+
 describe('hooks-engine guardrail-utils: isPipedOutputFilter', () => {
   test('allows grep when filtering command output', () => {
     expect(isPipedOutputFilter('npx oxlint 2>&1 | grep -iE "(lowercase|Unused)" || true')).toBe(true);

--- a/test/hooks-engine/tool-response-parse.test.js
+++ b/test/hooks-engine/tool-response-parse.test.js
@@ -1,0 +1,85 @@
+const {
+  extractResponseText,
+  parseMemoryIds,
+  parseSearchResultIds,
+  wasSaveSuccessful,
+} = require('../../src/hooks-engine/tool-response-parse');
+
+describe('hooks-engine tool-response-parse', () => {
+  describe('parseMemoryIds', () => {
+    test('parses [#42] markers', () => {
+      expect(parseMemoryIds('Memory saved: [#42] My decision')).toEqual([42]);
+    });
+
+    test('parses multiple ids', () => {
+      expect(parseMemoryIds('- [#1] a\n- [#2] b')).toEqual([1, 2]);
+    });
+
+    test('returns empty for missing markers', () => {
+      expect(parseMemoryIds('no ids here')).toEqual([]);
+    });
+
+    test('handles null/empty input', () => {
+      expect(parseMemoryIds(null)).toEqual([]);
+      expect(parseMemoryIds('')).toEqual([]);
+    });
+  });
+
+  describe('parseSearchResultIds', () => {
+    test('parses formatted search lines', () => {
+      const text = 'Found 2 memories:\n- [#10] [decision] Auth flow\n- [#11] [bugfix] Fix login';
+      expect(parseSearchResultIds(text)).toEqual([10, 11]);
+    });
+
+    test('parses JSON results envelope', () => {
+      const text = JSON.stringify({ results: [{ id: 7 }, { id: 8 }] });
+      expect(parseSearchResultIds(text)).toEqual([7, 8]);
+    });
+
+    test('falls back to markers when JSON is invalid', () => {
+      expect(parseSearchResultIds('{not json [#3]')).toEqual([3]);
+    });
+  });
+
+  describe('wasSaveSuccessful', () => {
+    test('true for successful save with id', () => {
+      expect(wasSaveSuccessful('Memory saved: [#42] Title')).toBe(true);
+    });
+
+    test('false for potential duplicate warning', () => {
+      expect(wasSaveSuccessful('Potential duplicate detected:\n  - [#5] Similar (90% similar)')).toBe(false);
+    });
+
+    test('false for duplicate with leading warning emoji stripped context', () => {
+      expect(wasSaveSuccessful('Warning: Potential duplicate detected')).toBe(false);
+    });
+
+    test('true for JSON save result with id', () => {
+      expect(wasSaveSuccessful(JSON.stringify({ id: 99, title: 'x' }))).toBe(true);
+    });
+
+    test('false for JSON potential_duplicate status', () => {
+      expect(wasSaveSuccessful(JSON.stringify({ status: 'potential_duplicate', matches: [] }))).toBe(false);
+    });
+
+    test('false for error responses', () => {
+      expect(wasSaveSuccessful('Error: boom')).toBe(false);
+      expect(wasSaveSuccessful('Failed to save memory.')).toBe(false);
+    });
+  });
+
+  describe('extractResponseText', () => {
+    test('joins MCP content blocks', () => {
+      const tr = { content: [{ type: 'text', text: 'line1' }, { type: 'text', text: 'line2' }] };
+      expect(extractResponseText(tr)).toBe('line1\nline2');
+    });
+
+    test('passes through strings', () => {
+      expect(extractResponseText('plain')).toBe('plain');
+    });
+
+    test('handles null', () => {
+      expect(extractResponseText(null)).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Implements **Phase 3** of the Claude Code CLI epic ([#205](https://github.com/GeneGulanesJr/LaPis/issues/205)): PreToolUse guardrails, PostToolUse edit/git tracking, and MCP tool-state mirroring across the process boundary.

Fixes #208

Depends on Phase 2 ([#207](https://github.com/GeneGulanesJr/LaPis/issues/207) / #216).

## What changed

### PreToolUse (`handlers/pre-tool-use.js`)
- **Read** — blocks whole-file reads of indexed code files unless bypassed (offset/limit, config files, `node_modules`, cross-project, already-explored). No auto-index on miss; emits manual `memory-code index-repo` guidance.
- **Grep** (primary search guardrail) — denies broad regex scans in indexed repos; allows targeted single-symbol lookups via `isTargetedGrepLookup`.
- **Glob** — denies broad `**/*` discovery in indexed repos.
- **Bash** (secondary) — denies `rg|grep|ag|ack|find` scans in indexed repos; skips git ops (handled by PostToolUse trust sync).
- **`mcp__lapis__memory-code`** — seeds `exploredFiles`, resets memory reminder counters.
- **`mcp__lapis__memory-*`** — resets `lastMemoryToolCall` / `callsSinceLastMemory`.

### PostToolUse (`handlers/post-tool-use.js`)
- **Edit-track** — `Write|MultiEdit|Edit` → `editedFiles`
- **Git-trust** — `Bash` git pull/checkout/merge/rebase/reset/stash-pop → async `sync-code-trust`
- **Tool-state mirroring** (process-boundary fix):
  - `memory-save` (success) → `memoriesSavedThisSession++`
  - `memory-search` → populates `pendingRecallFeedback` from `[#id]` markers / JSON results
  - `memory-get` / `memory-delete` → removes matched recall feedback entries
  - `memory-code` → harvests file paths into `exploredFiles`

### New shared modules
- `src/hooks-engine/tool-response-parse.js` — `[#id]` marker parsing, `wasSaveSuccessful`, JSON/text response normalization
- `src/claude-code/tool-map.js` — tool → handler category routing
- `src/claude-code/state-mutations.js` — JSON-serializable state field helpers
- `src/hooks-engine/guardrail-utils.js` — `isTargetedGrepLookup`, `isBroadGlobDiscovery`

## Extraction Checklist

- [x] Full test suite passes locally for new tests: `npm test -- test/hooks-engine/tool-response-parse.test.js test/hooks-engine/guardrail-utils.test.js test/claude-code/pre-post-tool-use.test.js test/claude-code/handlers.test.js` (74 tests)
- [x] Smoke CLI tests pass: `node test/smoke-cli.js` (143 passed)
- [x] Lint passes: `npm run lint`

## Type of Change

- [x] New feature

## How Has This Been Tested?

- Unit tests for `tool-response-parse` (`[#42]` parsing, duplicate vs success, JSON envelopes)
- Handler tests for Read/Grep/Glob/Bash guardrail allow/deny matrix
- PostToolUse mirroring tests for save counter, recall feedback populate/remove, explored file harvest
- Router integration tests confirming PreToolUse deny JSON on stdout and silent PostToolUse
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31a3eedc-9c51-47d5-ad1c-e9fd56a62995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31a3eedc-9c51-47d5-ad1c-e9fd56a62995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

