### PR TITLE
fix(claude-code): don't follow symlinks when writing CLAUDE.md block (arbitrary-file-write)

### DIFF
--- a/src/claude-code/install.js
+++ b/src/claude-code/install.js
@@ -510,14 +510,60 @@ function claudeMdBlock(mcpName) {
   ].join('\n');
 }
 
-/** Insert or replace the delimited LaPis block in a CLAUDE.md file. */
-function upsertClaudeMdBlock(filePath, block) {
-  let existing = '';
+/**
+ * Read a CLAUDE.md file WITHOUT following a symlink. A symlinked CLAUDE.md is
+ * unexpected for a project memory-protocol file and is a known arbitrary-file-
+ * write vector for a malicious repo (commit `.claude/CLAUDE.md` → `~/.bashrc`,
+ * then `install` writes through the link). Treat a symlink as absent so we
+ * neither leak the target's contents into the block nor write back through it.
+ * Returns { existed: bool, content: string }.
+ */
+function readClaudeMdSafe(filePath) {
   try {
-    existing = fs.readFileSync(filePath, 'utf8');
+    if (fs.lstatSync(filePath).isSymbolicLink()) {
+      return { existed: false, content: '' };
+    }
   } catch (e) {
     if (e.code !== 'ENOENT') {
       throw e;
+    }
+    return { existed: false, content: '' };
+  }
+  try {
+    return { existed: true, content: fs.readFileSync(filePath, 'utf8') };
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return { existed: false, content: '' };
+    }
+    throw e;
+  }
+}
+
+/**
+ * Atomic text write (temp + rename), matching writeJson's discipline so a crash
+ * mid-write never leaves a truncated file and a symlink at the path is REPLACED
+ * by a regular file rather than written through. The previous direct
+ * writeFileSync followed symlinks (see readClaudeMdSafe).
+ */
+function writeTextAtomic(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, content, 'utf8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+/** Insert or replace the delimited LaPis block in a CLAUDE.md file. */
+function upsertClaudeMdBlock(filePath, block) {
+  const { existed, content: existing } = readClaudeMdSafe(filePath);
+  // If a symlink is in the way, remove the link itself (NOT its target) so the
+  // atomic rename below installs a fresh regular file.
+  if (existed === false) {
+    try {
+      if (fs.lstatSync(filePath).isSymbolicLink()) {
+        fs.unlinkSync(filePath);
+      }
+    } catch {
+      // raced away — the atomic rename below still produces a regular file
     }
   }
   const start = existing.indexOf(CLAUDE_MD_START);
@@ -530,20 +576,23 @@ function upsertClaudeMdBlock(filePath, block) {
   } else {
     next = `${block}\n`;
   }
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, next, 'utf8');
+  writeTextAtomic(filePath, next);
 }
 
 /** Remove the delimited LaPis block; delete the file when nothing else remains. */
 function removeClaudeMdBlock(filePath) {
-  let existing;
-  try {
-    existing = fs.readFileSync(filePath, 'utf8');
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      return false;
+  const { existed, content: existing } = readClaudeMdSafe(filePath);
+  if (!existed) {
+    // A bare symlink (no block to remove) — unlink the LINK only, never a target.
+    try {
+      if (fs.lstatSync(filePath).isSymbolicLink()) {
+        fs.unlinkSync(filePath);
+        return true;
+      }
+    } catch {
+      // already gone
     }
-    throw e;
+    return false;
   }
   const start = existing.indexOf(CLAUDE_MD_START);
   const end = existing.indexOf(CLAUDE_MD_END);
@@ -554,7 +603,7 @@ function removeClaudeMdBlock(filePath) {
   if (!next.trim()) {
     fs.unlinkSync(filePath);
   } else {
-    fs.writeFileSync(filePath, next, 'utf8');
+    writeTextAtomic(filePath, next);
   }
   return true;
 }
@@ -743,6 +792,8 @@ module.exports = {
   claudeMdBlock,
   upsertClaudeMdBlock,
   removeClaudeMdBlock,
+  readClaudeMdSafe,
+  writeTextAtomic,
   resolveIo,
   configPaths,
   routeTargets,

--- a/test/claude-code/install.test.js
+++ b/test/claude-code/install.test.js
@@ -762,3 +762,90 @@ describe('claude-code hook role filter', () => {
     expect(ids).toEqual([12, 34]);
   });
 });
+
+// =====================================================================
+// CLAUDE.md block writers — symlink safety
+// =====================================================================
+//
+// A malicious repo can commit `.claude/CLAUDE.md` as a symlink to an
+// attacker-chosen file (e.g. ~/.bashrc). install/uninstall must NEVER read or
+// write through that link — only ever replace it with a fresh regular file
+// (upsert) or unlink the link itself (remove). Regression coverage for the
+// arbitrary-file-write vector fixed alongside this test.
+
+describe('claude-code install: CLAUDE.md symlink safety', () => {
+  const { upsertClaudeMdBlock, removeClaudeMdBlock, claudeMdBlock } = install;
+
+  function makeSymlinkRoot() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-cc-symlink-'));
+    const claudeDir = path.join(root, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const target = path.join(root, 'victim.txt');
+    fs.writeFileSync(target, 'victim-contents-before\n', 'utf8');
+    const md = path.join(claudeDir, 'CLAUDE.md');
+    fs.symlinkSync(target, md);
+    return { root, claudeDir, target, md };
+  }
+
+  test('upsertClaudeMdBlock does NOT write through a symlink to its target', () => {
+    const { target, md } = makeSymlinkRoot();
+    const before = fs.readFileSync(target, 'utf8');
+
+    upsertClaudeMdBlock(md, claudeMdBlock('lapis'));
+
+    // The victim file must be byte-for-byte untouched.
+    expect(fs.readFileSync(target, 'utf8')).toBe(before);
+    // The path is now a regular file (the symlink was replaced), carrying the
+    // LaPis block — not the victim's prior contents.
+    expect(fs.lstatSync(md).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(md, 'utf8')).toContain('<!-- lapis:start -->');
+    expect(fs.readFileSync(md, 'utf8')).not.toContain('victim-contents');
+  });
+
+  test('removeClaudeMdBlock on a bare symlink unlinks the LINK, never the target', () => {
+    const { target, md } = makeSymlinkRoot();
+    const before = fs.readFileSync(target, 'utf8');
+
+    const removed = removeClaudeMdBlock(md);
+
+    expect(removed).toBe(true);
+    // Symlink itself is gone.
+    expect(fs.existsSync(md)).toBe(false);
+    // Target file is untouched.
+    expect(fs.readFileSync(target, 'utf8')).toBe(before);
+  });
+
+  test('upsert then remove round-trips on a regular file (no symlink regression)', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-cc-md-'));
+    const md = path.join(root, 'CLAUDE.md');
+    fs.writeFileSync(md, '# My project notes\n\nKeep these.\n', 'utf8');
+
+    upsertClaudeMdBlock(md, claudeMdBlock('lapis'));
+    expect(fs.readFileSync(md, 'utf8')).toContain('# My project notes');
+    expect(fs.readFileSync(md, 'utf8')).toContain('<!-- lapis:start -->');
+
+    const removed = removeClaudeMdBlock(md);
+    expect(removed).toBe(true);
+    // Surrounding prose is preserved, the block is gone.
+    const after = fs.readFileSync(md, 'utf8');
+    expect(after).toContain('# My project notes');
+    expect(after).not.toContain('<!-- lapis:start -->');
+  });
+
+  test('full install over a symlinked .claude/CLAUDE.md does not corrupt the target', async () => {
+    const io = makeIo();
+    const target = path.join(io.root, 'victim.txt');
+    fs.writeFileSync(target, 'victim-contents-before\n', 'utf8');
+    const md = path.join(io.cwd, '.claude', 'CLAUDE.md');
+    fs.mkdirSync(path.dirname(md), { recursive: true });
+    fs.symlinkSync(target, md);
+    const before = fs.readFileSync(target, 'utf8');
+
+    await runInstall([], io);
+
+    // Victim untouched, CLAUDE.md is now a regular file with the protocol block.
+    expect(fs.readFileSync(target, 'utf8')).toBe(before);
+    expect(fs.lstatSync(md).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(md, 'utf8')).toContain('<!-- lapis:start -->');
+  });
+});


