### PR TITLE
fix(claude-code): harden issue #205 review findings — state races, path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Claude Code bridge — issue #205 post-review hardening** (follow-up to #234).
+  - **Stop / UserPromptSubmit state races (#228):** Stop and UserPromptSubmit now
+    route all state writes through `mutateState` instead of unlocked load/save,
+    so parallel PostToolUse hooks are not clobbered by stale snapshots.
+  - **Path normalization (#227, #230):** `fileKey` / read-guardrail lookups and
+    `findMatchingRepo` normalize `/` vs `\` so Windows and mixed-separator paths
+    match correctly.
+  - **`sanitizeKey`:** case-insensitive rejection of placeholder session ids
+    (`Undefined`, `NaN`, …).
+  - **Git trust sync:** `git -C <path> pull` (and similar) now trigger
+    `sync-code-trust`.
+  - **Edit-track:** `MultiEdit` / `Edit` `edits[]` paths are recorded.
+  - **UserPromptSubmit timeout:** cancelled flag prevents state persistence after
+    the 30s budget fires.
+
 - **Claude Code bridge — Phase 1–6 review polish** (#234 follow-up).
   - `uniqueEditedPaths` dedupes dual full-path + basename `editedFiles` entries
     before session summaries, checkpoints, and `audit-diff` (storage shape

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - **Edit-track:** `MultiEdit` / `Edit` `edits[]` paths are recorded.
   - **UserPromptSubmit timeout:** cancelled flag prevents state persistence after
     the 30s budget fires.
+  - **Stop capture lock scope:** gateway dispatches (passive capture, dream,
+    negative-recall) run outside the `mutateState` file lock so parallel
+    PostToolUse hooks are not blocked for dispatch duration.
+  - **Read guardrail:** repo path matching uses the same separator normalization
+    as `findMatchingRepo`.
+  - **Shared `makeMutate`:** extracted to `src/claude-code/state-mutate.js`.
 
 - **Claude Code bridge — Phase 1–6 review polish** (#234 follow-up).
   - `uniqueEditedPaths` dedupes dual full-path + basename `editedFiles` entries

--- a/src/claude-code/file-keys.js
+++ b/src/claude-code/file-keys.js
@@ -18,12 +18,25 @@ const path = require('node:path');
  * @param {string} p
  * @returns {{ lower: string, base: string } | null}
  */
+/**
+ * Lowercase and normalize separators for stable path comparison (#230).
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+function normalizePathForCompare(p) {
+  if (typeof p !== 'string' || !p) {
+    return '';
+  }
+  return p.toLowerCase().replace(/\\/g, '/');
+}
+
 function fileKey(p) {
   if (typeof p !== 'string' || !p) {
     return null;
   }
-  const lower = p.toLowerCase();
-  const base = path.basename(lower.replace(/\\/g, '/'));
+  const lower = normalizePathForCompare(p);
+  const base = path.basename(lower);
   if (!base) {
     return null;
   }
@@ -77,4 +90,4 @@ function uniqueEditedPaths(editedFiles) {
   return [...byBase.values()];
 }
 
-module.exports = { fileKey, addNormalized, uniqueEditedPaths };
+module.exports = { fileKey, addNormalized, uniqueEditedPaths, normalizePathForCompare };

--- a/src/claude-code/file-keys.js
+++ b/src/claude-code/file-keys.js
@@ -12,13 +12,6 @@
 const path = require('node:path');
 
 /**
- * Lowercase a path and split off its basename, tolerating both POSIX and
- * Windows separators. Returns null for non-string / empty input.
- *
- * @param {string} p
- * @returns {{ lower: string, base: string } | null}
- */
-/**
  * Lowercase and normalize separators for stable path comparison (#230).
  *
  * @param {string} p
@@ -31,6 +24,13 @@ function normalizePathForCompare(p) {
   return p.toLowerCase().replace(/\\/g, '/');
 }
 
+/**
+ * Lowercase a path and split off its basename, tolerating both POSIX and
+ * Windows separators. Returns null for non-string / empty input.
+ *
+ * @param {string} p
+ * @returns {{ lower: string, base: string } | null}
+ */
 function fileKey(p) {
   if (typeof p !== 'string' || !p) {
     return null;

--- a/src/claude-code/handlers/post-tool-use.js
+++ b/src/claude-code/handlers/post-tool-use.js
@@ -32,7 +32,7 @@ const { CODE_EXTENSIONS } = require('../../hooks-engine/guardrail-utils');
 const { addNormalized } = require('../file-keys');
 const { postToolRole } = require('../tool-map');
 
-const GIT_TRUST_OP_RE = /\bgit\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/;
+const GIT_TRUST_OP_RE = /\bgit(?:\s+-C\s+\S+)?\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/;
 // Harvest relative code paths from a memory-code response (parity with the Pi
 // tool_result handler in tool-guardrails.ts). The extension alternation is the
 // same list SPECIFIC_CODE_FILE_RE uses so the harvest never lags the
@@ -166,7 +166,14 @@ async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore,
     }
     switch (role) {
       case 'edit-track':
-        addEditedFile(state, input.file_path);
+        addEditedFile(state, input.file_path || input.path);
+        if (Array.isArray(input.edits)) {
+          for (const edit of input.edits) {
+            if (edit && typeof edit.file_path === 'string') {
+              addEditedFile(state, edit.file_path);
+            }
+          }
+        }
         return;
       case 'memory-save-mirror':
         if (wasSaveSuccessful(toolResponse)) {

--- a/src/claude-code/handlers/pre-tool-use.js
+++ b/src/claude-code/handlers/pre-tool-use.js
@@ -35,7 +35,7 @@ const {
   CODE_PATH_HINT_RE,
 } = require('../../hooks-engine/guardrail-utils');
 const { preToolRole } = require('../tool-map');
-const { addNormalized } = require('../file-keys');
+const { addNormalized, normalizePathForCompare } = require('../file-keys');
 
 /** Build the PreToolUse deny envelope. */
 function deny(reason) {
@@ -110,12 +110,15 @@ function readGuardrail({ input, repos, cwd, state }) {
     return null;
   }
 
-  const relPath = path.relative(matchedRepo.path, absPath).toLowerCase();
+  const relPath = normalizePathForCompare(path.relative(matchedRepo.path, absPath));
   const explored = Array.isArray(state.exploredFiles) ? state.exploredFiles : [];
+  const exploredNorm = explored.map(normalizePathForCompare);
+  const basenameNorm = basename.toLowerCase();
+  const absNorm = normalizePathForCompare(absPath);
   if (
-    explored.includes(basename.toLowerCase()) ||
-    explored.includes(relPath) ||
-    explored.includes(absPath.toLowerCase())
+    exploredNorm.includes(basenameNorm) ||
+    exploredNorm.includes(relPath) ||
+    exploredNorm.includes(absNorm)
   ) {
     return null;
   }

--- a/src/claude-code/handlers/pre-tool-use.js
+++ b/src/claude-code/handlers/pre-tool-use.js
@@ -24,7 +24,7 @@
 
 const path = require('node:path');
 const { isCodeFile } = require('../../code-index/scanner');
-const { resolveCwd, projectFromCwd, findMatchingRepo } = require('../../hooks-engine/project');
+const { resolveCwd, projectFromCwd, findMatchingRepo, normalizeRepoPath } = require('../../hooks-engine/project');
 const {
   isPipedOutputFilter,
   isTargetedSymbolLookup,
@@ -94,16 +94,17 @@ function readGuardrail({ input, repos, cwd, state }) {
   }
 
   const absPath = path.resolve(cwd, filePath);
+  const absNorm = normalizeRepoPath(absPath);
+  const cwdNorm = normalizeRepoPath(cwd);
   // Cross-project reads (outside cwd) bypass the outline guard.
-  if (absPath !== cwd && !absPath.startsWith(cwd + path.sep)) {
+  if (absNorm !== cwdNorm && !absNorm.startsWith(`${cwdNorm}/`)) {
     return null;
   }
 
-  const matchedRepo = repos.find(
-    (r) =>
-      absPath.toLowerCase().startsWith(`${r.path.toLowerCase()}${path.sep}`) ||
-      absPath.toLowerCase() === r.path.toLowerCase(),
-  );
+  const matchedRepo = repos.find((r) => {
+    const rp = normalizeRepoPath(r.path);
+    return absNorm === rp || absNorm.startsWith(`${rp}/`);
+  });
   // Deferred auto-index: an unindexed project is allowed through (no outline to
   // point at, and indexing inline would blow the hook timeout).
   if (!matchedRepo) {
@@ -114,7 +115,6 @@ function readGuardrail({ input, repos, cwd, state }) {
   const explored = Array.isArray(state.exploredFiles) ? state.exploredFiles : [];
   const exploredNorm = explored.map(normalizePathForCompare);
   const basenameNorm = basename.toLowerCase();
-  const absNorm = normalizePathForCompare(absPath);
   if (
     exploredNorm.includes(basenameNorm) ||
     exploredNorm.includes(relPath) ||

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -12,11 +12,13 @@
  * re-entrancy loops.
  *
  * State writes route through mutateState so parallel PostToolUse hooks cannot
- * be clobbered by a stale snapshot saved at the end of capture (#228).
+ * be clobbered by a stale snapshot (#228). Slow gateway dispatches run OUTSIDE
+ * the file lock so PostToolUse hooks are not blocked for the dispatch duration.
  */
 
 const path = require('node:path');
 const { uniqueEditedPaths } = require('../file-keys');
+const { makeMutate } = require('../state-mutate');
 const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
 const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
 const { shouldAutoCapture } = require('../../hooks-engine/pattern-matcher');
@@ -32,18 +34,6 @@ const {
 // AUTO_DECISION_COOLDOWN) and the hooks-engine passive-capture defaults.
 const CHECKPOINT_EVERY = 10;
 const COOLDOWN_MS = 60000;
-
-function makeMutate(stateStore, claudeSessionId) {
-  if (stateStore.mutateState) {
-    return (mutator) => stateStore.mutateState(claudeSessionId, mutator);
-  }
-  return async (mutator) => {
-    const state = stateStore.loadState(claudeSessionId);
-    const result = await mutator(state);
-    stateStore.saveState(claudeSessionId, state);
-    return result;
-  };
-}
 
 function extractInlineAssistantText(payload) {
   // Preferred inline field (#207). Newer Claude Code builds may ship the last
@@ -185,40 +175,51 @@ async function runStopCapture({
   try {
     const text = await resolveAssistantText(lastText, transcriptPath);
 
-    await mutate(async (state) => {
+    // Passive capture: locked read → dispatch (unlocked) → locked cooldown stamp.
+    const autoPayload = await mutate((state) => {
       if (!text || text.length < 100) {
-        return;
+        return null;
       }
       if (isAutoDecisionCoolingDown(state.lastAutoDecisionSave, now, COOLDOWN_MS)) {
-        return;
+        return null;
       }
       if (text.includes('memory-save') || text.includes('memory-search') || text.includes('memory-get')) {
-        return;
+        return null;
       }
-
       const capture = shouldAutoCapture(text);
-      const payload = buildAutoDecisionPayload({ text, capture, project, sessionId: state.sessionId });
-      if (payload) {
-        state.lastAutoDecisionSave = now;
-        await dispatch('save', payload);
-      }
+      return buildAutoDecisionPayload({ text, capture, project, sessionId: state.sessionId });
     });
+    if (autoPayload) {
+      try {
+        await dispatch('save', autoPayload);
+        await mutate((state) => {
+          state.lastAutoDecisionSave = now;
+        });
+      } catch {
+        // Passive capture is best-effort; cooldown not stamped on failure.
+      }
+    }
 
-    await mutate(async (state) => {
+    // Dream: claim the once-per-session flag under lock, dispatch outside it.
+    const runDream = await mutate((state) => {
       if (!shouldDream(turnCount, state.dreamTriggeredThisSession)) {
-        return;
+        return false;
       }
       state.dreamTriggeredThisSession = true;
+      return true;
+    });
+    if (runDream) {
       try {
         await dispatch('dream', {});
       } catch {
         // Auto-dream is best-effort.
       }
-    });
+    }
 
-    await mutate(async (state) => {
+    // Negative recall: drain the queue under lock, dispatch outside it.
+    const recallEntries = await mutate((state) => {
       if (!state.pendingRecallFeedback || state.pendingRecallFeedback.length === 0) {
-        return;
+        return null;
       }
       const entries = state.pendingRecallFeedback.map(([memoryId, meta]) => ({
         memoryId,
@@ -226,9 +227,16 @@ async function runStopCapture({
         query: meta?.query,
         wasUseful: false,
       }));
-      await dispatch('log-negative-recall', { entries: JSON.stringify(entries) });
       state.pendingRecallFeedback = [];
+      return entries;
     });
+    if (recallEntries) {
+      try {
+        await dispatch('log-negative-recall', { entries: JSON.stringify(recallEntries) });
+      } catch {
+        // Negative-recall flush is best-effort.
+      }
+    }
 
     if (shouldCheckpoint(turnCount, CHECKPOINT_EVERY)) {
       const state = stateStore.loadState(claudeSessionId);
@@ -239,4 +247,4 @@ async function runStopCapture({
   }
 }
 
-module.exports = { handleStop, runStopCapture, makeMutate };
+module.exports = { handleStop, runStopCapture };

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -10,6 +10,9 @@
  *
  * Defensive: if payload.stop_hook_active is truthy, return immediately to avoid
  * re-entrancy loops.
+ *
+ * State writes route through mutateState so parallel PostToolUse hooks cannot
+ * be clobbered by a stale snapshot saved at the end of capture (#228).
  */
 
 const path = require('node:path');
@@ -29,6 +32,18 @@ const {
 // AUTO_DECISION_COOLDOWN) and the hooks-engine passive-capture defaults.
 const CHECKPOINT_EVERY = 10;
 const COOLDOWN_MS = 60000;
+
+function makeMutate(stateStore, claudeSessionId) {
+  if (stateStore.mutateState) {
+    return (mutator) => stateStore.mutateState(claudeSessionId, mutator);
+  }
+  return async (mutator) => {
+    const state = stateStore.loadState(claudeSessionId);
+    const result = await mutator(state);
+    stateStore.saveState(claudeSessionId, state);
+    return result;
+  };
+}
 
 function extractInlineAssistantText(payload) {
   // Preferred inline field (#207). Newer Claude Code builds may ship the last
@@ -65,28 +80,6 @@ async function resolveAssistantText(lastText, transcriptPath) {
     }
   }
   return '';
-}
-
-/**
- * Passive-capture an auto-decision from the last assistant message.
- */
-async function passiveCapture({ dispatch, text, project, sessionId, state, now }) {
-  if (!text || text.length < 100) {
-    return;
-  }
-  if (isAutoDecisionCoolingDown(state.lastAutoDecisionSave, now, COOLDOWN_MS)) {
-    return;
-  }
-  if (text.includes('memory-save') || text.includes('memory-search') || text.includes('memory-get')) {
-    return;
-  }
-
-  const capture = shouldAutoCapture(text);
-  const payload = buildAutoDecisionPayload({ text, capture, project, sessionId: state.sessionId });
-  if (payload) {
-    state.lastAutoDecisionSave = now;
-    await dispatch('save', payload);
-  }
 }
 
 /**
@@ -138,23 +131,6 @@ async function checkpoint({ dispatch, state, project }) {
   });
 }
 
-/**
- * Flush pending negative-recall feedback.
- */
-async function flushNegativeRecall({ dispatch, state }) {
-  if (!state.pendingRecallFeedback || state.pendingRecallFeedback.length === 0) {
-    return;
-  }
-  const entries = state.pendingRecallFeedback.map(([memoryId, meta]) => ({
-    memoryId,
-    sessionId: meta?.sessionId,
-    query: meta?.query,
-    wasUseful: false,
-  }));
-  await dispatch('log-negative-recall', { entries: JSON.stringify(entries) });
-  state.pendingRecallFeedback = [];
-}
-
 async function handleStop({ payload, dispatch, stateStore }) {
   // Avoid re-entrancy: Claude Code sets stop_hook_active when already inside a
   // stop continuation. Bail out so we never create a feedback loop.
@@ -165,23 +141,22 @@ async function handleStop({ payload, dispatch, stateStore }) {
   const cwd = resolveCwd(payload.cwd);
   const project = projectFromCwd(cwd);
   const claudeSessionId = payload.session_id;
-
-  const state = stateStore.loadState(claudeSessionId);
-  state.turnCount += 1;
   const now = Date.now();
+  const mutate = makeMutate(stateStore, claudeSessionId);
 
-  // Only the cheap inline field read happens synchronously; the transcript
-  // fallback (async stream read) runs inside runStopCapture, after we return, so
-  // Stop never blocks Claude Code's turn progression.
+  const turnCount = await mutate((state) => {
+    state.turnCount += 1;
+    return state.turnCount;
+  });
+
   const lastText = extractInlineAssistantText(payload);
 
   // All capture work is fire-and-forget: Stop must not block Claude Code.
-  // Exposed as runStopCapture for deterministic testing.
   void runStopCapture({
     dispatch,
     stateStore,
     claudeSessionId,
-    state,
+    turnCount,
     project,
     now,
     lastText,
@@ -199,40 +174,69 @@ async function runStopCapture({
   dispatch,
   stateStore,
   claudeSessionId,
-  state,
+  turnCount,
   project,
   now,
   lastText,
   transcriptPath,
 }) {
-  try {
-    // Transcript fallback is resolved here (async stream read), off the
-    // synchronous hook path; passive capture uses the resulting text.
-    const text = await resolveAssistantText(lastText, transcriptPath);
-    await passiveCapture({ dispatch, text, project, state, now });
+  const mutate = makeMutate(stateStore, claudeSessionId);
 
-    if (shouldDream(state.turnCount, state.dreamTriggeredThisSession)) {
+  try {
+    const text = await resolveAssistantText(lastText, transcriptPath);
+
+    await mutate(async (state) => {
+      if (!text || text.length < 100) {
+        return;
+      }
+      if (isAutoDecisionCoolingDown(state.lastAutoDecisionSave, now, COOLDOWN_MS)) {
+        return;
+      }
+      if (text.includes('memory-save') || text.includes('memory-search') || text.includes('memory-get')) {
+        return;
+      }
+
+      const capture = shouldAutoCapture(text);
+      const payload = buildAutoDecisionPayload({ text, capture, project, sessionId: state.sessionId });
+      if (payload) {
+        state.lastAutoDecisionSave = now;
+        await dispatch('save', payload);
+      }
+    });
+
+    await mutate(async (state) => {
+      if (!shouldDream(turnCount, state.dreamTriggeredThisSession)) {
+        return;
+      }
       state.dreamTriggeredThisSession = true;
       try {
         await dispatch('dream', {});
       } catch {
         // Auto-dream is best-effort.
       }
-    }
+    });
 
-    await flushNegativeRecall({ dispatch, state });
+    await mutate(async (state) => {
+      if (!state.pendingRecallFeedback || state.pendingRecallFeedback.length === 0) {
+        return;
+      }
+      const entries = state.pendingRecallFeedback.map(([memoryId, meta]) => ({
+        memoryId,
+        sessionId: meta?.sessionId,
+        query: meta?.query,
+        wasUseful: false,
+      }));
+      await dispatch('log-negative-recall', { entries: JSON.stringify(entries) });
+      state.pendingRecallFeedback = [];
+    });
 
-    if (shouldCheckpoint(state.turnCount, CHECKPOINT_EVERY)) {
+    if (shouldCheckpoint(turnCount, CHECKPOINT_EVERY)) {
+      const state = stateStore.loadState(claudeSessionId);
       await checkpoint({ dispatch, state, project });
     }
-
-    stateStore.saveState(claudeSessionId, state);
   } catch {
-    // Never throw out of a Stop handler; persist best-effort.
-    try {
-      stateStore.saveState(claudeSessionId, state);
-    } catch {}
+    // Never throw out of a Stop handler.
   }
 }
 
-module.exports = { handleStop, runStopCapture };
+module.exports = { handleStop, runStopCapture, makeMutate };

--- a/src/claude-code/handlers/user-prompt-submit.js
+++ b/src/claude-code/handlers/user-prompt-submit.js
@@ -32,6 +32,18 @@ const REMINDER_RECENT_MS = 180000; // 3min (context-injection.ts:235)
 const REMINDER_TEXT =
   '💡 Memory reminder: Use `memory-search` before decisions to avoid repeating past mistakes. Use `memory-save` for decisions, bugfixes, and discoveries.';
 
+function makeMutate(stateStore, claudeSessionId) {
+  if (stateStore.mutateState) {
+    return (mutator) => stateStore.mutateState(claudeSessionId, mutator);
+  }
+  return async (mutator) => {
+    const state = stateStore.loadState(claudeSessionId);
+    const result = await mutator(state);
+    stateStore.saveState(claudeSessionId, state);
+    return result;
+  };
+}
+
 /**
  * Append preflight + coding-context blocks (best-effort). Mutates lines.
  */
@@ -69,7 +81,7 @@ async function appendPreflight({ lines, dispatch, cwdRepo, prompt }) {
   }
 }
 
-async function run({ payload, dispatch, getKnownRepos, stateStore }) {
+async function run({ payload, dispatch, getKnownRepos, stateStore, isCancelled }) {
   const prompt = payload.prompt || '';
   const cwd = resolveCwd(payload.cwd);
   const project = projectFromCwd(cwd);
@@ -87,23 +99,46 @@ async function run({ payload, dispatch, getKnownRepos, stateStore }) {
     sessionId,
   }).catch(() => null);
 
+  if (isCancelled?.()) {
+    return null;
+  }
+
   const lines = assembled ? assembled.lines : [];
   const cwdRepo = assembled ? assembled.cwdRepo : findMatchingRepo(path.resolve(cwd), getKnownRepos());
 
   // Preflight / coding context (best-effort, timeout-safe).
   await appendPreflight({ lines, dispatch, cwdRepo, prompt });
 
+  if (isCancelled?.()) {
+    return null;
+  }
+
   // Cadence-gated reminder (parity of Pi's context-event reminder).
-  state.callsSinceLastMemory += 1;
-  const recentMemory = Date.now() - state.lastMemoryToolCall < REMINDER_RECENT_MS;
-  if (state.callsSinceLastMemory >= REMINDER_INTERVAL && !recentMemory) {
-    state.callsSinceLastMemory = 0;
+  // Routed through mutateState so parallel memory-tool hooks cannot be
+  // clobbered by an unlocked load/save (#228).
+  let shouldRemind = false;
+  const mutate = makeMutate(stateStore, claudeSessionId);
+  await mutate((s) => {
+    if (isCancelled?.()) {
+      return;
+    }
+    s.callsSinceLastMemory += 1;
+    const recentMemory = Date.now() - s.lastMemoryToolCall < REMINDER_RECENT_MS;
+    if (s.callsSinceLastMemory >= REMINDER_INTERVAL && !recentMemory) {
+      s.callsSinceLastMemory = 0;
+      shouldRemind = true;
+    }
+    s.hasInjectedContext = true;
+  });
+
+  if (isCancelled?.()) {
+    return null;
+  }
+
+  if (shouldRemind) {
     lines.push('');
     lines.push(REMINDER_TEXT);
   }
-
-  state.hasInjectedContext = true;
-  stateStore.saveState(claudeSessionId, state);
 
   const additionalContext = capInjectedContext(lines.join('\n'));
   if (!additionalContext) {
@@ -123,12 +158,17 @@ async function handleUserPromptSubmit(ctx) {
   // the prompt is never blocked. The timer is cleared when run() settles so the
   // hook process exits immediately on the fast path — otherwise the dangling
   // timer keeps Node's event loop (and thus Claude Code) alive for the full budget.
+  // A cancelled flag prevents run() from persisting state after the budget fires.
   let timer;
+  let cancelled = false;
   try {
     return await Promise.race([
-      run(ctx).catch(() => null),
+      run({ ...ctx, isCancelled: () => cancelled }).catch(() => null),
       new Promise((resolve) => {
-        timer = setTimeout(() => resolve(null), BUDGET_MS);
+        timer = setTimeout(() => {
+          cancelled = true;
+          resolve(null);
+        }, BUDGET_MS);
       }),
     ]);
   } finally {

--- a/src/claude-code/handlers/user-prompt-submit.js
+++ b/src/claude-code/handlers/user-prompt-submit.js
@@ -25,24 +25,13 @@ const {
 } = require('../../hooks-engine/preflight-assembly');
 const { capInjectedContext } = require('../../hooks-engine/context-builder');
 const { assembleContextLines } = require('../context-inject');
+const { makeMutate } = require('../state-mutate');
 
 const BUDGET_MS = 30000;
 const REMINDER_INTERVAL = 5; // MEMORY_REMINDER_INTERVAL (state.ts:107)
 const REMINDER_RECENT_MS = 180000; // 3min (context-injection.ts:235)
 const REMINDER_TEXT =
   '💡 Memory reminder: Use `memory-search` before decisions to avoid repeating past mistakes. Use `memory-save` for decisions, bugfixes, and discoveries.';
-
-function makeMutate(stateStore, claudeSessionId) {
-  if (stateStore.mutateState) {
-    return (mutator) => stateStore.mutateState(claudeSessionId, mutator);
-  }
-  return async (mutator) => {
-    const state = stateStore.loadState(claudeSessionId);
-    const result = await mutator(state);
-    stateStore.saveState(claudeSessionId, state);
-    return result;
-  };
-}
 
 /**
  * Append preflight + coding-context blocks (best-effort). Mutates lines.

--- a/src/claude-code/state-mutate.js
+++ b/src/claude-code/state-mutate.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Claude Code bridge: locked read-modify-write helper for hook handlers.
+ *
+ * Wraps stateStore.mutateState when available; falls back to load/save for
+ * injected test doubles that omit locking.
+ */
+
+function makeMutate(stateStore, claudeSessionId) {
+  if (stateStore.mutateState) {
+    return (mutator) => stateStore.mutateState(claudeSessionId, mutator);
+  }
+  return async (mutator) => {
+    const state = stateStore.loadState(claudeSessionId);
+    const result = await mutator(state);
+    stateStore.saveState(claudeSessionId, state);
+    return result;
+  };
+}
+
+module.exports = { makeMutate };

--- a/src/claude-code/state-store.js
+++ b/src/claude-code/state-store.js
@@ -79,7 +79,7 @@ function sanitizeKey(sessionId) {
     return null;
   }
   const safe = raw.replace(/[^\w.-]/g, '_');
-  if (!safe || PLACEHOLDER_KEYS.has(safe) || /^_+$/.test(safe)) {
+  if (!safe || PLACEHOLDER_KEYS.has(safe.toLowerCase()) || /^_+$/.test(safe)) {
     return null;
   }
   return safe;

--- a/src/hooks-engine/project.js
+++ b/src/hooks-engine/project.js
@@ -42,16 +42,18 @@ function projectFromCwd(cwd) {
  * @param {Array<{path:string}>} repos
  * @returns {object|null}
  */
+function normalizeRepoPath(p) {
+  return path.resolve(p).toLowerCase().replace(/\\/g, '/');
+}
+
 function findMatchingRepo(resolvedCwd, repos) {
-  // Use path.sep (not a hardcoded "/") so a Windows cwd nested under an
-  // indexed repo still prefix-matches: the DB stores backslash paths there,
-  // and the old `${rp}/` check only ever matched on exact equality (#227).
-  const abs = path.resolve(resolvedCwd).toLowerCase();
-  const sep = path.sep;
+  // Normalize separators so a Windows cwd matches a DB path stored with `/`
+  // (or vice versa). Prefix match always uses `/` after normalization (#227).
+  const abs = normalizeRepoPath(resolvedCwd);
   return (
     repos.find((r) => {
-      const rp = r.path.toLowerCase();
-      return abs === rp || abs.startsWith(rp + sep);
+      const rp = normalizeRepoPath(r.path);
+      return abs === rp || abs.startsWith(`${rp}/`);
     }) || null
   );
 }
@@ -83,4 +85,5 @@ module.exports = {
   projectFromCwd,
   findMatchingRepo,
   findMatchingProject,
+  normalizeRepoPath,
 };

--- a/test/claude-code/file-keys.test.js
+++ b/test/claude-code/file-keys.test.js
@@ -7,7 +7,7 @@ describe('claude-code file-keys: shared normalization', () => {
   });
 
   test('fileKey handles Windows-style separators', () => {
-    expect(fileKey('src\\sub\\Foo.JS')).toEqual({ lower: 'src\\sub\\foo.js', base: 'foo.js' });
+    expect(fileKey('src\\sub\\Foo.JS')).toEqual({ lower: 'src/sub/foo.js', base: 'foo.js' });
   });
 
   test('fileKey rejects non-strings', () => {

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -237,17 +237,6 @@ describe('claude-code handlers: Stop', () => {
     const { dispatch, calls } = makeFakeDispatch();
     const stateStore = makeStateStore();
     stateStore.saveState('claude-9', { ...realStateStore.defaultState(), sessionId: 1, turnCount: 4 });
-    await runStopCapture({
-      dispatch,
-      stateStore,
-      claudeSessionId: 'claude-9',
-      state: { ...stateStore.loadState('claude-9'), turnCount: 5 },
-      project: 'p',
-      now: Date.now(),
-      lastText: '',
-    });
-    // stop_hook_active is checked in handleStop, not runStopCapture; verify
-    // handleStop short-circuits before incrementing/persisting.
     const before = stateStore._peek('claude-9').turnCount;
     await handleStop({ payload: { session_id: 'claude-9', stop_hook_active: true, cwd: '/p' }, dispatch, stateStore });
     expect(stateStore._peek('claude-9').turnCount).toBe(before);
@@ -264,55 +253,53 @@ describe('claude-code handlers: Stop', () => {
     });
     const { dispatch, calls } = makeFakeDispatch();
 
-    const state = { ...stateStore.loadState('claude-10'), turnCount: 10, currentProject: 'p', editedFiles: [] };
     await runStopCapture({
       dispatch,
       stateStore,
       claudeSessionId: 'claude-10',
-      state,
+      turnCount: 10,
       project: 'p',
       now: Date.now(),
       lastText: '',
     });
 
     expect(hasCall(calls, 'save', (a) => a.type === 'progress')).toBe(true);
-    expect(stateStore._peek('claude-10').turnCount).toBe(10);
+    expect(stateStore._peek('claude-10').turnCount).toBe(9);
   });
 
   test('dream triggers at turn 50 once', async () => {
     const stateStore = makeStateStore();
     const { dispatch, calls } = makeFakeDispatch();
-    const state = {
-      ...realStateStore.defaultState(),
-      sessionId: 1,
-      turnCount: 50,
-      currentProject: 'p',
-      dreamTriggeredThisSession: false,
-    };
     await runStopCapture({
       dispatch,
       stateStore,
       claudeSessionId: 'x',
-      state,
+      turnCount: 50,
       project: 'p',
       now: Date.now(),
       lastText: '',
     });
     expect(hasCall(calls, 'dream')).toBe(true);
-    expect(state.dreamTriggeredThisSession).toBe(true);
+    expect(stateStore._peek('x').dreamTriggeredThisSession).toBe(true);
   });
 
   test('passive capture saves an auto-decision on a qualifying assistant message', async () => {
     const { dispatch, calls } = makeFakeDispatch();
-    const state = { ...realStateStore.defaultState(), sessionId: 1, turnCount: 3, lastAutoDecisionSave: 0 };
+    const stateStore = makeStateStore();
+    stateStore.saveState('y', {
+      ...realStateStore.defaultState(),
+      sessionId: 1,
+      turnCount: 3,
+      lastAutoDecisionSave: 0,
+    });
     const reasoning =
       'Analyzing the requirements and constraints of this subsystem in detail before proceeding. '.repeat(4);
     const longText = `${reasoning} Based on the tradeoffs, going with a queue-based design because it avoids head-of-line blocking.`;
     await runStopCapture({
       dispatch,
-      stateStore: makeStateStore(),
+      stateStore,
       claudeSessionId: 'y',
-      state,
+      turnCount: 3,
       project: 'p',
       now: Date.now(),
       lastText: longText,
@@ -369,23 +356,53 @@ describe('claude-code handlers: Stop', () => {
 
   test('negative-recall feedback is flushed', async () => {
     const { dispatch, calls } = makeFakeDispatch();
-    const state = {
+    const stateStore = makeStateStore();
+    stateStore.saveState('z', {
       ...realStateStore.defaultState(),
       sessionId: 1,
       turnCount: 3,
       pendingRecallFeedback: [[5, { sessionId: 1, query: 'q' }]],
-    };
+    });
     await runStopCapture({
       dispatch,
-      stateStore: makeStateStore(),
+      stateStore,
       claudeSessionId: 'z',
-      state,
+      turnCount: 3,
       project: 'p',
       now: Date.now(),
       lastText: '',
     });
     expect(hasCall(calls, 'log-negative-recall')).toBe(true);
-    expect(state.pendingRecallFeedback).toEqual([]);
+    expect(stateStore._peek('z').pendingRecallFeedback).toEqual([]);
+  });
+
+  test('runStopCapture does not clobber concurrent PostToolUse state', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('race', {
+      ...realStateStore.defaultState(),
+      sessionId: 1,
+      turnCount: 3,
+      editedFiles: [],
+    });
+    const { dispatch } = makeFakeDispatch();
+
+    const capture = runStopCapture({
+      dispatch,
+      stateStore,
+      claudeSessionId: 'race',
+      turnCount: 4,
+      project: 'p',
+      now: Date.now(),
+      lastText: '',
+    });
+
+    // Simulate a concurrent PostToolUse edit-track while capture is in flight.
+    await stateStore.mutateState('race', (s) => {
+      s.editedFiles.push('src/concurrent.js');
+    });
+
+    await capture;
+    expect(stateStore._peek('race').editedFiles).toContain('src/concurrent.js');
   });
 });
 

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -376,6 +376,42 @@ describe('claude-code handlers: Stop', () => {
     expect(stateStore._peek('z').pendingRecallFeedback).toEqual([]);
   });
 
+  test('runStopCapture dispatches outside the mutateState lock', async () => {
+    let mutateDepth = 0;
+    const stateStore = makeStateStore();
+    stateStore.saveState('lock', {
+      ...realStateStore.defaultState(),
+      sessionId: 1,
+      turnCount: 3,
+      pendingRecallFeedback: [[9, { sessionId: 1, query: 'q' }]],
+    });
+    const origMutate = stateStore.mutateState.bind(stateStore);
+    stateStore.mutateState = async (id, mutator) => {
+      mutateDepth += 1;
+      try {
+        return await origMutate(id, mutator);
+      } finally {
+        mutateDepth -= 1;
+      }
+    };
+    const dispatch = async (cmd) => {
+      if (cmd === 'log-negative-recall' || cmd === 'save' || cmd === 'dream') {
+        expect(mutateDepth).toBe(0);
+      }
+      return { ok: true };
+    };
+
+    await runStopCapture({
+      dispatch,
+      stateStore,
+      claudeSessionId: 'lock',
+      turnCount: 3,
+      project: 'p',
+      now: Date.now(),
+      lastText: '',
+    });
+  });
+
   test('runStopCapture does not clobber concurrent PostToolUse state', async () => {
     const stateStore = makeStateStore();
     stateStore.saveState('race', {

--- a/test/claude-code/state-store.test.js
+++ b/test/claude-code/state-store.test.js
@@ -117,7 +117,9 @@ describe('claude-code state-store: unusable session_id (fail-open)', () => {
     expect(stateStore.sanitizeKey('')).toBeNull();
     expect(stateStore.sanitizeKey('   ')).toBeNull();
     expect(stateStore.sanitizeKey('undefined')).toBeNull();
+    expect(stateStore.sanitizeKey('Undefined')).toBeNull();
     expect(stateStore.sanitizeKey('null')).toBeNull();
+    expect(stateStore.sanitizeKey('NaN')).toBeNull();
     // A real uuid is fine.
     expect(stateStore.sanitizeKey('a1b2-c3d4')).toBe('a1b2-c3d4');
   });

--- a/test/claude-code/tool-hooks.test.js
+++ b/test/claude-code/tool-hooks.test.js
@@ -94,6 +94,16 @@ describe('claude-code PreToolUse: Read guardrail', () => {
   test('allows reads in an unindexed project (deferred auto-index)', async () => {
     expect(isDeny(await runRead({ file_path: 'src/db.js' }, { repos: () => [] }))).toBe(false);
   });
+
+  test('blocks whole-file read when repo path uses mixed separators', async () => {
+    const repos = () => [{ name: 'app', path: 'C:/proj/app', indexed_at: new Date().toISOString() }];
+    const out = await handlePreToolUse({
+      payload: { session_id: 's', tool_name: 'Read', tool_input: { file_path: 'src/db.js' }, cwd: 'C:\\proj\\app' },
+      getKnownRepos: repos,
+      stateStore: makeStateStore(),
+    });
+    expect(isDeny(out)).toBe(true);
+  });
 });
 
 // =====================================================================

--- a/test/claude-code/tool-hooks.test.js
+++ b/test/claude-code/tool-hooks.test.js
@@ -84,6 +84,13 @@ describe('claude-code PreToolUse: Read guardrail', () => {
     expect(isDeny(await runRead({ file_path: 'src/db.js' }, { stateStore }))).toBe(false);
   });
 
+  test('allows when explored path uses a different separator style', async () => {
+    const stateStore = makeStateStore({
+      s: { ...realStateStore.defaultState(), exploredFiles: ['src\\db.js'] },
+    });
+    expect(isDeny(await runRead({ file_path: 'src/db.js' }, { stateStore }))).toBe(false);
+  });
+
   test('allows reads in an unindexed project (deferred auto-index)', async () => {
     expect(isDeny(await runRead({ file_path: 'src/db.js' }, { repos: () => [] }))).toBe(false);
   });
@@ -150,6 +157,11 @@ describe('claude-code PreToolUse: Glob + Bash guardrails', () => {
 
   test('Bash ignores non-search commands', async () => {
     expect(isDeny(await run('Bash', { command: 'npm test' }))).toBe(false);
+  });
+
+  test('Bash blocks compound search commands (cd repo && find)', async () => {
+    // #226: the full command string is classified, not a prefix-matched if-rule.
+    expect(isDeny(await run('Bash', { command: 'cd /proj/app && find . -name "*.ts"' }))).toBe(true);
   });
 });
 
@@ -253,6 +265,45 @@ describe('claude-code PostToolUse: edit-track + git-trust', () => {
       roleFilter: { only: 'git-trust' },
     });
     expect(calls.some((c) => c.cmd === 'sync-code-trust' && c.args.repo === 'app')).toBe(true);
+  });
+
+  test('git -C <path> pull triggers sync-code-trust', async () => {
+    const stateStore = makeStateStore({ s: { ...realStateStore.defaultState(), currentProject: 'app' } });
+    const { dispatch, calls } = makeFakeDispatch();
+    await handlePostToolUse({
+      payload: {
+        session_id: 's',
+        tool_name: 'Bash',
+        tool_input: { command: 'git -C /proj/app pull origin main' },
+        cwd: '/proj/app',
+      },
+      dispatch,
+      getKnownRepos: reposFn,
+      stateStore,
+      roleFilter: { only: 'git-trust' },
+    });
+    expect(calls.some((c) => c.cmd === 'sync-code-trust' && c.args.repo === 'app')).toBe(true);
+  });
+
+  test('MultiEdit records each edited file path', async () => {
+    const stateStore = makeStateStore();
+    const { dispatch } = makeFakeDispatch();
+    await handlePostToolUse({
+      payload: {
+        session_id: 's',
+        tool_name: 'MultiEdit',
+        tool_input: {
+          edits: [{ file_path: '/proj/app/src/a.js' }, { file_path: '/proj/app/src/b.js' }],
+        },
+        cwd: '/proj/app',
+      },
+      dispatch,
+      getKnownRepos: reposFn,
+      stateStore,
+    });
+    const edited = stateStore._peek('s').editedFiles;
+    expect(edited).toContain('/proj/app/src/a.js');
+    expect(edited).toContain('/proj/app/src/b.js');
   });
 
   test('non-git bash does not trigger sync-code-trust', async () => {

--- a/test/hooks-engine/project.test.js
+++ b/test/hooks-engine/project.test.js
@@ -58,6 +58,11 @@ describe('hooks-engine project: findMatchingRepo', () => {
     // separate a backslash-styled cwd from its repo.
     expect(findMatchingRepo('/repos/alphabeta', repos)).toBeNull();
   });
+
+  test('matches when repo path uses forward slashes and cwd uses backslashes', () => {
+    const mixed = [{ name: 'win', path: 'C:/repos/win' }];
+    expect(findMatchingRepo('C:\\repos\\win\\src', mixed)?.name).toBe('win');
+  });
 });
 
 describe('hooks-engine project: findMatchingProject', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up review of the Claude Code CLI epic (#205) after PR #234. Identifies and fixes remaining concurrency, path-normalization, and edge-case gaps.

## Fixes

### High — state corruption (#228)
- **Stop handler** no longer saves a stale in-memory snapshot at the end of `runStopCapture`. All mutations go through `mutateState`.
- **Stop dispatches outside lock** (follow-up commit): passive capture, dream, and negative-recall use short locked read/write phases with gateway `dispatch` between them — PostToolUse hooks are not blocked for dispatch duration.
- **UserPromptSubmit** cadence/reminder bookkeeping routes through `mutateState`.
- **UserPromptSubmit timeout** sets a `cancelled` flag so `run()` does not persist state after the 30s budget fires.

### Medium — path normalization (#227, #230)
- `fileKey` / `addNormalized` store forward-slash normalized paths.
- Read guardrail compares normalized explored paths **and** matches repos with `normalizeRepoPath`.
- `findMatchingRepo` normalizes separators for Windows/mixed DB paths.

### Low — edge cases
- Case-insensitive `sanitizeKey` rejects placeholder session ids (`Undefined`, `NaN`, …).
- `GIT_TRUST_OP_RE` detects `git -C <path> pull` (and similar).
- `edit-track` records `MultiEdit` / `Edit` `edits[]` file paths.
- Shared `makeMutate` extracted to `src/claude-code/state-mutate.js`.

## Tests

`npx vitest run test/claude-code test/hooks-engine` → **259 passed**

## Related

- Epic: #205
- Prior fix batch: #234 (#224–#233)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-173e0b6b-4eba-4156-8e6b-2a70a93e9e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-173e0b6b-4eba-4156-8e6b-2a70a93e9e20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

