### PR TITLE
fix(claude-code): session-start null id guard + cli subcommand routing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -173,9 +173,19 @@ if (isHelpRequest) {
       process.exitCode = 1;
       return;
     }
-    // Claude Code hooks bridge. runHook owns ensureDb() internally.
-    const { runHook } = require('./src/claude-code/hooks');
-    await runHook(process.argv.slice(3)); // ['hook', '<event>', ...flags]
+    // Claude Code hooks bridge. Only `hook` routes here — a missing or unknown
+    // subcommand should not fall through into the hook router (which would
+    // print a confusing hook-specific usage). runHook owns ensureDb() internally.
+    if (sub === 'hook') {
+      const { runHook } = require('./src/claude-code/hooks');
+      await runHook(process.argv.slice(3)); // ['hook', '<event>', ...flags]
+      return;
+    }
+    process.stderr.write(
+      `Unknown claude-code subcommand${sub ? ` "${sub}"` : ''}.\n` +
+        'Usage: lapis claude-code <install|uninstall|doctor|start|stop|gc|hook …>\n',
+    );
+    process.exitCode = 2;
     return;
   }
 

--- a/src/claude-code/handlers/session-start.js
+++ b/src/claude-code/handlers/session-start.js
@@ -69,7 +69,10 @@ async function handleSessionStart({ payload, dispatch, getKnownRepos, stateStore
     state.exploredFiles = [];
 
     const result = await dispatch('session-start', { project });
-    if (result && result.sessionId !== undefined) {
+    // A nullish server value must NOT overwrite the default null — SessionEnd's
+    // guard treats sessionId === null as "no session ever started" and skips the
+    // summary. Only accept a concrete value so the two checks stay symmetric.
+    if (result && result.sessionId !== undefined && result.sessionId !== null) {
       state.sessionId = result.sessionId;
       state.projectSessionCount = result.sessionCount || 0;
     }

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -95,6 +95,28 @@ describe('claude-code handlers: SessionStart', () => {
     expect(out.hookSpecificOutput.additionalContext).toContain('Memory Context');
   });
 
+  test('startup does not store a null sessionId (stays symmetric with SessionEnd guard)', async () => {
+    // If the server returns { sessionId: null } (or omits it), the stored value
+    // must remain the default null so SessionEnd's "no session ever started"
+    // guard doesn't skip a summary for a session that DID start.
+    const { dispatch } = makeFakeDispatch({
+      'session-start': () => ({ sessionId: null, sessionCount: 0 }),
+      context: () => EMPTY_CONTEXT,
+    });
+    const stateStore = makeStateStore();
+
+    await handleSessionStart({
+      payload: { session_id: 'claude-null', source: 'startup', cwd: '/proj/myapp' },
+      dispatch,
+      getKnownRepos: () => [],
+      stateStore,
+    });
+
+    const stored = stateStore._peek('claude-null');
+    expect(stored.sessionId).toBeNull();
+    expect(stored.projectSessionCount).toBe(0);
+  });
+
   test('resume and clear also call session-start', async () => {
     for (const source of ['resume', 'clear']) {
       const { dispatch, calls } = makeFakeDispatch({

--- a/test/claude-code/hooks.test.js
+++ b/test/claude-code/hooks.test.js
@@ -59,3 +59,27 @@ describe('claude-code router injection seams', () => {
     expect(dispatched).toContain('session-start');
   });
 });
+
+describe('claude-code router usage', () => {
+  test('runHook without a leading "hook" token prints usage and sets exit code 2', async () => {
+    const origExitCode = process.exitCode;
+    const stderrChunks = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    };
+    try {
+      process.exitCode = undefined;
+      // argv[0] must be the literal 'hook' token (cli.js guards on sub === 'hook'
+      // before delegating here). A missing/unknown subcommand no longer reaches
+      // runHook — it gets a top-level claude-code usage message in cli.js instead.
+      await runHook(['bogus', 'SessionStart'], { ensureDb: false, stdin: '' });
+      expect(stderrChunks.join('')).toContain('Usage: lapis claude-code hook');
+      expect(process.exitCode).toBe(2);
+    } finally {
+      process.stderr.write = origWrite;
+      process.exitCode = origExitCode;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the #205 review that addresses two findings I flagged while reviewing the merged Claude Code CLI implementation (#214–#235).

### 1. `SessionStart` could store a `null` sessionId (`session-start.js`)

`handleSessionStart` accepted any server value where `result.sessionId !== undefined`, so a `session-start` dispatch returning `{ sessionId: null }` overwrote the default `null`. That is inconsistent with `SessionEnd`, whose guard (`session-end.js:27`) treats `sessionId === null` as "no session ever started" and **skips the session summary entirely**. A session that genuinely started could silently lose its summary.

**Fix:** only accept a concrete value (`!== undefined && !== null`), so the two checks stay symmetric.

### 2. `lapis claude-code <unknown>` fell through into the hook router (`cli.js`)

A missing or unknown `claude-code` subcommand dropped into `runHook`, which printed a confusing hook-specific usage line (`Usage: lapis claude-code hook <event> …`) instead of a top-level `claude-code` usage. It also failed to `return`, leaking into cli.js's global help dump.

**Fix:** only `hook` routes to the hook router; anything else gets a clear `Unknown claude-code subcommand "<x>"` message + the subcommand list, with exit code 2 and a proper return.

## What I deliberately did **not** change

Two other observations from my review were left as-is because they aren't bugs:
- **`countSessionMemories` is a direct DB read even in daemon mode** — the DB is co-located and SessionEnd is awaited/latency-insensitive, so going over the daemon socket adds nothing.
- **No dedicated `daemon.test.js`** — daemon lifecycle is covered via `dispatch-client.test.js` with injected seams; reorganizing the test file isn't a fix.

## Test plan

- [x] New test: `startup does not store a null sessionId (stays symmetric with SessionEnd guard)`
- [x] New test: `runHook without a leading "hook" token prints usage and sets exit code 2`
- [x] `npx vitest run test/claude-code test/hooks-engine` → **261 passed** (was 259, +2)
- [x] Manual: `lapis claude-code frobnicate` / `lapis claude-code` → clear message, exit 2
- [x] Manual: `lapis claude-code hook SessionStart` → still routes to the handler

Closes follow-up findings from #205.