### PR TITLE
fix(claude-code): address Phase 1-6 review findings (#224-#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Claude Code bridge — Phase 1–6 review polish** (#234 follow-up).
+  - `uniqueEditedPaths` dedupes dual full-path + basename `editedFiles` entries
+    before session summaries, checkpoints, and `audit-diff` (storage shape
+    unchanged for read-guardrail matching).
+  - Updated stale `post-tool-use.js` module comment to reflect `mutateState` locking.
+  - Test coverage for `mutateState` lock-timeout fail-open path.
+
 ### Added
 
 - **Claude Code bridge — Phase 6: docs + package.json + polish** (#211, part of #205).

--- a/cli.js
+++ b/cli.js
@@ -163,6 +163,11 @@ if (isHelpRequest) {
         await runStop(subArgv);
         return;
       }
+      if (sub === 'gc') {
+        const { runGc } = require('./src/claude-code/state-store');
+        runGc(subArgv);
+        return;
+      }
     } catch (e) {
       process.stderr.write(`claude-code ${sub}: ${e instanceof Error ? e.message : String(e)}\n`);
       process.exitCode = 1;

--- a/src/claude-code/daemon.js
+++ b/src/claude-code/daemon.js
@@ -199,8 +199,28 @@ async function runStart(argv, io = {}) {
 
   const existing = readLockfile(lockfilePath);
   if (existing?.pid && isProcessAlive(existing.pid)) {
-    log(`LaPis daemon already running (pid ${existing.pid}, port ${existing.port}).`);
-    return { alreadyRunning: true, ...existing };
+    const portMismatch = Number.isFinite(existing.port) && existing.port !== flags.port;
+    const hostMismatch = Boolean(existing.host) && existing.host !== flags.host;
+    if (portMismatch || hostMismatch) {
+      // The lockfile is the source of truth; the install `--daemon-port` flag
+      // cannot relocate a running daemon. Warn loudly and keep the existing one
+      // rather than silently dropping the flag or disrupting other sessions
+      // sharing this daemon (#232).
+      log(
+        `⚠ LaPis daemon already running (pid ${existing.pid}) on http://${existing.host}:${existing.port},` +
+          ` but http://${flags.host}:${flags.port} was requested.`,
+      );
+      log('  Run `lapis claude-code stop` first to change the host/port. Keeping the existing daemon.');
+    } else {
+      log(`LaPis daemon already running (pid ${existing.pid}, port ${existing.port}).`);
+    }
+    return {
+      alreadyRunning: true,
+      ...existing,
+      requestedPort: flags.port,
+      requestedHost: flags.host,
+      ...(portMismatch || hostMismatch ? { mismatch: { portMismatch, hostMismatch } } : {}),
+    };
   }
   if (existing) {
     removeLockfile(lockfilePath);

--- a/src/claude-code/dispatch-client.js
+++ b/src/claude-code/dispatch-client.js
@@ -8,7 +8,7 @@
  *
  * Backends (auto-selected):
  *   1. Daemon mode — when LAPIS_DAEMON_URL or the daemon lockfile points at a
- *      live `lapis serve`, POST {cmd,args,project} to /dispatch (~ms latency).
+ *      live `lapis serve`, POST {cmd,args} to /dispatch (~ms latency).
  *   2. Direct mode — in-process gateway.dispatch (Phase 2 fallback).
  *
  * Handlers receive `dispatch` (writes) and the read helpers below. In tests
@@ -48,10 +48,11 @@ async function dispatchViaDaemon(baseUrl, cmd, args, opts = {}) {
   if (typeof fetchFn !== 'function') {
     throw new Error('fetch is unavailable for daemon dispatch');
   }
+  // args.project is already serialized into payload.args.project by
+  // stringifyArgs; the server's mergeDispatchArgs reads it from there. A
+  // redundant top-level `project` field was never consumed and only obscured
+  // the real source of truth (#229).
   const payload = { cmd, args: stringifyArgs(args) };
-  if (args?.project !== undefined && args?.project !== null && args?.project !== '') {
-    payload.project = String(args.project);
-  }
   const res = await fetchFn(`${baseUrl.replace(/\/$/, '')}/dispatch`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/claude-code/doctor.js
+++ b/src/claude-code/doctor.js
@@ -182,7 +182,33 @@ function checkStateStore(deps) {
     const probe = path.join(dir, `.doctor-probe-${process.pid}`);
     fs.writeFileSync(probe, 'ok', 'utf8');
     fs.unlinkSync(probe);
-    return { name: 'session state store', ok: true, detail: `writable at ${dir}` };
+
+    // Observability into the state dir: TTL window + size + oldest file (#233).
+    const ttl = typeof stateStore.defaultTtlHours === 'function' ? stateStore.defaultTtlHours() : 24;
+    let bytes = 0;
+    let oldestName = null;
+    let oldestMs = Infinity;
+    try {
+      for (const entry of fs.readdirSync(dir)) {
+        if (!entry.endsWith('.json')) {
+          continue;
+        }
+        const full = path.join(dir, entry);
+        const stat = fs.statSync(full);
+        bytes += stat.size;
+        if (stat.mtimeMs < oldestMs) {
+          oldestMs = stat.mtimeMs;
+          oldestName = entry;
+        }
+      }
+    } catch {
+      // Ignore readdir/stat failures; the writability check above is the gate.
+    }
+    const kib = (bytes / 1024).toFixed(1);
+    const age =
+      oldestName && Number.isFinite(oldestMs) ? `${((Date.now() - oldestMs) / 3600000).toFixed(1)}h old` : 'none';
+    const detail = `writable at ${dir} · TTL ${ttl}h · ${kib} KiB across .json · oldest: ${oldestName || 'none'} (${age})`;
+    return { name: 'session state store', ok: true, detail };
   } catch (e) {
     return {
       name: 'session state store',

--- a/src/claude-code/file-keys.js
+++ b/src/claude-code/file-keys.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Claude Code bridge: shared file-path normalization for per-session state.
+ *
+ * editedFiles and exploredFiles previously normalized inconsistently
+ * (exploredFiles: lowercased + basename; editedFiles: raw). Centralizing the
+ * scheme here makes the two arrays comparable and keeps the read-guardrail's
+ * lookup shape stable (#230).
+ */
+
+const path = require('node:path');
+
+/**
+ * Lowercase a path and split off its basename, tolerating both POSIX and
+ * Windows separators. Returns null for non-string / empty input.
+ *
+ * @param {string} p
+ * @returns {{ lower: string, base: string } | null}
+ */
+function fileKey(p) {
+  if (typeof p !== 'string' || !p) {
+    return null;
+  }
+  const lower = p.toLowerCase();
+  const base = path.basename(lower.replace(/\\/g, '/'));
+  if (!base) {
+    return null;
+  }
+  return { lower, base };
+}
+
+/**
+ * Append the canonical {lower, base} forms of a path onto an array, deduped.
+ * Used by both addEditedFile (PostToolUse) and addExploredFile/addExploredPath
+ * (PreToolUse/PostToolUse) so the two trackers share one normalization scheme.
+ *
+ * @param {string[]} arr
+ * @param {string} p
+ */
+function addNormalized(arr, p) {
+  const key = fileKey(p);
+  if (!key) {
+    return;
+  }
+  for (const candidate of [key.lower, key.base]) {
+    if (candidate && !arr.includes(candidate)) {
+      arr.push(candidate);
+    }
+  }
+}
+
+module.exports = { fileKey, addNormalized };

--- a/src/claude-code/file-keys.js
+++ b/src/claude-code/file-keys.js
@@ -50,4 +50,31 @@ function addNormalized(arr, p) {
   }
 }
 
-module.exports = { fileKey, addNormalized };
+/**
+ * Collapse the dual {fullPath, basename} entries stored by addNormalized into
+ * one representative path per file for summaries, checkpoints, and audit-diff.
+ * Prefers the longest path in each basename group (typically the full path).
+ *
+ * @param {Iterable<string>|null|undefined} editedFiles
+ * @returns {string[]}
+ */
+function uniqueEditedPaths(editedFiles) {
+  if (!editedFiles) {
+    return [];
+  }
+  const byBase = new Map();
+  for (const entry of editedFiles instanceof Set ? editedFiles : editedFiles) {
+    if (!entry) {
+      continue;
+    }
+    const raw = String(entry);
+    const base = path.basename(raw.replace(/\\/g, '/')).toLowerCase();
+    const prev = byBase.get(base);
+    if (!prev || raw.length > prev.length) {
+      byBase.set(base, raw);
+    }
+  }
+  return [...byBase.values()];
+}
+
+module.exports = { fileKey, addNormalized, uniqueEditedPaths };

--- a/src/claude-code/handlers/post-tool-use.js
+++ b/src/claude-code/handlers/post-tool-use.js
@@ -16,9 +16,9 @@
  *   memory-get-mirror    memory-get|memory-delete → drop consumed ids (marked useful)
  *   memory-code-harvest  memory-code → harvest file paths into exploredFiles
  *
- * All state writes are load → mutate → save on the per-session state file.
- * lost-update under parallel PostToolUse is tolerated for counters (documented
- * risk); the set-like fields dedupe so a concurrent add is at worst a no-op.
+ * State writes that mutate counters or sets route through mutateState (locked
+ * read-modify-write, #228) so parallel PostToolUse hooks cannot lose increments
+ * or clobber each other. git-trust is read-only and never writes back.
  */
 
 const {

--- a/src/claude-code/handlers/post-tool-use.js
+++ b/src/claude-code/handlers/post-tool-use.js
@@ -28,12 +28,16 @@ const {
   extractToolResponseText,
 } = require('../../hooks-engine/tool-response-parse');
 const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const { CODE_EXTENSIONS } = require('../../hooks-engine/guardrail-utils');
+const { addNormalized } = require('../file-keys');
 const { postToolRole } = require('../tool-map');
 
 const GIT_TRUST_OP_RE = /\bgit\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/;
 // Harvest relative code paths from a memory-code response (parity with the Pi
-// tool_result handler in tool-guardrails.ts).
-const CODE_PATH_RE = /[\w/.-]+\.(ts|js|tsx|jsx|mjs|cjs|py|go|rs)/g;
+// tool_result handler in tool-guardrails.ts). The extension alternation is the
+// same list SPECIFIC_CODE_FILE_RE uses so the harvest never lags the
+// classifier (#230).
+const CODE_PATH_RE = new RegExp(`[\\w/.-]+\\.(${CODE_EXTENSIONS.join('|')})`, 'g');
 
 function addEditedFile(state, filePath) {
   if (!filePath) {
@@ -42,9 +46,7 @@ function addEditedFile(state, filePath) {
   if (!Array.isArray(state.editedFiles)) {
     state.editedFiles = [];
   }
-  if (!state.editedFiles.includes(filePath)) {
-    state.editedFiles.push(filePath);
-  }
+  addNormalized(state.editedFiles, filePath);
 }
 
 function addExploredPath(state, p) {
@@ -54,13 +56,7 @@ function addExploredPath(state, p) {
   if (!Array.isArray(state.exploredFiles)) {
     state.exploredFiles = [];
   }
-  const lower = String(p).toLowerCase();
-  const base = lower.split('/').pop();
-  for (const candidate of [lower, base]) {
-    if (candidate && !state.exploredFiles.includes(candidate)) {
-      state.exploredFiles.push(candidate);
-    }
-  }
+  addNormalized(state.exploredFiles, p);
 }
 
 /** Harvest file paths mentioned in a memory-code response into exploredFiles. */
@@ -142,46 +138,59 @@ async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore,
   const claudeSessionId = payload.session_id;
   const cwd = resolveCwd(payload.cwd);
 
-  const state = stateStore.loadState(claudeSessionId);
-  if (!state.currentProject) {
-    state.currentProject = projectFromCwd(cwd);
+  // git-trust only READS state (for currentProject), runs the heavy dispatch,
+  // and never writes back — writing a pre-dispatch snapshot after a slow
+  // sync-code-trust would clobber whatever the synchronous handler saved.
+  // Falls back to loadState when the injected store lacks mutateState.
+  if (role === 'git-trust') {
+    const state = stateStore.loadState(claudeSessionId);
+    await gitTrustSync({ input, dispatch, getKnownRepos, state, cwd });
+    return null;
   }
 
-  switch (role) {
-    case 'edit-track':
-      addEditedFile(state, input.file_path);
-      break;
-    case 'git-trust':
-      await gitTrustSync({ input, dispatch, getKnownRepos, state, cwd });
-      // Deliberately NO saveState: this role runs in the async split handler
-      // (install config `--only git-trust`), gitTrustSync never mutates state,
-      // and writing the pre-dispatch snapshot back after a slow sync-code-trust
-      // would clobber whatever the synchronous handler saved in the meantime.
-      return null;
-    case 'memory-save-mirror':
-      if (wasSaveSuccessful(toolResponse)) {
-        state.memoriesSavedThisSession = (state.memoriesSavedThisSession || 0) + 1;
-      }
-      break;
-    case 'memory-search-mirror':
-      recordSearchRecall(state, parseSearchResultIds(toolResponse), input.query);
-      break;
-    case 'memory-get-mirror': {
-      // memory-get / memory-delete both take a single `id`; prefer it, fall
-      // back to parsing the response for robustness.
-      const targetId = Number(input.id);
-      const ids = Number.isFinite(targetId) ? [targetId] : parseMemoryIds(toolResponse);
-      consumeRecall(state, ids);
-      break;
+  // All other roles are read-modify-write: route through mutateState so two
+  // parallel PostToolUse hooks can't both read N and both write N+1 (lost
+  // increment / clobbered set) (#228).
+  const mutate = stateStore.mutateState
+    ? (mutator) => stateStore.mutateState(claudeSessionId, mutator)
+    : (mutator) => {
+        const state = stateStore.loadState(claudeSessionId);
+        const r = mutator(state);
+        stateStore.saveState(claudeSessionId, state);
+        return r;
+      };
+
+  await mutate((state) => {
+    if (!state.currentProject) {
+      state.currentProject = projectFromCwd(cwd);
     }
-    case 'memory-code-harvest':
-      harvestExploredFiles(state, toolResponse);
-      break;
-    default:
-      return null;
-  }
-
-  stateStore.saveState(claudeSessionId, state);
+    switch (role) {
+      case 'edit-track':
+        addEditedFile(state, input.file_path);
+        return;
+      case 'memory-save-mirror':
+        if (wasSaveSuccessful(toolResponse)) {
+          state.memoriesSavedThisSession = (state.memoriesSavedThisSession || 0) + 1;
+        }
+        return;
+      case 'memory-search-mirror':
+        recordSearchRecall(state, parseSearchResultIds(toolResponse), input.query);
+        return;
+      case 'memory-get-mirror': {
+        // memory-get / memory-delete both take a single `id`; prefer it, fall
+        // back to parsing the response for robustness.
+        const targetId = Number(input.id);
+        const ids = Number.isFinite(targetId) ? [targetId] : parseMemoryIds(toolResponse);
+        consumeRecall(state, ids);
+        return;
+      }
+      case 'memory-code-harvest':
+        harvestExploredFiles(state, toolResponse);
+        return;
+      default:
+        return;
+    }
+  });
   return null; // silent — PostToolUse injects nothing
 }
 

--- a/src/claude-code/handlers/pre-tool-use.js
+++ b/src/claude-code/handlers/pre-tool-use.js
@@ -35,6 +35,7 @@ const {
   CODE_PATH_HINT_RE,
 } = require('../../hooks-engine/guardrail-utils');
 const { preToolRole } = require('../tool-map');
+const { addNormalized } = require('../file-keys');
 
 /** Build the PreToolUse deny envelope. */
 function deny(reason) {
@@ -55,13 +56,7 @@ function addExploredFile(state, filePath) {
   if (!Array.isArray(state.exploredFiles)) {
     state.exploredFiles = [];
   }
-  const lower = String(filePath).toLowerCase();
-  const base = path.basename(lower);
-  for (const candidate of [lower, base]) {
-    if (candidate && !state.exploredFiles.includes(candidate)) {
-      state.exploredFiles.push(candidate);
-    }
-  }
+  addNormalized(state.exploredFiles, filePath);
 }
 
 /** Resolve the indexed repo the current cwd belongs to (cwd prefix or project name). */
@@ -208,14 +203,24 @@ async function handlePreToolUse({ payload, getKnownRepos, stateStore }) {
   const claudeSessionId = payload.session_id;
 
   // Memory-tool cadence bookkeeping (state mutations Pi's tool_call hook does).
+  // Routed through mutateState so a parallel memory-* tool can't lose the
+  // update (#228). Falls back to load/save when the injected store lacks it.
   if (role === 'memory-code-seed' || role === 'memory-reminder-reset') {
-    const state = stateStore.loadState(claudeSessionId);
-    state.lastMemoryToolCall = Date.now();
-    state.callsSinceLastMemory = 0;
-    if (role === 'memory-code-seed') {
-      addExploredFile(state, input.file);
-    }
-    stateStore.saveState(claudeSessionId, state);
+    const mutate = stateStore.mutateState
+      ? (mutator) => stateStore.mutateState(claudeSessionId, mutator)
+      : (mutator) => {
+          const state = stateStore.loadState(claudeSessionId);
+          const r = mutator(state);
+          stateStore.saveState(claudeSessionId, state);
+          return r;
+        };
+    await mutate((state) => {
+      state.lastMemoryToolCall = Date.now();
+      state.callsSinceLastMemory = 0;
+      if (role === 'memory-code-seed') {
+        addExploredFile(state, input.file);
+      }
+    });
     return null;
   }
 

--- a/src/claude-code/handlers/session-start.js
+++ b/src/claude-code/handlers/session-start.js
@@ -39,8 +39,17 @@ async function handleSessionStart({ payload, dispatch, getKnownRepos, stateStore
 
   if (!isCompact) {
     // GC orphaned state files from force-killed sessions before starting fresh.
+    // The TTL honors LAPIS_SESSION_TTL_HOURS (default 24h); surface a sweep so
+    // the user can correlate a missing state file (#233).
     try {
-      stateStore.sweepStaleSessions(24);
+      const sweep = stateStore.sweepStaleSessions();
+      if (sweep && sweep.swept > 0) {
+        const ttl = typeof stateStore.defaultTtlHours === 'function' ? stateStore.defaultTtlHours() : 24;
+        process.stderr.write(
+          `claude-code: swept ${sweep.swept} stale session state file(s) older than ${ttl}h` +
+            ` (set LAPIS_SESSION_TTL_HOURS to adjust).\n`,
+        );
+      }
     } catch {
       // GC is best-effort.
     }

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -13,6 +13,7 @@
  */
 
 const path = require('node:path');
+const { uniqueEditedPaths } = require('../file-keys');
 const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
 const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
 const { shouldAutoCapture } = require('../../hooks-engine/pattern-matcher');
@@ -96,14 +97,14 @@ async function checkpoint({ dispatch, state, project }) {
     return;
   }
 
-  const summaryFiles = state.editedFiles
+  const editedPaths = uniqueEditedPaths(state.editedFiles).slice(0, 20);
+  const summaryFiles = editedPaths
     .slice(0, 10)
     .map((f) => `- ${path.basename(f)}`)
     .join('\n');
 
   let auditNote = '';
   try {
-    const editedPaths = state.editedFiles.slice(0, 20);
     if (editedPaths.length > 0) {
       const auditResult = await dispatch('audit-diff', {
         repo: project,
@@ -130,7 +131,7 @@ async function checkpoint({ dispatch, state, project }) {
     content: [
       `**What**: Auto-checkpoint at turn ${state.turnCount}`,
       `**Where**: Session ${state.sessionId}`,
-      `**Learned**: ${state.memoriesSavedThisSession} explicit memories saved, ${state.editedFiles.length} files edited`,
+      `**Learned**: ${state.memoriesSavedThisSession} explicit memories saved, ${editedPaths.length} files edited`,
       summaryFiles ? `Files touched:\n${summaryFiles}` : '',
       auditNote,
     ].join('\n'),

--- a/src/claude-code/hooks.js
+++ b/src/claude-code/hooks.js
@@ -120,8 +120,13 @@ async function runHook(argv, opts = {}) {
     return;
   }
 
-  const dispatch = opts.dispatch || dispatchClient.dispatch;
-  const getKnownRepos = opts.getKnownRepos || dispatchClient.getKnownRepos;
+  // Allow tests / alternate backends to inject the state store and dispatch
+  // client the same way they inject dispatch/getKnownRepos (#231). `dispatch`
+  // and `getKnownRepos` fall back to the (possibly injected) client's methods.
+  const resolvedDispatchClient = opts.dispatchClient || dispatchClient;
+  const dispatch = opts.dispatch || resolvedDispatchClient.dispatch;
+  const getKnownRepos = opts.getKnownRepos || resolvedDispatchClient.getKnownRepos;
+  const resolvedStateStore = opts.stateStore || stateStore;
 
   // ensureDb once — mirrors src/mcp/server.js:118-130.
   if (opts.ensureDb !== false) {
@@ -138,7 +143,14 @@ async function runHook(argv, opts = {}) {
 
   let output;
   try {
-    output = await handler({ payload, dispatch, dispatchClient, getKnownRepos, stateStore, roleFilter });
+    output = await handler({
+      payload,
+      dispatch,
+      dispatchClient: resolvedDispatchClient,
+      getKnownRepos,
+      stateStore: resolvedStateStore,
+      roleFilter,
+    });
   } catch (e) {
     // Hooks must fail open: log to stderr, do NOT set a non-zero exit.
     process.stderr.write(`claude-code ${resolvedEvent} handler error: ${e instanceof Error ? e.message : String(e)}\n`);

--- a/src/claude-code/install.js
+++ b/src/claude-code/install.js
@@ -37,11 +37,6 @@ const DEFAULT_MCP_NAME = 'lapis';
 const CLAUDE_MD_START = '<!-- lapis:start -->';
 const CLAUDE_MD_END = '<!-- lapis:end -->';
 
-// Secondary bash-search guardrail: the `if` field holds exactly ONE permission
-// rule (no `||`), so each raw-discovery command gets its own handler. Mirrors
-// RAW_CODE_DISCOVERY_RE in src/hooks-engine/guardrail-utils.js.
-const BASH_GUARDRAIL_IF_RULES = ['Bash(grep *)', 'Bash(rg *)', 'Bash(ag *)', 'Bash(ack *)', 'Bash(find *)'];
-
 // --- flag parsing ---------------------------------------------------------
 
 /**
@@ -237,6 +232,13 @@ function hookHandler(invocation, event, { timeout, async: isAsync, ifRule, extra
  *   - Heavy handlers run `async: true`: git-trust (PostToolUse `--only`
  *     split so tracking/mirroring stays synchronous) and Stop
  *     (passive-capture + checkpoint + dream).
+ *
+ * Bash command-prefix `if` rules are intentionally NOT used: Claude Code
+ * evaluates `if` as a literal command-prefix match, so `cd repo && git pull`
+ * or `ls | grep foo` would bypass the guardrail entirely. The Bash matcher is
+ * a single bare `Bash` group and the handlers themselves do the real
+ * classification (GIT_TRUST_OP_RE / RAW_CODE_DISCOVERY_RE), returning null
+ * fast for non-matching commands (#225, #226).
  */
 function buildHookGroups(invocation, mcpName) {
   const h = (event, opts) => hookHandler(invocation, event, opts);
@@ -248,10 +250,7 @@ function buildHookGroups(invocation, mcpName) {
     UserPromptSubmit: [{ hooks: [h('UserPromptSubmit', { timeout: 30 })] }],
     PreToolUse: [
       { matcher: 'Read|Grep|Glob', hooks: [h('PreToolUse', { timeout: 15 })] },
-      {
-        matcher: 'Bash',
-        hooks: BASH_GUARDRAIL_IF_RULES.map((rule) => h('PreToolUse', { timeout: 15, ifRule: rule })),
-      },
+      { matcher: 'Bash', hooks: [h('PreToolUse', { timeout: 15 })] },
       { matcher: `mcp__${mcpName}__.*`, hooks: [h('PreToolUse', { timeout: 15 })] },
     ],
     PostToolUse: [
@@ -261,10 +260,11 @@ function buildHookGroups(invocation, mcpName) {
           // PreToolUse sees fresh state (edit-track, exploredFiles, recall).
           h('PostToolUse', { timeout: 15, extraArgs: ['--skip', 'git-trust'] }),
           // git-trust is heavy (sync-code-trust over the repo) → background.
+          // No `if` prefix rule: the handler's GIT_TRUST_OP_RE does the real
+          // check, so compound commands like `cd repo && git pull` are covered.
           h('PostToolUse', {
             timeout: 60,
             async: true,
-            ifRule: 'Bash(git *)',
             extraArgs: ['--only', 'git-trust'],
           }),
         ],
@@ -701,7 +701,15 @@ async function runInstall(argv, io) {
     const { runStart } = require('./daemon');
     daemon = await runStart(['--detached', '--port', String(flags.daemonPort)], io);
     log('');
-    log(`Daemon mode enabled (port ${flags.daemonPort}) — hooks will POST to /dispatch.`);
+    if (daemon?.alreadyRunning && daemon?.mismatch) {
+      // runStart already warned; report the port hooks will actually POST to.
+      log(
+        `Daemon mode requested port ${flags.daemonPort}, but the running daemon is on port ${daemon.port}` +
+          ` — hooks will POST to port ${daemon.port}. Run \`lapis claude-code stop\` to relocate it.`,
+      );
+    } else {
+      log(`Daemon mode enabled (port ${flags.daemonPort}) — hooks will POST to /dispatch.`);
+    }
     log('Stop with: lapis claude-code stop');
   }
 
@@ -713,7 +721,6 @@ module.exports = {
   DEFAULT_MCP_NAME,
   CLAUDE_MD_START,
   CLAUDE_MD_END,
-  BASH_GUARDRAIL_IF_RULES,
   parseFlags,
   resolveInvocation,
   hookInvocationFor,

--- a/src/claude-code/state-store.js
+++ b/src/claude-code/state-store.js
@@ -12,6 +12,13 @@
  * Concurrency: each hook is its own process, so reads may be stale relative to
  * a concurrent hook. loadState merges onto defaults so newer fields never
  * crash older state files, and a corrupt file degrades to defaults.
+ * mutateState performs a locked read-modify-write so parallel PostToolUse
+ * counters are not lost (#228).
+ *
+ * Fail-open contract: an unusable session_id (missing/null/empty/placeholder)
+ * must NEVER collapse multiple sessions onto one shared file (#224). Such a
+ * key yields defaults on load and a no-op on save, so the hook degrades
+ * gracefully instead of cross-contaminating state.
  */
 
 const fs = require('node:fs');
@@ -20,6 +27,18 @@ const os = require('node:os');
 
 const HOME = process.env.HOME || process.env.USERPROFILE || os.homedir();
 const DEFAULT_DIR = path.join(HOME, '.pi', 'memory', 'claude-sessions');
+const DEFAULT_TTL_HOURS = 24;
+
+// Lock tuning for mutateState (#228). A crashed holder leaves a lockfile; it is
+// broken once older than LOCK_STALE_MS so a wedged lock never permanently
+// blocks the fast path.
+const LOCK_TIMEOUT_MS = 2000;
+const LOCK_POLL_MS = 25;
+const LOCK_STALE_MS = 10_000;
+
+// Placeholders that String(...) of a missing session_id collapses to; refusing
+// them prevents every keyless session sharing one file (#224).
+const PLACEHOLDER_KEYS = new Set(['undefined', 'null', 'nan', '', '_', '__', '___']);
 
 // Field set mirrors extensions/memory-layer/state.ts (session-relevant subset;
 // caches like cachedRepos/compressionStats are intentionally excluded).
@@ -46,19 +65,61 @@ function resolveDir(opts) {
   return opts?.dir || DEFAULT_DIR;
 }
 
+/**
+ * Resolve a session_id into a safe, non-placeholder filename stem. Returns
+ * null for unusable keys (non-string, empty, or one of the placeholder strings
+ * a missing session_id degenerates to) so callers can fail open (#224).
+ */
+function sanitizeKey(sessionId) {
+  if (typeof sessionId !== 'string' && typeof sessionId !== 'number') {
+    return null;
+  }
+  const raw = String(sessionId).trim();
+  if (!raw) {
+    return null;
+  }
+  const safe = raw.replace(/[^\w.-]/g, '_');
+  if (!safe || PLACEHOLDER_KEYS.has(safe) || /^_+$/.test(safe)) {
+    return null;
+  }
+  return safe;
+}
+
 function statePath(sessionId, opts) {
-  const safe = String(sessionId).replace(/[^\w.-]/g, '_');
+  const safe = sanitizeKey(sessionId);
+  if (!safe) {
+    return null;
+  }
   return path.join(resolveDir(opts), `${safe}.json`);
+}
+
+/** Resolve the configurable stale-session TTL (hours). #233 */
+function defaultTtlHours() {
+  const raw = process.env.LAPIS_SESSION_TTL_HOURS;
+  const n = Number(raw);
+  if (Number.isFinite(n) && n > 0) {
+    return n;
+  }
+  return DEFAULT_TTL_HOURS;
 }
 
 /**
  * Load + normalize a stored state. Returns defaults for missing/corrupt files,
  * merged onto the current default set so forward-compatible fields are filled.
+ * A null (unusable) session_id returns defaults without touching disk (#224).
  */
 function loadState(sessionId, opts) {
+  const filePath = statePath(sessionId, opts);
+  if (!filePath) {
+    return defaultState();
+  }
+  return readStateFile(filePath);
+}
+
+function readStateFile(filePath) {
   let raw;
   try {
-    raw = fs.readFileSync(statePath(sessionId, opts), 'utf8');
+    raw = fs.readFileSync(filePath, 'utf8');
   } catch {
     return defaultState();
   }
@@ -79,22 +140,35 @@ function loadState(sessionId, opts) {
 }
 
 /**
- * Atomic write: temp file + rename. read-modify-write callers should loadState
- * first, mutate, then saveState.
+ * Atomic write: temp file + rename. read-modify-write callers should use
+ * mutateState (locked) or loadState first, mutate, then saveState.
+ * A null (unusable) session_id is a no-op (#224).
  */
 function saveState(sessionId, state, opts) {
-  const dir = resolveDir(opts);
-  fs.mkdirSync(dir, { recursive: true });
-  const finalPath = statePath(sessionId, opts);
-  const tmpPath = `${finalPath}.${process.pid}.tmp`;
-  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 0), 'utf8');
-  fs.renameSync(tmpPath, finalPath);
+  const filePath = statePath(sessionId, opts);
+  if (!filePath) {
+    return false;
+  }
+  atomicWrite(filePath, state);
+  return true;
 }
 
-/** Unlink the state file; idempotent on ENOENT. */
+function atomicWrite(filePath, state) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(state, null, 0), 'utf8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+/** Unlink the state file; idempotent on ENOENT. A null key is a no-op (#224). */
 function clearState(sessionId, opts) {
+  const filePath = statePath(sessionId, opts);
+  if (!filePath) {
+    return;
+  }
   try {
-    fs.unlinkSync(statePath(sessionId, opts));
+    fs.unlinkSync(filePath);
   } catch (e) {
     if (e.code !== 'ENOENT') {
       throw e;
@@ -103,11 +177,89 @@ function clearState(sessionId, opts) {
 }
 
 /**
+ * Locked read-modify-write. Prevents lost updates when two PostToolUse hooks
+ * race on the same session file (#228). Best-effort: if the lock cannot be
+ * acquired within LOCK_TIMEOUT_MS it proceeds unlocked (a possible lost write
+ * is preferable to blocking the hook and tripping Claude Code's timeout). A
+ * null (unusable) session_id runs the mutator against a transient default
+ * state and discards the result (#224).
+ *
+ * @returns the mutator's return value.
+ */
+async function mutateState(sessionId, mutator, opts) {
+  const filePath = statePath(sessionId, opts);
+  if (!filePath) {
+    return mutator(defaultState());
+  }
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const lockPath = `${filePath}.lock`;
+  const acquired = await acquireLock(lockPath, opts);
+  try {
+    const state = readStateFile(filePath);
+    const result = await mutator(state);
+    atomicWrite(filePath, state);
+    return result;
+  } finally {
+    if (acquired) {
+      releaseLock(lockPath);
+    }
+  }
+}
+
+async function acquireLock(lockPath, opts = {}) {
+  const timeoutMs = opts.lockTimeoutMs ?? LOCK_TIMEOUT_MS;
+  const pollMs = opts.lockPollMs ?? LOCK_POLL_MS;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      fs.closeSync(fd);
+      fs.writeFileSync(lockPath, String(process.pid), 'utf8');
+      return true;
+    } catch (e) {
+      if (e.code !== 'EEXIST') {
+        // Cannot create the lock — fail open (proceed unlocked).
+        return false;
+      }
+      // Break a lock held by a process that died leaving the file behind.
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch {
+        // ignore; retry
+      }
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+}
+
+function releaseLock(lockPath) {
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Already gone — nothing to release.
+  }
+}
+
+/**
  * Sweep state files older than maxAgeHours (from force-killed Claude processes
  * that never reached SessionEnd). Called on SessionStart. Best-effort: never
- * throws — a GC failure must not block a session start.
+ * throws — a GC failure must not block a session start. The default honors
+ * LAPIS_SESSION_TTL_HOURS (#233).
  */
-function sweepStaleSessions(maxAgeHours = 24, opts) {
+function sweepStaleSessions(maxAgeHours, opts) {
+  const ttl = maxAgeHours === undefined ? defaultTtlHours() : maxAgeHours;
+  return sweepSessions(ttl, opts);
+}
+
+function sweepSessions(maxAgeHours, opts) {
   const dir = resolveDir(opts);
   let entries;
   try {
@@ -136,11 +288,44 @@ function sweepStaleSessions(maxAgeHours = 24, opts) {
   return { swept };
 }
 
+/**
+ * On-demand GC entry point: `lapis claude-code gc [--max-age-hours N]` (#233).
+ * Never throws — surfaces a swept count + the directory it ran against.
+ */
+function runGc(argv, io = {}) {
+  const log = io.log || (() => {});
+  let maxAgeHours = defaultTtlHours();
+  const args = Array.isArray(argv) ? argv : [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--max-age-hours' && args[i + 1] !== undefined) {
+      const n = Number(args[++i]);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error('--max-age-hours requires a positive number');
+      }
+      maxAgeHours = n;
+    } else if (args[i] === '--help' || args[i] === '-h') {
+      log('Usage: lapis claude-code gc [--max-age-hours N]');
+      return { swept: 0, maxAgeHours };
+    } else {
+      throw new Error(`Unknown flag: ${args[i]}`);
+    }
+  }
+  const result = sweepSessions(maxAgeHours, io);
+  const dir = resolveDir(io);
+  log(`Swept ${result.swept} stale session state file(s) older than ${maxAgeHours}h from ${dir}.`);
+  return { ...result, maxAgeHours, dir };
+}
+
 module.exports = {
   defaultState,
   loadState,
   saveState,
   clearState,
+  mutateState,
   sweepStaleSessions,
+  sanitizeKey,
+  defaultTtlHours,
+  runGc,
   DEFAULT_DIR,
+  DEFAULT_TTL_HOURS,
 };

--- a/src/hooks-engine/guardrail-utils.js
+++ b/src/hooks-engine/guardrail-utils.js
@@ -174,8 +174,37 @@ const CODE_PATH_HINT_RE =
 // rather than a single-symbol lookup. Mirrors the check in
 // isTargetedSymbolLookup so Grep and Bash gate identically.
 const GREP_METACHAR_RE = /[.*+?|^$()[\]{}\\]/;
-const SPECIFIC_CODE_FILE_RE =
-  /\.(cjs|cts|js|jsx|mjs|mts|ts|tsx|py|pyi|go|rs|java|kt|rb|c|h|cpp|hpp|cs|scala|swift|php)$/i;
+
+// Single source of truth for the set of code file extensions. Both the
+// "specific code file" classifier (below) and the bridge's harvest regex
+// (src/claude-code/handlers/post-tool-use.js CODE_PATH_RE) build from this so
+// they never drift (#230).
+const CODE_EXTENSIONS = [
+  'cjs',
+  'cts',
+  'js',
+  'jsx',
+  'mjs',
+  'mts',
+  'ts',
+  'tsx',
+  'py',
+  'pyi',
+  'go',
+  'rs',
+  'java',
+  'kt',
+  'rb',
+  'c',
+  'h',
+  'cpp',
+  'hpp',
+  'cs',
+  'scala',
+  'swift',
+  'php',
+];
+const SPECIFIC_CODE_FILE_RE = new RegExp(`\\.(${CODE_EXTENSIONS.join('|')})$`, 'i');
 
 /**
  * True when a path points at a single concrete code file (not a directory,
@@ -261,6 +290,7 @@ module.exports = {
   isTargetedGrepLookup,
   isBroadGlob,
   CONFIG_FILENAMES,
+  CODE_EXTENSIONS,
   RAW_CODE_DISCOVERY_RE,
   CODE_PATH_HINT_RE,
   MIN_SYMBOL_LENGTH,

--- a/src/hooks-engine/project.js
+++ b/src/hooks-engine/project.js
@@ -43,8 +43,17 @@ function projectFromCwd(cwd) {
  * @returns {object|null}
  */
 function findMatchingRepo(resolvedCwd, repos) {
+  // Use path.sep (not a hardcoded "/") so a Windows cwd nested under an
+  // indexed repo still prefix-matches: the DB stores backslash paths there,
+  // and the old `${rp}/` check only ever matched on exact equality (#227).
   const abs = path.resolve(resolvedCwd).toLowerCase();
-  return repos.find((r) => abs.startsWith(`${r.path.toLowerCase()}/`) || abs === r.path.toLowerCase()) || null;
+  const sep = path.sep;
+  return (
+    repos.find((r) => {
+      const rp = r.path.toLowerCase();
+      return abs === rp || abs.startsWith(rp + sep);
+    }) || null
+  );
 }
 
 /**

--- a/src/hooks-engine/session-summary.js
+++ b/src/hooks-engine/session-summary.js
@@ -9,6 +9,7 @@
  */
 
 const path = require('node:path');
+const { uniqueEditedPaths } = require('../claude-code/file-keys');
 const { extractMessageText } = require('./prompt-classifiers');
 
 /**
@@ -52,7 +53,7 @@ function buildSessionSummary({
     ...topics.slice(0, 10).map((t) => `- ${t}`),
   ];
 
-  const files = [...(editedFiles instanceof Set ? editedFiles : editedFiles || [])];
+  const files = uniqueEditedPaths(editedFiles);
   if (files.length > 0) {
     summaryParts.push('', '## Files Modified');
     for (const f of files.slice(0, 20)) {

--- a/test/claude-code/dispatch-client.test.js
+++ b/test/claude-code/dispatch-client.test.js
@@ -41,7 +41,6 @@ describe('dispatch-client', () => {
     expect(calls[0].body).toEqual({
       cmd: 'preflight',
       args: { query: 'auth', project: '/repo' },
-      project: '/repo',
     });
     expect(result.route).toBe('daemon');
   });
@@ -69,11 +68,15 @@ describe('dispatch-client', () => {
     };
     const directSpy = vi.fn(async () => ({ via: 'direct' }));
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    const result = await dispatchClient.dispatch('search', { query: 'x' }, {
-      resolveDaemonUrl: () => 'http://127.0.0.1:9100',
-      fetch,
-      directDispatch: directSpy,
-    });
+    const result = await dispatchClient.dispatch(
+      'search',
+      { query: 'x' },
+      {
+        resolveDaemonUrl: () => 'http://127.0.0.1:9100',
+        fetch,
+        directDispatch: directSpy,
+      },
+    );
 
     expect(result).toEqual({ via: 'direct' });
     expect(directSpy).toHaveBeenCalledWith('search', { query: 'x' });
@@ -161,6 +164,42 @@ describe('daemon start/stop flags', () => {
 
     expect(stopSpy).toHaveBeenCalledWith(4242, expect.objectContaining({ lockfilePath }));
     expect(fs.existsSync(lockfilePath)).toBe(false);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('runStart warns and keeps the existing daemon when a different port is requested', async () => {
+    // #232: re-install with a different --daemon-port must not silently drop the
+    // flag nor relocate the running daemon; it warns loudly and keeps the old one.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-daemon-port-'));
+    const lockfilePath = path.join(tmpDir, 'daemon.json');
+    daemon.writeLockfile({ pid: process.pid, port: 9100, host: '127.0.0.1' }, lockfilePath);
+    const lines = [];
+    const result = await daemon.runStart(['--detached', '--port', '9300'], {
+      lockfilePath,
+      log: (l) => lines.push(l),
+    });
+    expect(result.alreadyRunning).toBe(true);
+    expect(result.port).toBe(9100);
+    expect(result.requestedPort).toBe(9300);
+    expect(result.mismatch.portMismatch).toBe(true);
+    expect(lines.join('\n')).toContain('9300 was requested');
+    // Lockfile unchanged — the running daemon is preserved.
+    expect(daemon.readLockfile(lockfilePath).port).toBe(9100);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('runStart silently no-ops when the same port is requested', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-daemon-same-'));
+    const lockfilePath = path.join(tmpDir, 'daemon.json');
+    daemon.writeLockfile({ pid: process.pid, port: 9100, host: '127.0.0.1' }, lockfilePath);
+    const lines = [];
+    const result = await daemon.runStart(['--port', '9100'], {
+      lockfilePath,
+      log: (l) => lines.push(l),
+    });
+    expect(result.alreadyRunning).toBe(true);
+    expect(result.mismatch).toBeUndefined();
+    expect(lines.join('\n')).not.toContain('was requested');
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });

--- a/test/claude-code/file-keys.test.js
+++ b/test/claude-code/file-keys.test.js
@@ -1,4 +1,4 @@
-const { fileKey, addNormalized } = require('../../src/claude-code/file-keys');
+const { fileKey, addNormalized, uniqueEditedPaths } = require('../../src/claude-code/file-keys');
 
 describe('claude-code file-keys: shared normalization', () => {
   test('fileKey lowercases and splits the basename', () => {
@@ -33,5 +33,16 @@ describe('claude-code file-keys: shared normalization', () => {
     const arr = ['x'];
     addNormalized(arr, '');
     expect(arr).toEqual(['x']);
+  });
+
+  test('uniqueEditedPaths collapses full path + basename to one entry per file', () => {
+    expect(uniqueEditedPaths(['/proj/a.js', 'a.js', '/proj/b.ts', 'b.ts'])).toEqual([
+      '/proj/a.js',
+      '/proj/b.ts',
+    ]);
+  });
+
+  test('uniqueEditedPaths accepts a Set and ignores empty entries', () => {
+    expect(uniqueEditedPaths(new Set(['/x/foo.js', 'foo.js', '']))).toEqual(['/x/foo.js']);
   });
 });

--- a/test/claude-code/file-keys.test.js
+++ b/test/claude-code/file-keys.test.js
@@ -1,0 +1,37 @@
+const { fileKey, addNormalized } = require('../../src/claude-code/file-keys');
+
+describe('claude-code file-keys: shared normalization', () => {
+  test('fileKey lowercases and splits the basename', () => {
+    expect(fileKey('src/Foo.JS')).toEqual({ lower: 'src/foo.js', base: 'foo.js' });
+    expect(fileKey('SRC/Bar.TS')).toEqual({ lower: 'src/bar.ts', base: 'bar.ts' });
+  });
+
+  test('fileKey handles Windows-style separators', () => {
+    expect(fileKey('src\\sub\\Foo.JS')).toEqual({ lower: 'src\\sub\\foo.js', base: 'foo.js' });
+  });
+
+  test('fileKey rejects non-strings', () => {
+    expect(fileKey(undefined)).toBeNull();
+    expect(fileKey(null)).toBeNull();
+    expect(fileKey('')).toBeNull();
+    expect(fileKey(42)).toBeNull();
+  });
+
+  test('addNormalized appends both the lowercased path and basename, deduped', () => {
+    const arr = [];
+    addNormalized(arr, 'src/Foo.JS');
+    expect(arr).toEqual(['src/foo.js', 'foo.js']);
+    // Idempotent: same path doesn't double-up.
+    addNormalized(arr, 'src/Foo.js');
+    expect(arr).toEqual(['src/foo.js', 'foo.js']);
+    // A second, distinct file adds both its forms.
+    addNormalized(arr, 'lib/Bar.TS');
+    expect(arr).toEqual(['src/foo.js', 'foo.js', 'lib/bar.ts', 'bar.ts']);
+  });
+
+  test('addNormalized ignores empty input', () => {
+    const arr = ['x'];
+    addNormalized(arr, '');
+    expect(arr).toEqual(['x']);
+  });
+});

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -30,6 +30,12 @@ function makeStateStore() {
     saveState: (id, s) => {
       map.set(id, s);
     },
+    mutateState: async (id, mutator) => {
+      const s = map.get(id) || realStateStore.defaultState();
+      const r = await mutator(s);
+      map.set(id, s);
+      return r;
+    },
     clearState: (id) => {
       map.delete(id);
     },

--- a/test/claude-code/hooks.test.js
+++ b/test/claude-code/hooks.test.js
@@ -1,0 +1,61 @@
+const { runHook } = require('../../src/claude-code/hooks');
+
+// Integration-level coverage for the router's dependency-injection seams (#231):
+// opts.stateStore and opts.dispatchClient must be honored end-to-end, not only
+// opts.dispatch / opts.getKnownRepos. The existing handlers.test.js exercises
+// handlers directly with a fake store; these run the full runHook path.
+
+function fakeStateStore(seed = {}) {
+  const map = new Map(Object.entries(seed));
+  const defaults = () => ({ editedFiles: [], exploredFiles: [], memoriesSavedThisSession: 0 });
+  return {
+    defaultState: defaults,
+    loadState: (id) => map.get(id) || defaults(),
+    saveState: (id, s) => map.set(id, s),
+    mutateState: async (id, mutator) => {
+      const s = map.get(id) || defaults();
+      const r = await mutator(s);
+      map.set(id, s);
+      return r;
+    },
+    _peek: (id) => map.get(id),
+  };
+}
+
+describe('claude-code router injection seams', () => {
+  test('runHook honors opts.stateStore for a PostToolUse edit-track', async () => {
+    const stateStore = fakeStateStore();
+    const dispatch = async () => ({ ok: true });
+    await runHook(['hook', 'PostToolUse'], {
+      ensureDb: false,
+      stdin: JSON.stringify({
+        session_id: 'inj-1',
+        tool_name: 'Write',
+        tool_input: { file_path: '/proj/app/src/y.js' },
+        cwd: '/proj/app',
+      }),
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore,
+    });
+    expect(stateStore._peek('inj-1').editedFiles).toContain('/proj/app/src/y.js');
+  });
+
+  test('runHook honors opts.dispatchClient as the dispatched client', async () => {
+    const dispatched = [];
+    const fakeDispatchClient = {
+      dispatch: async (cmd, args) => {
+        dispatched.push(cmd);
+        return cmd === 'session-start' ? { sessionId: 77 } : { observations: [] };
+      },
+      getKnownRepos: () => [],
+    };
+    await runHook(['hook', 'SessionStart'], {
+      ensureDb: false,
+      stdin: JSON.stringify({ session_id: 'inj-2', source: 'startup', cwd: '/proj/app' }),
+      dispatchClient: fakeDispatchClient,
+      stateStore: fakeStateStore(),
+    });
+    expect(dispatched).toContain('session-start');
+  });
+});

--- a/test/claude-code/install.test.js
+++ b/test/claude-code/install.test.js
@@ -75,16 +75,16 @@ describe('claude-code install: default (npx, project scope)', () => {
     }
   });
 
-  test('PreToolUse: Read|Grep|Glob (timeout 15), Bash gated by if-rules, mcp__lapis__.* cadence', async () => {
+  test('PreToolUse: Read|Grep|Glob (timeout 15), a single bare Bash matcher, mcp__lapis__.* cadence', async () => {
     const settings = readJson(path.join(io.cwd, '.claude', 'settings.json'));
     const groups = settings.hooks.PreToolUse;
     expect(groups.map((g) => g.matcher)).toEqual(['Read|Grep|Glob', 'Bash', 'mcp__lapis__.*']);
     expect(groups[0].hooks[0].timeout).toBe(15);
-    const ifRules = groups[1].hooks.map((h) => h.if);
-    expect(ifRules).toEqual(['Bash(grep *)', 'Bash(rg *)', 'Bash(ag *)', 'Bash(ack *)', 'Bash(find *)']);
-    for (const h of groups[1].hooks) {
-      expect(h.timeout).toBe(15);
-    }
+    // Bash is one handler with NO `if` prefix rule — the handler classifies
+    // compound commands itself (#225, #226).
+    expect(groups[1].hooks).toHaveLength(1);
+    expect(groups[1].hooks[0].if).toBeUndefined();
+    expect(groups[1].hooks[0].timeout).toBe(15);
   });
 
   test('always-fire events carry NO matcher', async () => {
@@ -108,7 +108,9 @@ describe('claude-code install: default (npx, project scope)', () => {
     const asyncH = post.find((h) => h.async);
     expect(sync.args.slice(5)).toEqual(['--skip', 'git-trust']);
     expect(asyncH.args.slice(5)).toEqual(['--only', 'git-trust']);
-    expect(asyncH.if).toBe('Bash(git *)');
+    // No `if` prefix rule on git-trust: GIT_TRUST_OP_RE classifies compound
+    // commands like `cd repo && git pull` (#225).
+    expect(asyncH.if).toBeUndefined();
   });
 
   test('CLAUDE.md protocol block is written between delimiters', async () => {
@@ -636,6 +638,12 @@ describe('claude-code hook role filter', () => {
     return {
       loadState: (id) => map.get(id) || realStateStore.defaultState(),
       saveState: (id, s) => map.set(id, s),
+      mutateState: async (id, mutator) => {
+        const s = map.get(id) || realStateStore.defaultState();
+        const r = await mutator(s);
+        map.set(id, s);
+        return r;
+      },
       _peek: (id) => map.get(id),
     };
   }
@@ -670,7 +678,7 @@ describe('claude-code hook role filter', () => {
       stateStore,
       roleFilter: { skip: 'git-trust' },
     });
-    expect(stateStore._peek('s1').editedFiles).toEqual(['/proj/a.js']);
+    expect(stateStore._peek('s1').editedFiles).toEqual(['/proj/a.js', 'a.js']);
   });
 
   test('--only git-trust runs git-trust and nothing else', async () => {

--- a/test/claude-code/state-store.test.js
+++ b/test/claude-code/state-store.test.js
@@ -212,6 +212,25 @@ describe('claude-code state-store: locked mutateState', () => {
     expect(seen).toEqual(stateStore.defaultState());
     expect(fs.readdirSync(dir)).toEqual([]);
   });
+
+  test('mutateState proceeds unlocked when the lock cannot be acquired', async () => {
+    stateStore.saveState('m4', { ...stateStore.defaultState(), memoriesSavedThisSession: 0 }, { dir });
+    const lockPath = path.join(dir, 'm4.lock');
+    fs.writeFileSync(lockPath, '99999', 'utf8');
+    const now = Date.now();
+    fs.utimesSync(lockPath, now / 1000, now / 1000);
+
+    await stateStore.mutateState(
+      'm4',
+      (s) => {
+        s.memoriesSavedThisSession = 3;
+      },
+      { dir, lockTimeoutMs: 50 },
+    );
+
+    expect(stateStore.loadState('m4', { dir }).memoriesSavedThisSession).toBe(3);
+    fs.unlinkSync(lockPath);
+  });
 });
 
 describe('claude-code state-store: TTL + gc', () => {

--- a/test/claude-code/state-store.test.js
+++ b/test/claude-code/state-store.test.js
@@ -101,3 +101,167 @@ describe('claude-code state-store', () => {
     expect(fs.existsSync(path.join(dir, 'fresh.json'))).toBe(true);
   });
 });
+
+describe('claude-code state-store: unusable session_id (fail-open)', () => {
+  let dir;
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('sanitizeKey rejects missing/null/empty/placeholder ids', () => {
+    expect(stateStore.sanitizeKey(undefined)).toBeNull();
+    expect(stateStore.sanitizeKey(null)).toBeNull();
+    expect(stateStore.sanitizeKey('')).toBeNull();
+    expect(stateStore.sanitizeKey('   ')).toBeNull();
+    expect(stateStore.sanitizeKey('undefined')).toBeNull();
+    expect(stateStore.sanitizeKey('null')).toBeNull();
+    // A real uuid is fine.
+    expect(stateStore.sanitizeKey('a1b2-c3d4')).toBe('a1b2-c3d4');
+  });
+
+  test('loadState returns defaults (no file written) for an unusable id', () => {
+    expect(stateStore.loadState(undefined, { dir })).toEqual(stateStore.defaultState());
+    expect(stateStore.loadState(null, { dir })).toEqual(stateStore.defaultState());
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+
+  test('saveState is a no-op for an unusable id (no shared undefined.json)', () => {
+    expect(stateStore.saveState(undefined, { ...stateStore.defaultState(), sessionId: 9 }, { dir })).toBe(false);
+    expect(stateStore.saveState(null, { ...stateStore.defaultState(), sessionId: 9 }, { dir })).toBe(false);
+    expect(stateStore.saveState('', { ...stateStore.defaultState(), sessionId: 9 }, { dir })).toBe(false);
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+
+  test('clearState is a no-op for an unusable id', () => {
+    expect(() => stateStore.clearState(undefined, { dir })).not.toThrow();
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+
+  test('two distinct usable ids stay isolated', () => {
+    stateStore.saveState('aaa', { ...stateStore.defaultState(), sessionId: 1 }, { dir });
+    stateStore.saveState('bbb', { ...stateStore.defaultState(), sessionId: 2 }, { dir });
+    expect(stateStore.loadState('aaa', { dir }).sessionId).toBe(1);
+    expect(stateStore.loadState('bbb', { dir }).sessionId).toBe(2);
+  });
+});
+
+describe('claude-code state-store: locked mutateState', () => {
+  let dir;
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('mutateState load-modify-write round-trips and persists', async () => {
+    stateStore.saveState('m1', { ...stateStore.defaultState(), memoriesSavedThisSession: 1 }, { dir });
+    await stateStore.mutateState(
+      'm1',
+      (s) => {
+        s.memoriesSavedThisSession += 1;
+      },
+      { dir },
+    );
+    expect(stateStore.loadState('m1', { dir }).memoriesSavedThisSession).toBe(2);
+  });
+
+  test('mutateState serializes concurrent increments (no lost update)', async () => {
+    stateStore.saveState('m2', { ...stateStore.defaultState(), memoriesSavedThisSession: 0 }, { dir });
+    const inc = () =>
+      stateStore.mutateState(
+        'm2',
+        async (s) => {
+          const before = s.memoriesSavedThisSession;
+          // Simulate the read-compute gap that lost updates before the lock.
+          await new Promise((r) => setTimeout(r, 5));
+          s.memoriesSavedThisSession = before + 1;
+        },
+        { dir },
+      );
+    await Promise.all([inc(), inc(), inc(), inc(), inc()]);
+    expect(stateStore.loadState('m2', { dir }).memoriesSavedThisSession).toBe(5);
+  });
+
+  test('mutateState leaves no stray .lock file behind', async () => {
+    await stateStore.mutateState(
+      'm3',
+      (s) => {
+        s.sessionId = 1;
+      },
+      { dir },
+    );
+    const leftovers = fs.readdirSync(dir).filter((f) => f.endsWith('.lock'));
+    expect(leftovers).toEqual([]);
+  });
+
+  test('mutateState on an unusable id runs the mutator against a transient state', async () => {
+    let seen;
+    const result = await stateStore.mutateState(
+      undefined,
+      (s) => {
+        seen = s;
+        return 'done';
+      },
+      { dir },
+    );
+    expect(result).toBe('done');
+    expect(seen).toEqual(stateStore.defaultState());
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+});
+
+describe('claude-code state-store: TTL + gc', () => {
+  let dir;
+  beforeEach(() => {
+    dir = tmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    delete process.env.LAPIS_SESSION_TTL_HOURS;
+  });
+
+  test('defaultTtlHours honors LAPIS_SESSION_TTL_HOURS and falls back to 24', () => {
+    expect(stateStore.defaultTtlHours()).toBe(24);
+    process.env.LAPIS_SESSION_TTL_HOURS = '72';
+    expect(stateStore.defaultTtlHours()).toBe(72);
+    process.env.LAPIS_SESSION_TTL_HOURS = 'not-a-number';
+    expect(stateStore.defaultTtlHours()).toBe(24);
+  });
+
+  test('sweepStaleSessions uses the env TTL by default', () => {
+    stateStore.saveState('fresh', stateStore.defaultState(), { dir });
+    stateStore.saveState('stale', stateStore.defaultState(), { dir });
+    const oldTime = new Date(Date.now() - 30 * 3600 * 1000).getTime() / 1000;
+    fs.utimesSync(path.join(dir, 'stale.json'), oldTime, oldTime);
+    // 48h window → nothing swept.
+    process.env.LAPIS_SESSION_TTL_HOURS = '48';
+    expect(stateStore.sweepStaleSessions(undefined, { dir }).swept).toBe(0);
+    // 24h default window → stale swept.
+    delete process.env.LAPIS_SESSION_TTL_HOURS;
+    fs.utimesSync(path.join(dir, 'stale.json'), oldTime, oldTime);
+    expect(stateStore.sweepStaleSessions(undefined, { dir }).swept).toBe(1);
+  });
+
+  test('runGc sweeps and reports, honoring --max-age-hours', () => {
+    stateStore.saveState('a', stateStore.defaultState(), { dir });
+    stateStore.saveState('b', stateStore.defaultState(), { dir });
+    const oldTime = new Date(Date.now() - 100 * 3600 * 1000).getTime() / 1000;
+    fs.utimesSync(path.join(dir, 'b.json'), oldTime, oldTime);
+    const lines = [];
+    const result = stateStore.runGc(['--max-age-hours', '50'], { dir, log: (l) => lines.push(l) });
+    expect(result.swept).toBe(1);
+    expect(result.maxAgeHours).toBe(50);
+    expect(lines.join('\n')).toContain('Swept 1');
+    expect(fs.existsSync(path.join(dir, 'b.json'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'a.json'))).toBe(true);
+  });
+
+  test('runGc rejects unknown flags and invalid --max-age-hours', () => {
+    expect(() => stateStore.runGc(['--bogus'], { dir, log: () => {} })).toThrow(/Unknown flag/);
+    expect(() => stateStore.runGc(['--max-age-hours', '0'], { dir, log: () => {} })).toThrow(/positive number/);
+  });
+});

--- a/test/claude-code/tool-hooks.test.js
+++ b/test/claude-code/tool-hooks.test.js
@@ -10,6 +10,12 @@ function makeStateStore(seed = {}) {
     saveState: (id, s) => {
       map.set(id, s);
     },
+    mutateState: async (id, mutator) => {
+      const s = map.get(id) || realStateStore.defaultState();
+      const r = await mutator(s);
+      map.set(id, s);
+      return r;
+    },
     clearState: (id) => map.delete(id),
     sweepStaleSessions: () => ({ swept: 0 }),
     _peek: (id) => map.get(id),
@@ -225,6 +231,26 @@ describe('claude-code PostToolUse: edit-track + git-trust', () => {
       dispatch,
       getKnownRepos: reposFn,
       stateStore,
+    });
+    expect(calls.some((c) => c.cmd === 'sync-code-trust' && c.args.repo === 'app')).toBe(true);
+  });
+
+  test('a compound git command (cd repo && git pull) still triggers sync-code-trust', async () => {
+    // #225: the install `if: "Bash(git *)"` prefix rule used to skip this; now
+    // the Bash PostToolUse matcher is bare and GIT_TRUST_OP_RE classifies it.
+    const stateStore = makeStateStore({ s: { ...realStateStore.defaultState(), currentProject: 'app' } });
+    const { dispatch, calls } = makeFakeDispatch();
+    await handlePostToolUse({
+      payload: {
+        session_id: 's',
+        tool_name: 'Bash',
+        tool_input: { command: 'cd /proj/app && git pull origin main' },
+        cwd: '/proj/app',
+      },
+      dispatch,
+      getKnownRepos: reposFn,
+      stateStore,
+      roleFilter: { only: 'git-trust' },
     });
     expect(calls.some((c) => c.cmd === 'sync-code-trust' && c.args.repo === 'app')).toBe(true);
   });

--- a/test/hooks-engine/guardrail-utils.test.js
+++ b/test/hooks-engine/guardrail-utils.test.js
@@ -5,9 +5,40 @@ const {
   isSpecificCodeFilePath,
   isBroadGlob,
   CONFIG_FILENAMES,
+  CODE_EXTENSIONS,
   RAW_CODE_DISCOVERY_RE,
   CODE_PATH_HINT_RE,
 } = require('../../src/hooks-engine/guardrail-utils');
+
+describe('hooks-engine guardrail-utils: CODE_EXTENSIONS (single source of truth)', () => {
+  test('classifies every extension in the shared list as a code file', () => {
+    for (const ext of CODE_EXTENSIONS) {
+      expect(isSpecificCodeFilePath(`src/thing.${ext}`)).toBe(true);
+    }
+  });
+
+  test('covers the extensions the bridge harvest regex previously lacked', () => {
+    // #230: the harvest CODE_PATH_RE was missing these vs SPECIFIC_CODE_FILE_RE.
+    for (const ext of [
+      'java',
+      'kt',
+      'rb',
+      'c',
+      'h',
+      'cpp',
+      'hpp',
+      'cs',
+      'scala',
+      'swift',
+      'php',
+      'cts',
+      'mts',
+      'pyi',
+    ]) {
+      expect(CODE_EXTENSIONS).toContain(ext);
+    }
+  });
+});
 
 describe('hooks-engine guardrail-utils: isTargetedSymbolLookup', () => {
   test('allows grep for single quoted symbol', () => {

--- a/test/hooks-engine/project.test.js
+++ b/test/hooks-engine/project.test.js
@@ -48,6 +48,16 @@ describe('hooks-engine project: findMatchingRepo', () => {
   test('returns null when nothing matches', () => {
     expect(findMatchingRepo('/elsewhere', repos)).toBeNull();
   });
+
+  test('does not false-match a sibling that merely shares a path prefix', () => {
+    // Regression guard for #227: matching must require the platform separator
+    // after the repo path. The fix switched from a hardcoded "/" to path.sep;
+    // a sibling repo whose name is a textual extension of another's path
+    // (/repos/alphabeta vs /repos/alpha) must NOT match. This boundary is the
+    // same one that was broken on Windows, where a hardcoded "/" could not
+    // separate a backslash-styled cwd from its repo.
+    expect(findMatchingRepo('/repos/alphabeta', repos)).toBeNull();
+  });
 });
 
 describe('hooks-engine project: findMatchingProject', () => {

--- a/test/hooks-engine/session-summary.test.js
+++ b/test/hooks-engine/session-summary.test.js
@@ -60,4 +60,19 @@ describe('hooks-engine session-summary: buildSessionSummary', () => {
     });
     expect(a).toContain('## Files Modified');
   });
+
+  test('dedupes dual full-path + basename editedFiles entries', () => {
+    const out = buildSessionSummary({
+      userMessages: [],
+      assistantCount: 0,
+      turnCount: 0,
+      memoriesSaved: 0,
+      editedFiles: ['/tmp/repo/src/a.js', 'a.js', '/tmp/repo/lib/b.ts', 'b.ts'],
+      cwd: '/tmp/repo',
+    });
+    expect(out).toContain('- src/a.js');
+    expect(out).toContain('- lib/b.ts');
+    expect(out.match(/- src\/a\.js/g)).toHaveLength(1);
+    expect(out.match(/- lib\/b\.ts/g)).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Resolves #224, #225, #226, #227, #228, #229, #230, #231, #232, #233 (the ten issues filed in the #205 epic review).

## Summary

Addresses every finding from the Phase 1–6 review in one PR. Each fix is independently scoped; together they close the silent-data-corruption, wrong-behaviour, and inconsistency classes plus the observability gaps.

## High impact (silent data corruption / wrong behaviour)

| Issue | Fix |
| --- | --- |
| **#224** shared `undefined.json` | `state-store` `sanitizeKey` rejects missing/null/empty/placeholder ids; `load`/`clear` no-op and `save` returns false → fail-open, no cross-session contamination. |
| **#225** compound git commands miss trust-sync | Removed `ifRule: "Bash(git *)"`; `GIT_TRUST_OP_RE` already classifies the command (covers `cd repo && git pull`, `sudo git …`, etc.). |
| **#226** compound bash searches bypass guardrail | Collapsed the five `Bash(grep *)`…ifRules into one bare `Bash` matcher; `bashGuardrail` classifies and short-circuits fast. |
| **#227** Windows `findMatchingRepo` broken | Switched the hardcoded `/` to `path.sep` so a Windows cwd nested under an indexed repo prefix-matches (was exact-only). |
| **#228** load/mutate/save race drops counters | Added `mutateState` (locked read-modify-write, stale-lock breaking, fail-open) and routed the PreToolUse/PostToolUse write paths through it. git-trust stays read-only. |

## Medium (leaky abstractions / inconsistency / observability)

| Issue | Fix |
| --- | --- |
| **#229** redundant daemon POST `project` | Dropped the top-level field (already serialized into `args.project`, never consumed). |
| **#230** editedFiles vs exploredFiles normalization | New `file-keys.js` centralizes lower+basename normalization; `CODE_PATH_RE` is now derived from a shared `CODE_EXTENSIONS` so the harvest never lags `SPECIFIC_CODE_FILE_RE`. |
| **#231** `runHook` ignores injected deps | `opts.stateStore` / `opts.dispatchClient` are now honored (and `dispatch`/`getKnownRepos` resolve from an injected client). |
| **#232** re-install port drift | `runStart` warns loudly and keeps the running daemon on host/port mismatch; install surfaces the port hooks actually POST to. |
| **#233** hardcoded 24h sweep | `sweepStaleSessions` honors `LAPIS_SESSION_TTL_HOURS`; session-start logs sweeps; doctor reports TTL/size/oldest file; new `lapis claude-code gc [--max-age-hours N]`. |

## Design notes

- **#225/#226 latency:** matching on bare `Bash` spawns a hook process for every shell command. This is the documented tradeoff of the hooks architecture; the handlers early-return on a single regex (`RAW_CODE_DISCOVERY_RE`/`GIT_TRUST_OP_RE`) so non-search commands are cheap. Matches the Option 1 recommendation in the issues.
- **#228** chose the per-file advisory lock over moving counters to the DB: smaller, contained to the bridge, and the only user-visible counter (`memories`) is already DB-derived at session-end.
- **#232** chose warn-and-keep over auto-restart so a port change can't disrupt other Claude Code sessions sharing the daemon.

## Verification

- `npx vitest run test/claude-code test/hooks-engine` → **247 passed, 0 failed**
- `oxlint` (changed dirs) → exit 0 (only pre-existing style warnings)
- `oxfmt --check` (changed dirs) → all formatted
- New tests: state-store fail-open + locked concurrency + TTL/gc; daemon port mismatch; router injection seams; file-keys; CODE_EXTENSIONS; compound git-trust; project separator boundary.
- The 205 failures in the full DB-backed suite are pre-existing (`better-sqlite3` native module not compiled in this sandbox) and unrelated to these pure-JS changes.

Closes #224, closes #225, closes #226, closes #227, closes #228, closes #229, closes #230, closes #231, closes #232, closes #233.