### PR DESCRIPTION
## Summary

Deeper follow-up review of the #205 implementation. The parity audit confirmed the `hooks-engine` extraction is genuinely single-source-of-truth (no drift). The security audit found one real, exploitable issue — fixed here — plus a few low-severity items documented below.

### 🔴 Fixed: arbitrary-file write via symlinked `.claude/CLAUDE.md` (install.js)

`upsertClaudeMdBlock` and `removeClaudeMdBlock` used direct `readFileSync`/`writeFileSync`, which **follow symlinks**. This is inconsistent with `writeJson` in the *same file*, which correctly uses temp+rename (rename *replaces* a symlink rather than following it).

**Exploit (within the stated malicious-repo threat model):** a repo commits `.claude/CLAUDE.md` as a symlink to `~/.bashrc` (or any file). When a victim clones and runs `lapis claude-code install`, the installer reads `~/.bashrc`'s contents through the link, wraps them in the LaPis memory-protocol block, and writes the result **back into `~/.bashrc`** — corrupting it. `uninstall` corrupts it again. The CLAUDE.md block is written by default (`claudeMd: true`); `--no-claude-md` opts out.

I verified this empirically before fixing (victim file corrupted through the link, symlink preserved). The read path also **leaked the target file's contents** into the LaPis block.

