### PR TITLE
fix(session-summary): Goal line drops for string content (Claude Code transcripts)

### DIFF
--- a/src/hooks-engine/session-summary.js
+++ b/src/hooks-engine/session-summary.js
@@ -43,11 +43,17 @@ function buildSessionSummary({
     }
   }
 
+  // Goal: the first user message's text, regardless of whether `content` is a
+  // plain string (Claude Code transcripts) or an array of parts (Pi extension).
+  // The previous `.content?.[0]?.text` chain only worked for the array shape and
+  // fell back to "Session work" for string content — losing the goal for every
+  // Claude Code session. extractMessageText handles both shapes.
+  const goalText =
+    userMessages.length > 0 ? extractMessageText(userMessages[0]?.message)?.slice(0, 200) || 'Session work' : 'Session work';
+
   const summaryParts = [
     '## Goal',
-    userMessages.length > 0
-      ? userMessages[0]?.message?.content?.[0]?.text?.slice(0, 200) || 'Session work'
-      : 'Session work',
+    goalText,
     '',
     '## Topics Discussed',
     ...topics.slice(0, 10).map((t) => `- ${t}`),

--- a/test/hooks-engine/session-summary.test.js
+++ b/test/hooks-engine/session-summary.test.js
@@ -23,6 +23,24 @@ describe('hooks-engine session-summary: buildSessionSummary', () => {
     expect(out).toContain('2 memories saved, 3 assistant turns, 12 total turns');
   });
 
+  test('Goal line reads string content (Claude Code transcript shape), not just content-block arrays', () => {
+    // Claude Code transcripts carry user messages as { message: { role, content: '<string>' } }.
+    // The Goal line previously used `.content[0].text`, which for a string returned the first
+    // CHARACTER and fell back to "Session work" — losing the goal for every Claude Code session.
+    const stringContentMessages = [{ message: { role: 'user', content: 'Fix the login bug in auth.ts' } }];
+    const out = buildSessionSummary({
+      userMessages: stringContentMessages,
+      assistantCount: 1,
+      turnCount: 1,
+      memoriesSaved: 0,
+      editedFiles: [],
+      cwd: process.cwd(),
+    });
+    expect(out).toContain('## Goal');
+    expect(out).toContain('Fix the login bug in auth.ts');
+    expect(out).not.toContain('Session work');
+  });
+
   test('includes Files Modified section when files present', () => {
     const out = buildSessionSummary({
       userMessages,


### PR DESCRIPTION
## Summary

Third-pass review of the #205 implementation. This pass audited the remaining hooks-engine modules and the dispatch-argument wiring. The dispatch audit came back fully clean (all 13 calls match their gateway signatures, Pi extension parity confirmed). One real bug found in the shared `session-summary` engine — fixed here.

### Bug: `buildSessionSummary` Goal line is blank for string content

The Goal line read the first user message via `.content?.[0]?.text`, which **only works when `content` is an array of parts** (the Pi extension shape). Claude Code transcripts carry user messages with `content` as a **plain string**, so `.content[0]` returned the first *character*, `.text` was `undefined`, and the Goal line silently fell back to `"Session work"` — for **every Claude Code session summary**.

The kicker: the goal *was* present and parseable. The `## Topics Discussed` line right below it worked fine, because it uses `extractMessageText` (which handles both string and array shapes). Only the Goal line used the brittle accessor.

**Verified before fixing** — string content → `"Session work"` (wrong); array content → correct goal.

```js
// before — only works for array content
userMessages[0]?.message?.content?.[0]?.text?.slice(0, 200)

// after — works for string AND array content
extractMessageText(userMessages[0]?.message)?.slice(0, 200)
```

### Scope

This is a **pre-existing bug**, faithful to the original TS source (`session-lifecycle.ts:190` at the pre-extraction commit `3d72bc1^`). It was ported verbatim into the engine during the Phase 1 extraction. Because it lives in the shared `hooks-engine`, it affected **both** transports:
- **Pi extension** — any session whose first user message had string content lost its Goal.
- **Claude Code bridge** — *every* session lost its Goal, since Claude Code transcripts always use string content (see `src/claude-code/hooks-engine/transcript-reader.js:58`).

The existing test only covered the array-content shape (which worked), so the bug was never caught. The new test covers the string-content shape.

## Other audit results this pass (clean, no action)

- **Dispatch-argument parity** — all 13 `dispatch()` calls from the bridge handlers match their gateway command signatures exactly. Argument names, types (after `stringifyArgs` coercion), and required-args all correct. The Pi extension calls the same commands with identical argument names. No silent `undefined`-arg bugs.
- **`tool-response-parse.js`** — tolerant of all MCP response shapes (string / content-block array / CallToolResult / plain object); `/g` regexes have `lastIndex` reset. No issues.
- **`pattern-matcher.js`, `passive-capture.js`, `prompt-classifiers.js`** — faithful ports, no behavioral drift from the TS originals.

## Test plan

- [x] New: `Goal line reads string content (Claude Code transcript shape), not just content-block arrays`
- [x] `npx vitest run test/claude-code test/hooks-engine` → **266 passed** (was 265, +1)
- [x] Manual repro confirmed: string content now yields the correct Goal; array content unchanged

Follow-up to #205.