### PR TITLE
docs(claude-code): Phase 6 — docs, package.json exports, polish (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Claude Code bridge — Phase 6: docs + package.json + polish** (#211, part of #205).
+  - New [`docs/CLAUDE_CODE.md`](docs/CLAUDE_CODE.md) — install guide, hook → feature mapping,
+    two-config layout, state storage, first-use MCP approval, deliberate Pi divergences,
+    troubleshooting (silent DB init, stdio-only errors, hooks fail open), and deferred
+    output-compression follow-up.
+  - README "Use with Claude Code" install subsection; updates to
+    [`docs/COMMANDS.md`](docs/COMMANDS.md), [`docs/INDEX.md`](docs/INDEX.md),
+    [`docs/SKILL.md`](docs/SKILL.md).
+  - `package.json`: explicit `src/claude-code/` + `src/hooks-engine/` in `files`;
+    `"./claude-code"` export; optional `lapis-cc` bin alias.
+
 - **Claude Code bridge — Phase 5: daemon mode + POST /dispatch (optional perf tier)** (#210, part of #205).
   - `POST /dispatch` on the existing HTTP server — wraps `gateway.dispatch(cmd, args)`
     and returns the raw gateway JSON (including `{error}` envelopes for unknown cmds).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     [`docs/SKILL.md`](docs/SKILL.md).
   - `package.json`: explicit `src/claude-code/` + `src/hooks-engine/` in `files`;
     `"./claude-code"` export; optional `lapis-cc` bin alias.
+  - Review polish: hook table adds `MultiEdit` and PostToolUse `memory-code` harvest;
+    documents `lapis-cc` alias; fixes relative doc links.
 
 - **Claude Code bridge — Phase 5: daemon mode + POST /dispatch (optional perf tier)** (#210, part of #205).
   - `POST /dispatch` on the existing HTTP server — wraps `gateway.dispatch(cmd, args)`

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ LaPis does not install npm dependencies at runtime. If you are running from a lo
 npm install
 ```
 
+### Use with Claude Code
+
+LaPis also integrates with the [Claude Code CLI](https://code.claude.com/docs/en/overview) — same persistent memory, code guardrails, and session lifecycle as the Pi extension, wired through Claude Code's MCP + hooks config.
+
+```bash
+npx -y @genegulanesjr/lapis claude-code install
+npx -y @genegulanesjr/lapis claude-code doctor   # verify install
+```
+
+This writes `.mcp.json` (MCP tools) and `.claude/settings.json` (lifecycle hooks). On first use, approve the LaPis MCP server via `/mcp` in an interactive `claude` session.
+
+Full setup, hook mapping, troubleshooting, and install flags: [`docs/CLAUDE_CODE.md`](docs/CLAUDE_CODE.md).
+
 ## What It Does
 
 - **Remembers across sessions** - decisions, bugfixes, patterns, discoveries, and constraints persist.

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -1,0 +1,206 @@
+# Claude Code Integration
+
+LaPis ships first-class support for the [Claude Code CLI](https://code.claude.com/docs/en/overview). Claude Code gets the same hook-driven experience Pi has — auto context injection, passive capture, trust sync, session lifecycle, and tool guardrails — not just bare MCP tools.
+
+Claude Code integration runs over **two separate config systems** that LaPis never mixes:
+
+| System | Config file | What it wires |
+| --- | --- | --- |
+| **MCP tools** | `.mcp.json` (project) or `~/.claude.json` (user/local) | `mcp__lapis__memory-*`, `mcp__lapis__memory-code`, etc. |
+| **Hooks** | `.claude/settings.json` (project) or `~/.claude/settings.json` (user) | Session lifecycle, guardrails, passive capture, tracking |
+
+See the [Claude Code hooks spec](https://code.claude.com/docs/en/hooks) and [MCP config docs](https://code.claude.com/docs/en/mcp) for upstream details.
+
+## Quick start
+
+From your project root:
+
+```bash
+npx -y @genegulanesjr/lapis claude-code install
+```
+
+Then start an interactive Claude Code session in the same directory. On first use, approve the LaPis MCP server when prompted (`/mcp`).
+
+Verify the install:
+
+```bash
+npx -y @genegulanesjr/lapis claude-code doctor
+```
+
+Uninstall (reverses only LaPis-owned entries):
+
+```bash
+npx -y @genegulanesjr/lapis claude-code uninstall
+```
+
+## Install options
+
+```bash
+lapis claude-code install [flags]
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--global` | User scope: hooks → `~/.claude/settings.json`, MCP → `~/.claude.json` top-level `mcpServers`. |
+| `--mcp-name <name>` | MCP server name (default `lapis`). Tool names become `mcp__<name>__*`. |
+| `--no-claude-md` | Skip appending the memory-usage protocol block to `.claude/CLAUDE.md`. |
+| `--bin <path>` | Command resolution: bare name on PATH (`lapis`), or `node <script>` for a local clone. Machine-specific paths go to `.claude/settings.local.json` and `~/.claude.json` local scope. |
+| `--auto-allow` | Pre-approve `mcp__<name>__*` in `permissions.allow` (default off — you approve on first use). |
+| `--daemon` | Start a detached `lapis serve` and write the daemon lockfile so hooks POST to `/dispatch` instead of cold-starting per hook. |
+| `--daemon-port <port>` | Daemon port when `--daemon` is set (default `9100`). |
+
+**Command resolution ladder** (portability vs speed):
+
+1. **npx** (default) — `npx -y @genegulanesjr/lapis …` — portable, committable.
+2. **global bin** — `--bin lapis` — fastest direct spawn, still PATH-relative and committable.
+3. **local clone** — `--bin ./memory-store.js` — machine-specific; hooks land in `settings.local.json`.
+4. **daemon** — `--daemon` — optional perf tier; hooks reuse a warm `lapis serve` process via `POST /dispatch`.
+
+Manage the daemon separately:
+
+```bash
+lapis claude-code start [--port 9100] [--host 127.0.0.1] [--detached]
+lapis claude-code stop
+```
+
+## Two-config layout
+
+After install, your project typically has:
+
+```text
+.mcp.json                          # MCP server: npx -y @genegulanesjr/lapis mcp
+.claude/
+  settings.json                    # Hook handlers (exec-form command hooks)
+  CLAUDE.md                        # Memory protocol block (<!-- lapis:start --> … <!-- lapis:end -->)
+```
+
+With `--global`, hooks and MCP move to user scope. With machine-specific `--bin` paths, hooks go to `.claude/settings.local.json` (gitignored) and MCP to `~/.claude.json` under `projects[<cwd>].mcpServers` — the committable files are never touched with absolute paths.
+
+Re-install is idempotent: LaPis hook handlers are identified by a sentinel (`claude-code hook <Event>` in the args array) and replaced in place; MCP servers are deduped by name and resolved command string.
+
+## Hook → feature mapping
+
+| Claude Code event | LaPis behavior |
+| --- | --- |
+| `SessionStart` (`startup` \| `resume` \| `clear`) | `session-start` dispatch + inject context |
+| `SessionStart` (`compact`) | Re-inject only (no new session-start) |
+| `UserPromptSubmit` | Prompt-matched context + preflight + cadence-gated memory reminder (30s budget) |
+| `PreToolUse` `Read` | Block whole-file reads of indexed code |
+| `PreToolUse` `Grep` / `Glob` | **Primary** code-search guardrail (agent is instructed to prefer these over bash grep/find) |
+| `PreToolUse` `Bash` (search cmds) | Secondary search guardrail via `if`-field rules (`grep`, `rg`, `ag`, `ack`, `find`) |
+| `PreToolUse` `mcp__lapis__memory-code` | Seed `exploredFiles` |
+| `PostToolUse` `Write` \| `Edit` | Edit-track (sync) |
+| `PostToolUse` `Bash` (git ops) | `sync-code-trust` (async) |
+| `PostToolUse` `mcp__lapis__memory-save` \| `search` \| `get` \| `delete` | **Tool-state mirroring** (counters + recall feedback) — process-boundary fix |
+| `Stop` | Passive-capture + checkpoint + dream (silent, async) |
+| `SessionEnd` | `session-summary` + `session-end` (awaited, DB-derived count) |
+
+Hooks are wired as exec-form command handlers, e.g.:
+
+```json
+{
+  "type": "command",
+  "command": "npx",
+  "args": ["-y", "@genegulanesjr/lapis", "claude-code", "hook", "SessionStart"],
+  "timeout": 30
+}
+```
+
+Heavy handlers (`Stop`, git-trust `PostToolUse`) run with `async: true`. `PostToolUse` is split with `--skip git-trust` / `--only git-trust` so tracking stays synchronous while trust sync runs in the background.
+
+## State storage
+
+Claude Code spawns a **fresh process per hook event**. The in-process `state` object Pi's extension mutates is invisible across hook invocations.
+
+LaPis persists per-session state to:
+
+```text
+~/.pi/memory/claude-sessions/<claude_session_id>.json
+```
+
+Fields mirror the Pi extension's session state (`sessionId`, `turnCount`, `editedFiles`, `exploredFiles`, `memoriesSavedThisSession`, `pendingRecallFeedback`, etc.). The main SQLite database stays at `~/.pi/memory/memory.db` (configurable via `~/.pi/memory/config.jsonc`).
+
+**Shared config is intentional.** LaPis does **not** fork a `~/.claude/` database or fragment memories. The same `~/.pi/memory/` store is shared across Pi, Claude Code, and the MCP server — memories, code indexes, and trust scores stay in one place.
+
+## First-use MCP approval
+
+Project-scoped `.mcp.json` servers show as **"⏸ Pending approval"** until you approve them inside an interactive `claude` session (`/mcp`). This is Claude Code's security model, not LaPis.
+
+To skip manual approval (e.g. in trusted dev environments):
+
+```bash
+lapis claude-code install --auto-allow
+```
+
+## Deliberate divergences from Pi
+
+| Area | Pi extension | Claude Code bridge |
+| --- | --- | --- |
+| Guardrail auto-indexing on miss | May trigger indexing | **Deferred** — would blow the hook timeout budget |
+| MCP tool search scope | Project-scoped | Project-scoped (same) |
+| Config / DB path | `~/.pi/memory/` | `~/.pi/memory/` (shared — not forked) |
+| Output compression | Replaces bash tool result in place | **Not wired** — `PostToolUse` cannot rewrite an already-executed tool result (see [deferred follow-up](#deferred-output-compression)) |
+| Process model | In-process `state` | Disk-backed `claude-sessions/` + tool-state mirroring on `PostToolUse` |
+
+## Troubleshooting
+
+### Silent DB init
+
+If the database has never been initialized, the first hook call runs `ensureDb()` silently. If initialization fails (permissions, corrupt schema), the hook logs to **stderr** and exits non-zero for DB errors — but handler crashes still **fail open** (exit 0) so Claude Code is never blocked.
+
+Check manually:
+
+```bash
+lapis claude-code doctor
+node memory-store.js stats
+```
+
+### stdio-only errors
+
+Hook handlers write the Claude Code JSON decision to **stdout only**. All diagnostics go to **stderr**. If hooks appear to do nothing, inspect stderr:
+
+```bash
+echo '{}' | npx -y @genegulanesjr/lapis claude-code hook SessionStart 2>debug.log
+```
+
+### Hooks fail open
+
+By design, a timed-out or crashed hook lets the tool call proceed. Guardrail reliability matters — if a `PreToolUse` handler crashes, the read/search is **not** blocked. Check stderr for `claude-code <event> handler error:` lines.
+
+Timeouts are tuned per handler: 15s for `PreToolUse`/`PostToolUse` tracking, 30s for lifecycle events, 60s for async `Stop` and git-trust.
+
+### MCP tools work but hooks do not
+
+Run `lapis claude-code doctor`. Common causes:
+
+- Hooks file missing or LaPis handlers stripped — re-run `install`.
+- `better-sqlite3` native module mismatch — run `npm install` in the LaPis checkout or use `npx` so the published binary matches your Node version.
+- Machine-specific `--bin` path moved — re-install or update `.claude/settings.local.json`.
+
+### Daemon mode not used
+
+Hooks auto-select daemon dispatch when `LAPIS_DAEMON_URL` is set or `~/.pi/memory/claude-daemon.json` points at a live process. Otherwise they cold-start direct dispatch. Start the daemon with `lapis claude-code start --detached` or install with `--daemon`.
+
+## Programmatic access
+
+The bridge is published as npm subpath exports:
+
+```js
+const { runHook } = require('@genegulanesjr/lapis/claude-code');
+const hooksEngine = require('@genegulanesjr/lapis/hooks-engine');
+```
+
+See [`docs/MODULE_MAP.md`](MODULE_MAP.md) for module ownership.
+
+## Deferred: output compression
+
+Pi's `output-compression` **replaces** the bash tool result in place. Claude Code's `PostToolUse` cannot rewrite an already-executed tool's result.
+
+A follow-up option: emit the compressed summary as `additionalContext` on the same `PostToolUse` so Claude still sees the savings note without the raw bytes. This is tracked separately and is not required for parity.
+
+## See also
+
+- [`docs/COMMANDS.md`](COMMANDS.md) — `claude-code` subcommand reference
+- [`docs/CONFIGURATION.md`](CONFIGURATION.md) — `~/.pi/memory/config.jsonc`
+- [`docs/MODULE_MAP.md`](MODULE_MAP.md) — `src/claude-code/` and `src/hooks-engine/` ownership
+- [Epic #205](https://github.com/GeneGulanesJr/LaPis/issues/205) — full phased breakdown

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -89,8 +89,9 @@ Re-install is idempotent: LaPis hook handlers are identified by a sentinel (`cla
 | `PreToolUse` `Grep` / `Glob` | **Primary** code-search guardrail (agent is instructed to prefer these over bash grep/find) |
 | `PreToolUse` `Bash` (search cmds) | Secondary search guardrail via `if`-field rules (`grep`, `rg`, `ag`, `ack`, `find`) |
 | `PreToolUse` `mcp__lapis__memory-code` | Seed `exploredFiles` |
-| `PostToolUse` `Write` \| `Edit` | Edit-track (sync) |
+| `PostToolUse` `Write` \| `Edit` \| `MultiEdit` | Edit-track (sync) |
 | `PostToolUse` `Bash` (git ops) | `sync-code-trust` (async) |
+| `PostToolUse` `mcp__lapis__memory-code` | Harvest file paths into `exploredFiles` |
 | `PostToolUse` `mcp__lapis__memory-save` \| `search` \| `get` \| `delete` | **Tool-state mirroring** (counters + recall feedback) — process-boundary fix |
 | `Stop` | Passive-capture + checkpoint + dream (silent, async) |
 | `SessionEnd` | `session-summary` + `session-end` (awaited, DB-derived count) |
@@ -183,14 +184,16 @@ Hooks auto-select daemon dispatch when `LAPIS_DAEMON_URL` is set or `~/.pi/memor
 
 ## Programmatic access
 
-The bridge is published as npm subpath exports:
+The hook router is published as an npm subpath export (install, doctor, and daemon lifecycle remain CLI-only via `lapis` / `lapis-cc`):
 
 ```js
 const { runHook } = require('@genegulanesjr/lapis/claude-code');
 const hooksEngine = require('@genegulanesjr/lapis/hooks-engine');
 ```
 
-See [`docs/MODULE_MAP.md`](MODULE_MAP.md) for module ownership.
+`lapis-cc` is a bin alias for `lapis` — both resolve to `memory-store.js`.
+
+See [`MODULE_MAP.md`](MODULE_MAP.md) for module ownership.
 
 ## Deferred: output compression
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -184,6 +184,7 @@ Commands for the [Claude Code CLI](https://code.claude.com/docs/en/overview) int
 
 ```bash
 node memory-store.js claude-code <subcommand> [flags]
+# or: lapis claude-code … / lapis-cc claude-code …
 ```
 
 | Subcommand | Purpose |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -177,3 +177,20 @@ node memory-store.js serve [--host HOST] [--port PORT]
 Defaults to `127.0.0.1:9100`. The server exposes REST endpoints for missions, milestones, working units, handoffs, contracts, verdicts, broadcasts, findings, sessions, memory search, costs, retry/rescope, compression, checkpoints, settings, code indexing/analysis, and the todo/ledger domain. See [`API.md`](API.md) for the full endpoint reference.
 
 See [`DREAM_CYCLE.md`](DREAM_CYCLE.md) for the cleanup policy behind `dream`.
+
+## Claude Code Bridge
+
+Commands for the [Claude Code CLI](https://code.claude.com/docs/en/overview) integration. Full setup guide: [`CLAUDE_CODE.md`](CLAUDE_CODE.md).
+
+```bash
+node memory-store.js claude-code <subcommand> [flags]
+```
+
+| Subcommand | Purpose |
+| --- | --- |
+| `install` | Write Claude Code config: MCP server (`.mcp.json` or `~/.claude.json`) + hooks (`.claude/settings.json`). Flags: `--global`, `--mcp-name <name>`, `--no-claude-md`, `--bin <path>`, `--auto-allow`, `--daemon`, `--daemon-port <port>`. |
+| `uninstall` | Remove LaPis-owned MCP entries and hook handlers (sentinel-based; unrelated config left intact). |
+| `doctor` | Install self-check: `better-sqlite3` loads, DB writable, MCP `command`/`args` resolve, hooks present, session state store writable. Exit code 1 on failure. |
+| `start` | Start the optional dispatch daemon (`lapis serve`). Flags: `--port`, `--host`, `--detached`. |
+| `stop` | Stop the dispatch daemon and remove the lockfile. |
+| `hook <event>` | Internal hook router (invoked by Claude Code, not manually). Events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `SessionEnd`. Optional `--only <role>` / `--skip <role>` for split handlers. |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -28,6 +28,7 @@ Run `npm test` to regenerate. The previous numbers (89 / 1454 / 1455) reflected 
 | Step-by-step usage tutorial          | [`docs/TUTORIAL.md`](TUTORIAL.md)                |
 | Async code indexing                  | [`docs/code-indexing.md`](code-indexing.md)      |
 | Extension skill overview             | [`docs/SKILL.md`](SKILL.md)                      |
+| Claude Code CLI integration          | [`docs/CLAUDE_CODE.md`](CLAUDE_CODE.md)          |
 | Memory layer skill (authoritative)   | [`../skills/memory-layer/SKILL.md`](../skills/memory-layer/SKILL.md) |
 | Token efficiency benchmark           | [`../bench/README.md`](../bench/README.md)       |
 | Module boundaries diagram            | [`docs/diagrams/lapis-module-boundaries.png`](diagrams/lapis-module-boundaries.png) |
@@ -51,6 +52,7 @@ Grouped by router under `src/cli/commands/`. Full syntax in [`docs/COMMANDS.md`]
 - **Agent intel**: `preflight`, `agent-pack`, `dupes`, `enrich-symbols`, `symbol-meta`, `audit-diff`, `runtime-ingest`, `hot-symbols`, `cold-symbols`, `blast`, `stale-flags`
 - **Token saver**: `run`, `token-saver-stats`, `token-saver-clear`
 - **Top-level**: `serve` (HTTP)
+- **Claude Code bridge**: `claude-code install`, `uninstall`, `doctor`, `start`, `stop`, `hook <event>`
 
 ### HTTP endpoints
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -6,6 +6,8 @@ This is the companion skill doc for the `skills/memory-layer/SKILL.md` extension
 
 The memory layer provides persistent memory capabilities for the Pi coding agent. It runs as a Pi extension with a local SQLite backend, providing observation CRUD, code indexing, code analysis, doc indexing, trust scoring, and session lifecycle management — all without cloud dependencies or API keys.
 
+The same backend also powers a [Claude Code CLI](https://code.claude.com/docs/en/overview) integration (`lapis claude-code install`) that wires MCP tools plus lifecycle hooks for context injection, guardrails, passive capture, and session tracking. See [`CLAUDE_CODE.md`](CLAUDE_CODE.md).
+
 ## Key Capabilities
 
 - **Declarative memory** — save, search, update, and delete observations (decisions, bugfixes, patterns, discoveries).
@@ -15,8 +17,11 @@ The memory layer provides persistent memory capabilities for the Pi coding agent
 - **Trust scoring** — memories linked to changed code lose confidence; stable linked code recovers trust.
 - **HTTP server** — optional REST API for programmatic access to the Aurex domain model and code analysis.
 - **Auto-detection** — the extension automatically captures decisions, bugfixes, and discoveries from assistant messages.
+- **Claude Code bridge** — first-class CLI integration via MCP + hooks (`lapis claude-code install`).
 
 ## See Also
+
+- [`CLAUDE_CODE.md`](CLAUDE_CODE.md) — Claude Code install, hook mapping, troubleshooting
 
 - [`../skills/memory-layer/SKILL.md`](../skills/memory-layer/SKILL.md) — complete extension skill reference
 - [`API.md`](API.md) — HTTP API and CLI reference

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "bin": {
     "lapis": "./memory-store.js",
     "memory-store": "./memory-store.js",
-    "lapis-mcp": "./memory-store.js"
+    "lapis-mcp": "./memory-store.js",
+    "lapis-cc": "./memory-store.js"
   },
   "directories": {
     "doc": "docs"
@@ -42,6 +43,8 @@
     "data-access/",
     "services/",
     "src/",
+    "src/claude-code/",
+    "src/hooks-engine/",
     "extensions/",
     "skills/",
     "grammars/",
@@ -53,6 +56,7 @@
     ".": "./memory-store.js",
     "./cli": "./cli.js",
     "./memory-store": "./memory-store.js",
+    "./claude-code": "./src/claude-code/hooks.js",
     "./hooks-engine": "./src/hooks-engine/index.js",
     "./extension": "./extensions/memory-layer/index.ts",
     "./code-analysis": "./src/code-analysis/index.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Closes #211 (Phase 6 of the Claude Code epic #205).

Documentation, packaging, and polish for first-class Claude Code CLI support.

### Docs

- New [`docs/CLAUDE_CODE.md`](docs/CLAUDE_CODE.md) — install (`lapis claude-code install`), hook → feature mapping table, two-config layout (MCP `.mcp.json` vs hooks `.claude/settings.json`), state storage, first-use MCP approval, troubleshooting (silent DB init, stdio-only errors, hooks fail open), deliberate Pi divergences, and deferred output-compression follow-up.
- [`README.md`](README.md) — "Use with Claude Code" subsection under Install.
- Updated [`docs/COMMANDS.md`](docs/COMMANDS.md), [`docs/INDEX.md`](docs/INDEX.md), [`docs/SKILL.md`](docs/SKILL.md).
- [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md) already had `src/claude-code/` + `src/hooks-engine/` entries from earlier phases — no change needed.

### package.json

- `files`: explicit `src/claude-code/` and `src/hooks-engine/` entries.
- `exports`: `"./claude-code": "./src/claude-code/hooks.js"` (hooks-engine export was already present).
- `bin`: optional `lapis-cc` alias.

### Review polish (2nd commit)

- Hook table: `MultiEdit` edit-track + PostToolUse `memory-code` harvest row.
- `lapis-cc` documented as a `lapis` alias; programmatic access section clarifies CLI-only install/doctor/daemon.
- Fixed relative `MODULE_MAP.md` link in `CLAUDE_CODE.md`.

## Type of Change

- [x] Documentation

## How Has This Been Tested?

- `npm pack` — tarball includes `package/src/claude-code/`, `package/src/hooks-engine/`, and `package/docs/CLAUDE_CODE.md`.
- `require('@genegulanesjr/lapis/claude-code')` resolves `runHook` via the new export path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3f68b42-18e4-4712-a04c-fd425416a3be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3f68b42-18e4-4712-a04c-fd425416a3be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