**Fix:**
- `readClaudeMdSafe` `lstat`\s first — a symlink is treated as absent, so its target's contents are never read into the block.
- `writeTextAtomic` uses temp+rename, so a symlink at the path is **replaced** by a regular file (matching `writeJson`) instead of being written through.
- `upsert` unlinks a pre-existing symlink (the link itself, never its target) before installing a fresh regular file.
- `remove` unlinks a bare symlink (the link only) rather than touching the target.

After the fix: the victim file is byte-for-byte untouched; `.claude/CLAUDE.md` becomes a regular file carrying only the LaPis block.

## Other audit findings (NOT fixed here — low severity, documented for the record)

| # | Finding | Severity | Why not fixed here |
|---|---------|----------|--------------------|
| 1 | `acquireLock` stale-break TOCTOU (`state-store.js:226`) — two procs can both break a stale lock and both proceed | Low–Med | Impact is bounded to a lost state-counter increment (already documented as acceptable best-effort); narrowing the window needs a more invasive rework |
| 2 | `sanitizeKey` collapses distinct ids (`a/b`=`a_b`=`a b`) onto one file | Low | Only reachable if an attacker controls `session_id`; Claude Code emits UUIDs that never collide, and placeholder rejection (#224) already blocks the mass-collision case |
| 3 | Read-guardrail does lexical (non-realpath) repo matching | Low | Guardrail is deny-only and never opens the path; a bypass = "agent reads a code file without a nudge", not a security boundary |
| 4 | Triplicated `CHECKPOINT_EVERY`/`COOLDOWN_MS` constants (`stop.js` hardcode vs `state.ts` vs engine defaults) | Low | Values agree today; tightening is a refactor, not a fix |

The parity audit confirmed **no regex DoS** (all linear, `/g` lastIndex properly reset), **no SQLi** (`countSessionMemories` is parameterized), and **no spawn injection** (`daemon.js` uses array-form spawn with a validated port).

## Test plan

- [x] New: `upsertClaudeMdBlock does NOT write through a symlink to its target`
- [x] New: `removeClaudeMdBlock on a bare symlink unlinks the LINK, never the target`
- [x] New: `upsert then remove round-trips on a regular file (no symlink regression)`
- [x] New: `full install over a symlinked .claude/CLAUDE.md does not corrupt the target`
- [x] `npx vitest run test/claude-code test/hooks-engine` → **265 passed** (was 261, +4)
- [x] Manual repro confirmed: victim file untouched after install + uninstall

Follow-up to #205. Supersedes none.