### PR TITLE
fix(claude-code): address issue #205 review follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     when several indexed repos overlap.
   - **Compact cwd refresh:** `SessionStart(compact)` updates `currentProject`
     when cwd resolves to a different project key.
+  - **Polish:** MCP `detectMcpProject` reuses `dispatch-client` DB helpers;
+    `SessionEnd` summary uses `resolveCwd` for relative file paths.
 
 - **Claude Code bridge — issue #205 post-review hardening** (follow-up to #234).
   - **Stop / UserPromptSubmit state races (#228):** Stop and UserPromptSubmit now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Claude Code bridge — issue #205 review follow-ups**
+  - **Monorepo project detection:** `resolveProjectKey` / `resolveIndexedRepo` in
+    `hooks-engine/project.js` prefer indexed repo path prefix over cwd basename,
+    so git-trust sync and guardrails work from subdirectories like
+    `packages/foo` when the repo is indexed as `my-monorepo`.
+  - **Session summary count:** `SessionEnd` summary text now uses the same
+    DB-derived memory count as `session-end` dispatch (not the mirrored counter).
+  - **Stop checkpoint race:** progress checkpoints snapshot state under
+    `mutateState` instead of an unlocked `loadState`.
+  - **State lock budget:** `mutateState` lock timeout raised to 5s to reduce
+    fail-open races under parallel PostToolUse hooks.
+  - **MCP project key:** `detectMcpProject()` uses hooks-engine path-prefix
+    resolution so MCP and the Claude Code bridge agree in monorepos.
+
 - **Claude Code bridge — issue #205 post-review hardening** (follow-up to #234).
   - **Stop / UserPromptSubmit state races (#228):** Stop and UserPromptSubmit now
     route all state writes through `mutateState` instead of unlocked load/save,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     fail-open races under parallel PostToolUse hooks.
   - **MCP project key:** `detectMcpProject()` uses hooks-engine path-prefix
     resolution so MCP and the Claude Code bridge agree in monorepos.
+  - **knownProjects fallback:** handlers and MCP load memory project names from
+    the DB (list-projects parity) when cwd is not inside an indexed code repo.
+  - **Nested repo match:** `findMatchingRepo` prefers the deepest matching path
+    when several indexed repos overlap.
+  - **Compact cwd refresh:** `SessionStart(compact)` updates `currentProject`
+    when cwd resolves to a different project key.
 
 - **Claude Code bridge — issue #205 post-review hardening** (follow-up to #234).
   - **Stop / UserPromptSubmit state races (#228):** Stop and UserPromptSubmit now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     when cwd resolves to a different project key.
   - **Polish:** MCP `detectMcpProject` reuses `dispatch-client` DB helpers;
     `SessionEnd` summary uses `resolveCwd` for relative file paths.
+  - **Shared project DB reads:** `src/platform/project-db.js` centralizes
+    `getKnownRepos` / `getKnownProjects` (5 min in-process cache); MCP no
+    longer imports from `claude-code/`.
+  - **Context injection:** `assembleContextLines` honors `CLAUDE_PROJECT_DIR`
+    via `resolveCwd` for repo matching and index hints.
+  - **`resolveCwd`:** prefers `CLAUDE_PROJECT_DIR` over payload `cwd` when set
+    (aligns with hooks-engine module contract).
 
 - **Claude Code bridge — issue #205 post-review hardening** (follow-up to #234).
   - **Stop / UserPromptSubmit state races (#228):** Stop and UserPromptSubmit now

--- a/src/claude-code/context-inject.js
+++ b/src/claude-code/context-inject.js
@@ -16,7 +16,7 @@
 const path = require('node:path');
 const { CONTEXT } = require('../../constants');
 const { buildContextBlock, capInjectedContext, appendExtensionHint } = require('../hooks-engine/context-builder');
-const { findMatchingRepo } = require('../hooks-engine/project');
+const { findMatchingRepo, resolveCwd } = require('../hooks-engine/project');
 
 /**
  * Fetch project context, falling back to cross-project if empty.
@@ -73,7 +73,7 @@ async function assembleContextLines({ dispatch, getKnownRepos, project, cwd, que
 
   // Staleness check is deferred to Phase 2's best-effort posture.
   const repos = getKnownRepos();
-  const resolvedCwd = path.resolve(cwd);
+  const resolvedCwd = path.resolve(resolveCwd(cwd));
   const cwdRepo = findMatchingRepo(resolvedCwd, repos);
   const isStale = false;
 
@@ -86,7 +86,7 @@ async function assembleContextLines({ dispatch, getKnownRepos, project, cwd, que
   const lines = buildContextBlock({
     promptQuery: query,
     currentProject: project,
-    projectDir: cwdRepo?.path || cwd,
+    projectDir: cwdRepo?.path || resolvedCwd,
     cwdRepo,
     isStale,
     isNewProject,
@@ -102,11 +102,11 @@ async function assembleContextLines({ dispatch, getKnownRepos, project, cwd, que
   if (!cwdRepo) {
     lines.push('');
     lines.push(
-      `⚠️ **Code not indexed:** Project "${project}" has no code index yet. Index it first: \`memory-code index-repo --path ${cwd} --name ${project}\``,
+      `⚠️ **Code not indexed:** Project "${project}" has no code index yet. Index it first: \`memory-code index-repo --path ${resolvedCwd} --name ${project}\``,
     );
   }
 
-  appendExtensionHint(lines, cwd);
+  appendExtensionHint(lines, resolvedCwd);
   return { lines, cwdRepo };
 }
 

--- a/src/claude-code/dispatch-client.js
+++ b/src/claude-code/dispatch-client.js
@@ -126,11 +126,34 @@ function getKnownRepos() {
   }
 }
 
+/**
+ * Known memory project names (observations grouped by project). Used by
+ * resolveProjectKey when cwd is not inside an indexed code repo — mirrors the
+ * list-projects fallback in project-detector.ts detectProject().
+ */
+function getKnownProjects() {
+  try {
+    const { sqlJson } = require('../../db');
+    const rows =
+      sqlJson(`
+        SELECT project
+        FROM observations
+        WHERE deleted_at IS NULL AND type != 'skill'
+          AND project IS NOT NULL AND project != ''
+        GROUP BY project
+      `) || [];
+    return rows.map((r) => r.project).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 module.exports = {
   dispatch,
   dispatchViaDaemon,
   countSessionMemories,
   getKnownRepos,
+  getKnownProjects,
   stringifyArgs,
   loadDirectDispatch,
 };

--- a/src/claude-code/dispatch-client.js
+++ b/src/claude-code/dispatch-client.js
@@ -16,6 +16,7 @@
  */
 
 const { resolveDaemonUrl } = require('./daemon');
+const { getKnownRepos, getKnownProjects } = require('../platform/project-db');
 
 /**
  * Coerce an args bag into the string-only record the gateway expects.
@@ -110,41 +111,6 @@ function countSessionMemories(sessionId) {
     return Number(row?.n) || 0;
   } catch {
     return 0;
-  }
-}
-
-/**
- * Known indexed code repos, for cwd-repo resolution + preflight gating.
- * Mirrors extensions/.../host/project-detector.ts getKnownRepos(). Best-effort.
- */
-function getKnownRepos() {
-  try {
-    const { sqlJson } = require('../../db');
-    return sqlJson('SELECT name, path, indexed_at FROM code_repos') || [];
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Known memory project names (observations grouped by project). Used by
- * resolveProjectKey when cwd is not inside an indexed code repo — mirrors the
- * list-projects fallback in project-detector.ts detectProject().
- */
-function getKnownProjects() {
-  try {
-    const { sqlJson } = require('../../db');
-    const rows =
-      sqlJson(`
-        SELECT project
-        FROM observations
-        WHERE deleted_at IS NULL AND type != 'skill'
-          AND project IS NOT NULL AND project != ''
-        GROUP BY project
-      `) || [];
-    return rows.map((r) => r.project).filter(Boolean);
-  } catch {
-    return [];
   }
 }
 

--- a/src/claude-code/handlers/post-tool-use.js
+++ b/src/claude-code/handlers/post-tool-use.js
@@ -28,7 +28,8 @@ const {
   wasSaveSuccessful,
   extractToolResponseText,
 } = require('../../hooks-engine/tool-response-parse');
-const { resolveCwd, resolveIndexedRepo, resolveProjectKey } = require('../../hooks-engine/project');
+const { resolveIndexedRepo } = require('../../hooks-engine/project');
+const { resolveProjectForCwd } = require('../project-resolve');
 const { CODE_EXTENSIONS } = require('../../hooks-engine/guardrail-utils');
 const { addNormalized } = require('../file-keys');
 const { postToolRole } = require('../tool-map');
@@ -100,14 +101,12 @@ function consumeRecall(state, ids) {
  * Git-trust sync. Best-effort and awaited (a per-event hook process would exit
  * before a fire-and-forget dispatch ran). Never throws.
  */
-async function gitTrustSync({ input, dispatch, getKnownRepos, state, cwd }) {
+async function gitTrustSync({ input, dispatch, repos, state, cwd }) {
   const cmd = typeof input.command === 'string' ? input.command : '';
   if (!cmd || !GIT_TRUST_OP_RE.test(cmd)) {
     return;
   }
-  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
-  const resolvedCwd = path.resolve(cwd);
-  const repo = resolveIndexedRepo(resolvedCwd, repos, state.currentProject);
+  const repo = resolveIndexedRepo(path.resolve(cwd), repos, state.currentProject);
   if (!repo) {
     return;
   }
@@ -118,7 +117,7 @@ async function gitTrustSync({ input, dispatch, getKnownRepos, state, cwd }) {
   }
 }
 
-async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore, roleFilter }) {
+async function handlePostToolUse({ payload, dispatch, getKnownRepos, getKnownProjects, stateStore, roleFilter }) {
   const toolName = payload.tool_name;
   const role = postToolRole(toolName);
   if (!role) {
@@ -134,7 +133,11 @@ async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore,
   const input = (payload.tool_input && typeof payload.tool_input === 'object' ? payload.tool_input : {}) || {};
   const toolResponse = payload.tool_response;
   const claudeSessionId = payload.session_id;
-  const cwd = resolveCwd(payload.cwd);
+  const { resolvedCwd, repos, project } = resolveProjectForCwd(
+    payload.cwd,
+    getKnownRepos,
+    getKnownProjects,
+  );
 
   // git-trust only READS state (for currentProject), runs the heavy dispatch,
   // and never writes back — writing a pre-dispatch snapshot after a slow
@@ -142,7 +145,7 @@ async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore,
   // Falls back to loadState when the injected store lacks mutateState.
   if (role === 'git-trust') {
     const state = stateStore.loadState(claudeSessionId);
-    await gitTrustSync({ input, dispatch, getKnownRepos, state, cwd });
+    await gitTrustSync({ input, dispatch, repos, state, cwd: resolvedCwd });
     return null;
   }
 
@@ -160,8 +163,7 @@ async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore,
 
   await mutate((state) => {
     if (!state.currentProject) {
-      const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
-      state.currentProject = resolveProjectKey(path.resolve(cwd), repos);
+      state.currentProject = project;
     }
     switch (role) {
       case 'edit-track':

--- a/src/claude-code/handlers/post-tool-use.js
+++ b/src/claude-code/handlers/post-tool-use.js
@@ -21,13 +21,14 @@
  * or clobber each other. git-trust is read-only and never writes back.
  */
 
+const path = require('node:path');
 const {
   parseSearchResultIds,
   parseMemoryIds,
   wasSaveSuccessful,
   extractToolResponseText,
 } = require('../../hooks-engine/tool-response-parse');
-const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const { resolveCwd, resolveIndexedRepo, resolveProjectKey } = require('../../hooks-engine/project');
 const { CODE_EXTENSIONS } = require('../../hooks-engine/guardrail-utils');
 const { addNormalized } = require('../file-keys');
 const { postToolRole } = require('../tool-map');
@@ -104,12 +105,9 @@ async function gitTrustSync({ input, dispatch, getKnownRepos, state, cwd }) {
   if (!cmd || !GIT_TRUST_OP_RE.test(cmd)) {
     return;
   }
-  const project = state.currentProject || projectFromCwd(cwd);
-  if (!project) {
-    return;
-  }
   const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
-  const repo = repos.find((r) => r.name && r.name.toLowerCase() === project.toLowerCase());
+  const resolvedCwd = path.resolve(cwd);
+  const repo = resolveIndexedRepo(resolvedCwd, repos, state.currentProject);
   if (!repo) {
     return;
   }
@@ -162,7 +160,8 @@ async function handlePostToolUse({ payload, dispatch, getKnownRepos, stateStore,
 
   await mutate((state) => {
     if (!state.currentProject) {
-      state.currentProject = projectFromCwd(cwd);
+      const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
+      state.currentProject = resolveProjectKey(path.resolve(cwd), repos);
     }
     switch (role) {
       case 'edit-track':

--- a/src/claude-code/handlers/pre-tool-use.js
+++ b/src/claude-code/handlers/pre-tool-use.js
@@ -24,7 +24,7 @@
 
 const path = require('node:path');
 const { isCodeFile } = require('../../code-index/scanner');
-const { resolveCwd, projectFromCwd, findMatchingRepo, normalizeRepoPath } = require('../../hooks-engine/project');
+const { resolveCwd, resolveIndexedRepo, resolveProjectKey, normalizeRepoPath } = require('../../hooks-engine/project');
 const {
   isPipedOutputFilter,
   isTargetedSymbolLookup,
@@ -59,16 +59,9 @@ function addExploredFile(state, filePath) {
   addNormalized(state.exploredFiles, filePath);
 }
 
-/** Resolve the indexed repo the current cwd belongs to (cwd prefix or project name). */
+/** Resolve the indexed repo the current cwd belongs to (path prefix or project name). */
 function resolveRepo(resolvedCwd, repos, currentProject) {
-  const byPath = findMatchingRepo(resolvedCwd, repos);
-  if (byPath) {
-    return byPath;
-  }
-  if (currentProject) {
-    return repos.find((r) => r.name && r.name.toLowerCase() === currentProject.toLowerCase()) || null;
-  }
-  return null;
+  return resolveIndexedRepo(resolvedCwd, repos, currentProject);
 }
 
 // --- guardrails ---------------------------------------------------------
@@ -231,7 +224,7 @@ async function handlePreToolUse({ payload, getKnownRepos, stateStore }) {
   const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
   const state = stateStore.loadState(claudeSessionId);
   if (!state.currentProject) {
-    state.currentProject = projectFromCwd(cwd);
+    state.currentProject = resolveProjectKey(cwd, repos);
   }
 
   const args = { input, repos, cwd, state };

--- a/src/claude-code/handlers/pre-tool-use.js
+++ b/src/claude-code/handlers/pre-tool-use.js
@@ -24,7 +24,8 @@
 
 const path = require('node:path');
 const { isCodeFile } = require('../../code-index/scanner');
-const { resolveCwd, resolveIndexedRepo, resolveProjectKey, normalizeRepoPath } = require('../../hooks-engine/project');
+const { resolveIndexedRepo, normalizeRepoPath } = require('../../hooks-engine/project');
+const { resolveProjectForCwd } = require('../project-resolve');
 const {
   isPipedOutputFilter,
   isTargetedSymbolLookup,
@@ -188,7 +189,7 @@ function bashGuardrail({ input, repos, cwd, state }) {
   );
 }
 
-async function handlePreToolUse({ payload, getKnownRepos, stateStore }) {
+async function handlePreToolUse({ payload, getKnownRepos, getKnownProjects, stateStore }) {
   const toolName = payload.tool_name;
   const role = preToolRole(toolName);
   if (!role) {
@@ -220,11 +221,14 @@ async function handlePreToolUse({ payload, getKnownRepos, stateStore }) {
     return null;
   }
 
-  const cwd = path.resolve(resolveCwd(payload.cwd));
-  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
+  const { resolvedCwd: cwd, repos, project } = resolveProjectForCwd(
+    payload.cwd,
+    getKnownRepos,
+    getKnownProjects,
+  );
   const state = stateStore.loadState(claudeSessionId);
   if (!state.currentProject) {
-    state.currentProject = resolveProjectKey(cwd, repos);
+    state.currentProject = project;
   }
 
   const args = { input, repos, cwd, state };

--- a/src/claude-code/handlers/session-end.js
+++ b/src/claude-code/handlers/session-end.js
@@ -12,13 +12,15 @@
  * Mirrors extensions/.../hooks/session-lifecycle.ts registerSessionShutdown.
  */
 
-const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const path = require('node:path');
+const { resolveCwd, resolveProjectKey } = require('../../hooks-engine/project');
 const { buildSessionSummary } = require('../../hooks-engine/session-summary');
 const { readTranscript } = require('../hooks-engine/transcript-reader');
 
-async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore }) {
+async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore, getKnownRepos }) {
   const cwd = resolveCwd(payload.cwd);
-  const project = projectFromCwd(cwd);
+  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
+  const project = resolveProjectKey(path.resolve(cwd), repos);
   const claudeSessionId = payload.session_id;
 
   const state = stateStore.loadState(claudeSessionId);
@@ -31,17 +33,17 @@ async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore 
 
   const transcript = readTranscript(payload.transcript_path);
 
+  // DB-derived count is authoritative for both summary text and session-end.
+  const memories = dispatchClient.countSessionMemories(state.sessionId);
+
   const summaryContent = buildSessionSummary({
     userMessages: transcript.userMessages,
     assistantCount: transcript.assistantMessageCount,
     turnCount: state.turnCount,
-    memoriesSaved: state.memoriesSavedThisSession,
+    memoriesSaved: memories,
     editedFiles: state.editedFiles,
     cwd,
   });
-
-  // DB-derived count, not the in-process counter (issue #207).
-  const memories = dispatchClient.countSessionMemories(state.sessionId);
 
   try {
     await dispatch('session-summary', { content: summaryContent, project });

--- a/src/claude-code/handlers/session-end.js
+++ b/src/claude-code/handlers/session-end.js
@@ -12,15 +12,12 @@
  * Mirrors extensions/.../hooks/session-lifecycle.ts registerSessionShutdown.
  */
 
-const path = require('node:path');
-const { resolveCwd, resolveProjectKey } = require('../../hooks-engine/project');
+const { resolveProjectForCwd } = require('../project-resolve');
 const { buildSessionSummary } = require('../../hooks-engine/session-summary');
 const { readTranscript } = require('../hooks-engine/transcript-reader');
 
-async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore, getKnownRepos }) {
-  const cwd = resolveCwd(payload.cwd);
-  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
-  const project = resolveProjectKey(path.resolve(cwd), repos);
+async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore, getKnownRepos, getKnownProjects }) {
+  const { project } = resolveProjectForCwd(payload.cwd, getKnownRepos, getKnownProjects);
   const claudeSessionId = payload.session_id;
 
   const state = stateStore.loadState(claudeSessionId);
@@ -42,7 +39,7 @@ async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore,
     turnCount: state.turnCount,
     memoriesSaved: memories,
     editedFiles: state.editedFiles,
-    cwd,
+    cwd: payload.cwd,
   });
 
   try {

--- a/src/claude-code/handlers/session-end.js
+++ b/src/claude-code/handlers/session-end.js
@@ -12,12 +12,14 @@
  * Mirrors extensions/.../hooks/session-lifecycle.ts registerSessionShutdown.
  */
 
+const { resolveCwd } = require('../../hooks-engine/project');
 const { resolveProjectForCwd } = require('../project-resolve');
 const { buildSessionSummary } = require('../../hooks-engine/session-summary');
 const { readTranscript } = require('../hooks-engine/transcript-reader');
 
 async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore, getKnownRepos, getKnownProjects }) {
-  const { project } = resolveProjectForCwd(payload.cwd, getKnownRepos, getKnownProjects);
+  const cwd = resolveCwd(payload.cwd);
+  const { project } = resolveProjectForCwd(cwd, getKnownRepos, getKnownProjects);
   const claudeSessionId = payload.session_id;
 
   const state = stateStore.loadState(claudeSessionId);
@@ -39,7 +41,7 @@ async function handleSessionEnd({ payload, dispatch, dispatchClient, stateStore,
     turnCount: state.turnCount,
     memoriesSaved: memories,
     editedFiles: state.editedFiles,
-    cwd: payload.cwd,
+    cwd,
   });
 
   try {

--- a/src/claude-code/handlers/session-start.js
+++ b/src/claude-code/handlers/session-start.js
@@ -13,7 +13,8 @@
  * registerSessionCompact.
  */
 
-const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const path = require('node:path');
+const { resolveCwd, resolveProjectKey } = require('../../hooks-engine/project');
 const { buildInjectedContext } = require('../context-inject');
 
 /**
@@ -29,7 +30,8 @@ const { buildInjectedContext } = require('../context-inject');
 async function handleSessionStart({ payload, dispatch, getKnownRepos, stateStore }) {
   const source = payload.source || 'startup';
   const cwd = resolveCwd(payload.cwd);
-  const project = projectFromCwd(cwd);
+  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
+  const project = resolveProjectKey(path.resolve(cwd), repos);
   const claudeSessionId = payload.session_id;
 
   let state = stateStore.loadState(claudeSessionId);

--- a/src/claude-code/handlers/session-start.js
+++ b/src/claude-code/handlers/session-start.js
@@ -13,7 +13,6 @@
  * registerSessionCompact.
  */
 
-const path = require('node:path');
 const { resolveCwd } = require('../../hooks-engine/project');
 const { resolveProjectForCwd } = require('../project-resolve');
 const { buildInjectedContext } = require('../context-inject');

--- a/src/claude-code/handlers/session-start.js
+++ b/src/claude-code/handlers/session-start.js
@@ -14,7 +14,8 @@
  */
 
 const path = require('node:path');
-const { resolveCwd, resolveProjectKey } = require('../../hooks-engine/project');
+const { resolveCwd } = require('../../hooks-engine/project');
+const { resolveProjectForCwd } = require('../project-resolve');
 const { buildInjectedContext } = require('../context-inject');
 
 /**
@@ -27,11 +28,10 @@ const { buildInjectedContext } = require('../context-inject');
  * @param {object} ctx.stateStore        { loadState, saveState, sweepStaleSessions }
  * @returns {Promise<object|null>}       Claude Code JSON or null
  */
-async function handleSessionStart({ payload, dispatch, getKnownRepos, stateStore }) {
+async function handleSessionStart({ payload, dispatch, getKnownRepos, getKnownProjects, stateStore }) {
   const source = payload.source || 'startup';
+  const { project } = resolveProjectForCwd(payload.cwd, getKnownRepos, getKnownProjects);
   const cwd = resolveCwd(payload.cwd);
-  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
-  const project = resolveProjectKey(path.resolve(cwd), repos);
   const claudeSessionId = payload.session_id;
 
   let state = stateStore.loadState(claudeSessionId);
@@ -79,6 +79,10 @@ async function handleSessionStart({ payload, dispatch, getKnownRepos, stateStore
       state.projectSessionCount = result.sessionCount || 0;
     }
     // Orphan recovery is automatic server-side; surface only if returned.
+    stateStore.saveState(claudeSessionId, state);
+  } else if (state.currentProject !== project) {
+    // Compact re-inject: refresh project when cwd moved (e.g. monorepo subdir).
+    state.currentProject = project;
     stateStore.saveState(claudeSessionId, state);
   }
 

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -19,7 +19,8 @@
 const path = require('node:path');
 const { uniqueEditedPaths } = require('../file-keys');
 const { makeMutate } = require('../state-mutate');
-const { resolveCwd, resolveProjectKey } = require('../../hooks-engine/project');
+const { resolveCwd } = require('../../hooks-engine/project');
+const { resolveProjectForCwd } = require('../project-resolve');
 const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
 const { shouldAutoCapture } = require('../../hooks-engine/pattern-matcher');
 const { readTranscriptStream } = require('../hooks-engine/transcript-reader');
@@ -121,7 +122,7 @@ async function checkpoint({ dispatch, state, project }) {
   });
 }
 
-async function handleStop({ payload, dispatch, stateStore, getKnownRepos }) {
+async function handleStop({ payload, dispatch, stateStore, getKnownRepos, getKnownProjects }) {
   // Avoid re-entrancy: Claude Code sets stop_hook_active when already inside a
   // stop continuation. Bail out so we never create a feedback loop.
   if (payload?.stop_hook_active) {
@@ -129,8 +130,7 @@ async function handleStop({ payload, dispatch, stateStore, getKnownRepos }) {
   }
 
   const cwd = resolveCwd(payload.cwd);
-  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
-  const project = resolveProjectKey(path.resolve(cwd), repos);
+  const { project } = resolveProjectForCwd(payload.cwd, getKnownRepos, getKnownProjects);
   const claudeSessionId = payload.session_id;
   const now = Date.now();
   const mutate = makeMutate(stateStore, claudeSessionId);

--- a/src/claude-code/handlers/stop.js
+++ b/src/claude-code/handlers/stop.js
@@ -19,7 +19,7 @@
 const path = require('node:path');
 const { uniqueEditedPaths } = require('../file-keys');
 const { makeMutate } = require('../state-mutate');
-const { resolveCwd, projectFromCwd } = require('../../hooks-engine/project');
+const { resolveCwd, resolveProjectKey } = require('../../hooks-engine/project');
 const { extractMessageText } = require('../../hooks-engine/prompt-classifiers');
 const { shouldAutoCapture } = require('../../hooks-engine/pattern-matcher');
 const { readTranscriptStream } = require('../hooks-engine/transcript-reader');
@@ -121,7 +121,7 @@ async function checkpoint({ dispatch, state, project }) {
   });
 }
 
-async function handleStop({ payload, dispatch, stateStore }) {
+async function handleStop({ payload, dispatch, stateStore, getKnownRepos }) {
   // Avoid re-entrancy: Claude Code sets stop_hook_active when already inside a
   // stop continuation. Bail out so we never create a feedback loop.
   if (payload?.stop_hook_active) {
@@ -129,7 +129,8 @@ async function handleStop({ payload, dispatch, stateStore }) {
   }
 
   const cwd = resolveCwd(payload.cwd);
-  const project = projectFromCwd(cwd);
+  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
+  const project = resolveProjectKey(path.resolve(cwd), repos);
   const claudeSessionId = payload.session_id;
   const now = Date.now();
   const mutate = makeMutate(stateStore, claudeSessionId);
@@ -239,8 +240,13 @@ async function runStopCapture({
     }
 
     if (shouldCheckpoint(turnCount, CHECKPOINT_EVERY)) {
-      const state = stateStore.loadState(claudeSessionId);
-      await checkpoint({ dispatch, state, project });
+      const snapshot = await mutate((state) => ({
+        sessionId: state.sessionId,
+        turnCount: state.turnCount,
+        memoriesSavedThisSession: state.memoriesSavedThisSession,
+        editedFiles: state.editedFiles,
+      }));
+      await checkpoint({ dispatch, state: snapshot, project });
     }
   } catch {
     // Never throw out of a Stop handler.

--- a/src/claude-code/handlers/user-prompt-submit.js
+++ b/src/claude-code/handlers/user-prompt-submit.js
@@ -15,7 +15,7 @@
 
 const path = require('node:path');
 const { CONTEXT } = require('../../../constants');
-const { resolveCwd, projectFromCwd, findMatchingRepo } = require('../../hooks-engine/project');
+const { resolveCwd, resolveProjectKey, findMatchingRepo } = require('../../hooks-engine/project');
 const { isPreflightWorthyPrompt } = require('../../hooks-engine/prompt-classifiers');
 const {
   appendPreflightBlock,
@@ -73,7 +73,8 @@ async function appendPreflight({ lines, dispatch, cwdRepo, prompt }) {
 async function run({ payload, dispatch, getKnownRepos, stateStore, isCancelled }) {
   const prompt = payload.prompt || '';
   const cwd = resolveCwd(payload.cwd);
-  const project = projectFromCwd(cwd);
+  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
+  const project = resolveProjectKey(path.resolve(cwd), repos);
   const claudeSessionId = payload.session_id;
 
   const state = stateStore.loadState(claudeSessionId);

--- a/src/claude-code/handlers/user-prompt-submit.js
+++ b/src/claude-code/handlers/user-prompt-submit.js
@@ -15,7 +15,8 @@
 
 const path = require('node:path');
 const { CONTEXT } = require('../../../constants');
-const { resolveCwd, resolveProjectKey, findMatchingRepo } = require('../../hooks-engine/project');
+const { findMatchingRepo } = require('../../hooks-engine/project');
+const { resolveProjectForCwd } = require('../project-resolve');
 const { isPreflightWorthyPrompt } = require('../../hooks-engine/prompt-classifiers');
 const {
   appendPreflightBlock,
@@ -70,11 +71,13 @@ async function appendPreflight({ lines, dispatch, cwdRepo, prompt }) {
   }
 }
 
-async function run({ payload, dispatch, getKnownRepos, stateStore, isCancelled }) {
+async function run({ payload, dispatch, getKnownRepos, getKnownProjects, stateStore, isCancelled }) {
   const prompt = payload.prompt || '';
-  const cwd = resolveCwd(payload.cwd);
-  const repos = (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [];
-  const project = resolveProjectKey(path.resolve(cwd), repos);
+  const { resolvedCwd, repos, project } = resolveProjectForCwd(
+    payload.cwd,
+    getKnownRepos,
+    getKnownProjects,
+  );
   const claudeSessionId = payload.session_id;
 
   const state = stateStore.loadState(claudeSessionId);
@@ -84,7 +87,7 @@ async function run({ payload, dispatch, getKnownRepos, stateStore, isCancelled }
     dispatch,
     getKnownRepos,
     project,
-    cwd,
+    cwd: payload.cwd,
     query: prompt,
     sessionId,
   }).catch(() => null);
@@ -94,7 +97,7 @@ async function run({ payload, dispatch, getKnownRepos, stateStore, isCancelled }
   }
 
   const lines = assembled ? assembled.lines : [];
-  const cwdRepo = assembled ? assembled.cwdRepo : findMatchingRepo(path.resolve(cwd), getKnownRepos());
+  const cwdRepo = assembled ? assembled.cwdRepo : findMatchingRepo(resolvedCwd, repos);
 
   // Preflight / coding context (best-effort, timeout-safe).
   await appendPreflight({ lines, dispatch, cwdRepo, prompt });

--- a/src/claude-code/hooks.js
+++ b/src/claude-code/hooks.js
@@ -126,6 +126,7 @@ async function runHook(argv, opts = {}) {
   const resolvedDispatchClient = opts.dispatchClient || dispatchClient;
   const dispatch = opts.dispatch || resolvedDispatchClient.dispatch;
   const getKnownRepos = opts.getKnownRepos || resolvedDispatchClient.getKnownRepos;
+  const getKnownProjects = opts.getKnownProjects || resolvedDispatchClient.getKnownProjects;
   const resolvedStateStore = opts.stateStore || stateStore;
 
   // ensureDb once — mirrors src/mcp/server.js:118-130.
@@ -148,6 +149,7 @@ async function runHook(argv, opts = {}) {
       dispatch,
       dispatchClient: resolvedDispatchClient,
       getKnownRepos,
+      getKnownProjects,
       stateStore: resolvedStateStore,
       roleFilter,
     });

--- a/src/claude-code/project-resolve.js
+++ b/src/claude-code/project-resolve.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Claude Code bridge: shared cwd → project resolution for hook handlers.
+ *
+ * Centralizes loading indexed repos + known memory projects and calling
+ * hooks-engine resolveProjectKey so every handler shares the same fallback
+ * chain (path prefix → knownProjects up-tree → basename).
+ */
+
+const path = require('node:path');
+const { resolveCwd, resolveProjectKey } = require('../hooks-engine/project');
+
+function loadReposAndProjects(getKnownRepos, getKnownProjects) {
+  return {
+    repos: (typeof getKnownRepos === 'function' ? getKnownRepos() : []) || [],
+    knownProjects: (typeof getKnownProjects === 'function' ? getKnownProjects() : []) || [],
+  };
+}
+
+/**
+ * @returns {{ resolvedCwd: string, repos: object[], knownProjects: string[], project: string }}
+ */
+function resolveProjectForCwd(cwdHint, getKnownRepos, getKnownProjects) {
+  const resolvedCwd = path.resolve(resolveCwd(cwdHint));
+  const { repos, knownProjects } = loadReposAndProjects(getKnownRepos, getKnownProjects);
+  return {
+    resolvedCwd,
+    repos,
+    knownProjects,
+    project: resolveProjectKey(resolvedCwd, repos, knownProjects),
+  };
+}
+
+module.exports = { loadReposAndProjects, resolveProjectForCwd };

--- a/src/claude-code/state-store.js
+++ b/src/claude-code/state-store.js
@@ -32,7 +32,7 @@ const DEFAULT_TTL_HOURS = 24;
 // Lock tuning for mutateState (#228). A crashed holder leaves a lockfile; it is
 // broken once older than LOCK_STALE_MS so a wedged lock never permanently
 // blocks the fast path.
-const LOCK_TIMEOUT_MS = 2000;
+const LOCK_TIMEOUT_MS = 5000;
 const LOCK_POLL_MS = 25;
 const LOCK_STALE_MS = 10_000;
 

--- a/src/hooks-engine/project.js
+++ b/src/hooks-engine/project.js
@@ -80,10 +80,58 @@ function findMatchingProject(resolvedCwd, knownProjects) {
   return null;
 }
 
+/**
+ * Resolve the indexed code repo for a cwd. Path-prefix match wins (monorepo
+ * subdirs whose basename differs from the repo name); then name match on the
+ * stored project hint.
+ *
+ * @param {string} resolvedCwd
+ * @param {Array<{name:string,path:string}>} repos
+ * @param {string|null|undefined} [currentProject]
+ * @returns {object|null}
+ */
+function resolveIndexedRepo(resolvedCwd, repos, currentProject) {
+  const byPath = findMatchingRepo(resolvedCwd, repos);
+  if (byPath) {
+    return byPath;
+  }
+  if (currentProject) {
+    const key = String(currentProject).toLowerCase();
+    return repos.find((r) => r.name && r.name.toLowerCase() === key) || null;
+  }
+  return null;
+}
+
+/**
+ * Best-effort memory project key: indexed repo name when cwd is inside one,
+ * else a known project basename from the up-tree walk, else cwd basename.
+ * Mirrors the fallback chain in detectProject() without async DB calls.
+ *
+ * @param {string} resolvedCwd
+ * @param {Array<{name:string,path:string}>} repos
+ * @param {string[]} [knownProjects]
+ * @returns {string}
+ */
+function resolveProjectKey(resolvedCwd, repos, knownProjects) {
+  const repo = findMatchingRepo(resolvedCwd, repos);
+  if (repo?.name) {
+    return repo.name.toLowerCase();
+  }
+  if (Array.isArray(knownProjects) && knownProjects.length > 0) {
+    const fromTree = findMatchingProject(resolvedCwd, knownProjects);
+    if (fromTree) {
+      return fromTree.toLowerCase();
+    }
+  }
+  return projectFromCwd(resolvedCwd);
+}
+
 module.exports = {
   resolveCwd,
   projectFromCwd,
   findMatchingRepo,
   findMatchingProject,
   normalizeRepoPath,
+  resolveIndexedRepo,
+  resolveProjectKey,
 };

--- a/src/hooks-engine/project.js
+++ b/src/hooks-engine/project.js
@@ -18,10 +18,13 @@ const path = require('node:path');
  * CLAUDE_PROJECT_DIR; Pi/MCP default to process.cwd().
  */
 function resolveCwd(hint) {
+  if (process.env.CLAUDE_PROJECT_DIR) {
+    return process.env.CLAUDE_PROJECT_DIR;
+  }
   if (hint) {
     return hint;
   }
-  return process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  return process.cwd();
 }
 
 /**

--- a/src/hooks-engine/project.js
+++ b/src/hooks-engine/project.js
@@ -8,8 +8,7 @@
  * extensions/memory-layer/host/project-detector.ts and tool-guardrails.ts.
  *
  * IMPORTANT: prefers process.env.CLAUDE_PROJECT_DIR over cwd/basename so the
- * Claude Code bridge and MCP agree on the project key (resolves the TODO at
- * src/mcp/server.js:30-34). NOT yet wired into mcp/server.js (Phase 2+).
+ * Claude Code bridge and MCP agree on the project key.
  */
 
 const path = require('node:path');
@@ -49,13 +48,25 @@ function normalizeRepoPath(p) {
 function findMatchingRepo(resolvedCwd, repos) {
   // Normalize separators so a Windows cwd matches a DB path stored with `/`
   // (or vice versa). Prefix match always uses `/` after normalization (#227).
+  // When several indexed repos match (nested paths), prefer the deepest/longest
+  // path — mirrors detectProject()'s depth tie-break in project-detector.ts.
   const abs = normalizeRepoPath(resolvedCwd);
-  return (
-    repos.find((r) => {
-      const rp = normalizeRepoPath(r.path);
-      return abs === rp || abs.startsWith(`${rp}/`);
-    }) || null
-  );
+  let best = null;
+  let bestLen = -1;
+  for (const r of repos) {
+    if (!r?.path) {
+      continue;
+    }
+    const rp = normalizeRepoPath(r.path);
+    if (abs !== rp && !abs.startsWith(`${rp}/`)) {
+      continue;
+    }
+    if (rp.length > bestLen) {
+      best = r;
+      bestLen = rp.length;
+    }
+  }
+  return best;
 }
 
 /**

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -14,27 +14,25 @@ const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio
 const { ListToolsRequestSchema, CallToolRequestSchema } = require('@modelcontextprotocol/sdk/types.js');
 const { tools } = require('./tools');
 const { toCallToolResult } = require('./translate-result');
+const { resolveCwd, projectFromCwd, resolveProjectKey } = require('../hooks-engine/project');
 
 const SERVER_NAME = 'lapis';
 const SERVER_VERSION = require('../../package.json').version || '0.0.0';
 
 /**
- * Derive a project name from the current working directory.
- *
- * Uses a simpler heuristic than the Pi extension's `detectProject()` in
- * `extensions/memory-layer/host/project-detector.ts` (which walks up the tree
- * matching known `code_repos.path` and `knownProjects`). MCP clients typically
- * run with a stable cwd at session start, so the basename is a reasonable
- * default and avoids an async DB round-trip before the first tool call.
- *
- * NOTE: This is NOT identical to `state.currentProject` in the Pi extension.
- * If you run LaPis MCP from inside a git worktree or subdirectory whose name
- * differs from the registered repo, MCP and Pi will scope memories under
- * different project keys. Sharing the full detector is a future refactor.
+ * Derive the MCP project key from cwd, preferring an indexed repo whose path
+ * contains cwd (monorepo subdirs) before falling back to the basename heuristic.
+ * Uses the same hooks-engine helpers as the Claude Code bridge.
  */
-function projectFromCwd(cwd = process.cwd()) {
-  const base = path.basename(path.resolve(cwd));
-  return base ? base.toLowerCase() : 'unknown';
+function detectMcpProject(cwd) {
+  const resolved = path.resolve(resolveCwd(cwd));
+  try {
+    const { sqlJson } = require('../../db');
+    const repos = sqlJson('SELECT name, path, indexed_at FROM code_repos') || [];
+    return resolveProjectKey(resolved, repos);
+  } catch {
+    return projectFromCwd(resolved);
+  }
 }
 
 /**
@@ -47,7 +45,7 @@ function projectFromCwd(cwd = process.cwd()) {
  */
 function createServer(opts = {}) {
   const dispatch = opts.dispatch || require('../cli/gateway').dispatch;
-  const project = opts.project || projectFromCwd();
+  const project = opts.project || detectMcpProject();
   const ctx = { project };
 
   const server = new Server(
@@ -135,4 +133,4 @@ async function startMcpServer(opts = {}) {
   return server;
 }
 
-module.exports = { createServer, startMcpServer, projectFromCwd };
+module.exports = { createServer, startMcpServer, projectFromCwd, detectMcpProject };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -15,6 +15,7 @@ const { ListToolsRequestSchema, CallToolRequestSchema } = require('@modelcontext
 const { tools } = require('./tools');
 const { toCallToolResult } = require('./translate-result');
 const { resolveCwd, projectFromCwd, resolveProjectKey } = require('../hooks-engine/project');
+const { getKnownRepos, getKnownProjects } = require('../claude-code/dispatch-client');
 
 const SERVER_NAME = 'lapis';
 const SERVER_VERSION = require('../../package.json').version || '0.0.0';
@@ -27,18 +28,7 @@ const SERVER_VERSION = require('../../package.json').version || '0.0.0';
 function detectMcpProject(cwd) {
   const resolved = path.resolve(resolveCwd(cwd));
   try {
-    const { sqlJson } = require('../../db');
-    const repos = sqlJson('SELECT name, path, indexed_at FROM code_repos') || [];
-    const rows =
-      sqlJson(`
-        SELECT project
-        FROM observations
-        WHERE deleted_at IS NULL AND type != 'skill'
-          AND project IS NOT NULL AND project != ''
-        GROUP BY project
-      `) || [];
-    const knownProjects = rows.map((r) => r.project).filter(Boolean);
-    return resolveProjectKey(resolved, repos, knownProjects);
+    return resolveProjectKey(resolved, getKnownRepos(), getKnownProjects());
   } catch {
     return projectFromCwd(resolved);
   }

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -15,7 +15,7 @@ const { ListToolsRequestSchema, CallToolRequestSchema } = require('@modelcontext
 const { tools } = require('./tools');
 const { toCallToolResult } = require('./translate-result');
 const { resolveCwd, projectFromCwd, resolveProjectKey } = require('../hooks-engine/project');
-const { getKnownRepos, getKnownProjects } = require('../claude-code/dispatch-client');
+const { getKnownRepos, getKnownProjects } = require('../platform/project-db');
 
 const SERVER_NAME = 'lapis';
 const SERVER_VERSION = require('../../package.json').version || '0.0.0';

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -29,7 +29,16 @@ function detectMcpProject(cwd) {
   try {
     const { sqlJson } = require('../../db');
     const repos = sqlJson('SELECT name, path, indexed_at FROM code_repos') || [];
-    return resolveProjectKey(resolved, repos);
+    const rows =
+      sqlJson(`
+        SELECT project
+        FROM observations
+        WHERE deleted_at IS NULL AND type != 'skill'
+          AND project IS NOT NULL AND project != ''
+        GROUP BY project
+      `) || [];
+    const knownProjects = rows.map((r) => r.project).filter(Boolean);
+    return resolveProjectKey(resolved, repos, knownProjects);
   } catch {
     return projectFromCwd(resolved);
   }

--- a/src/platform/project-db.js
+++ b/src/platform/project-db.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * Shared sync reads for project-detection (indexed code repos + memory projects).
+ *
+ * Used by the Claude Code bridge, MCP server, and dispatch-client so transport
+ * layers do not depend on each other for DB access. In-process TTL cache mirrors
+ * Pi's REPO_CACHE_TTL (5 min) to avoid duplicate queries within one hook/MCP
+ * process lifetime.
+ */
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let _reposCache = null;
+let _reposCacheTime = 0;
+let _projectsCache = null;
+let _projectsCacheTime = 0;
+
+function clearProjectDbCache() {
+  _reposCache = null;
+  _reposCacheTime = 0;
+  _projectsCache = null;
+  _projectsCacheTime = 0;
+}
+
+function loadKnownRepos() {
+  const { sqlJson } = require('../../db');
+  return sqlJson('SELECT name, path, indexed_at FROM code_repos') || [];
+}
+
+function loadKnownProjects() {
+  const { sqlJson } = require('../../db');
+  const rows =
+    sqlJson(`
+      SELECT project
+      FROM observations
+      WHERE deleted_at IS NULL AND type != 'skill'
+        AND project IS NOT NULL AND project != ''
+      GROUP BY project
+    `) || [];
+  return rows.map((r) => r.project).filter(Boolean);
+}
+
+/**
+ * Known indexed code repos. Best-effort; returns [] when the DB is unavailable.
+ */
+function getKnownRepos() {
+  const now = Date.now();
+  if (_reposCache && now - _reposCacheTime < CACHE_TTL_MS) {
+    return _reposCache;
+  }
+  try {
+    _reposCache = loadKnownRepos();
+    _reposCacheTime = now;
+    return _reposCache;
+  } catch {
+    return _reposCache || [];
+  }
+}
+
+/**
+ * Known memory project names (list-projects parity). Best-effort.
+ */
+function getKnownProjects() {
+  const now = Date.now();
+  if (_projectsCache && now - _projectsCacheTime < CACHE_TTL_MS) {
+    return _projectsCache;
+  }
+  try {
+    _projectsCache = loadKnownProjects();
+    _projectsCacheTime = now;
+    return _projectsCache;
+  } catch {
+    return _projectsCache || [];
+  }
+}
+
+module.exports = {
+  getKnownRepos,
+  getKnownProjects,
+  clearProjectDbCache,
+  CACHE_TTL_MS,
+};

--- a/test/claude-code/context-inject.test.js
+++ b/test/claude-code/context-inject.test.js
@@ -1,0 +1,32 @@
+const { assembleContextLines } = require('../../src/claude-code/context-inject');
+
+describe('claude-code context-inject', () => {
+  const EMPTY_CONTEXT = {
+    observations: [],
+    personal: [],
+    stats: { total_memories: 0, total_personal: 0 },
+  };
+
+  test('assembleContextLines honors CLAUDE_PROJECT_DIR for repo matching', async () => {
+    const prev = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = '/resolved/project';
+    try {
+      const repos = [{ name: 'app', path: '/resolved/project', indexed_at: 'now' }];
+      const assembled = await assembleContextLines({
+        dispatch: async () => EMPTY_CONTEXT,
+        getKnownRepos: () => repos,
+        project: 'app',
+        cwd: '/ignored/subdir',
+        query: null,
+        sessionId: null,
+      });
+      expect(assembled?.cwdRepo?.name).toBe('app');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = prev;
+      }
+    }
+  });
+});

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -549,6 +549,38 @@ describe('claude-code handlers: SessionEnd', () => {
     expect(summaryCall?.args?.content).toMatch(/2 memories saved/);
   });
 
+  test('summary relative paths use resolveCwd (CLAUDE_PROJECT_DIR)', async () => {
+    const prev = process.env.CLAUDE_PROJECT_DIR;
+    process.env.CLAUDE_PROJECT_DIR = '/resolved/project';
+    try {
+      const stateStore = makeStateStore();
+      stateStore.saveState('claude-cwd', {
+        ...realStateStore.defaultState(),
+        sessionId: 1,
+        editedFiles: ['/resolved/project/src/a.js'],
+      });
+      const { dispatch, calls } = makeFakeDispatch();
+      const dispatchClient = { countSessionMemories: () => 0 };
+
+      await handleSessionEnd({
+        payload: { session_id: 'claude-cwd', cwd: '/ignored', transcript_path: '' },
+        dispatch,
+        dispatchClient,
+        stateStore,
+      });
+
+      const summaryCall = calls.find((c) => c.cmd === 'session-summary');
+      expect(summaryCall?.args?.content).toContain('src/a.js');
+      expect(summaryCall?.args?.content).not.toContain('/ignored/');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.CLAUDE_PROJECT_DIR;
+      } else {
+        process.env.CLAUDE_PROJECT_DIR = prev;
+      }
+    }
+  });
+
   test('no-op when no session was started', async () => {
     const stateStore = makeStateStore();
     const { dispatch, calls } = makeFakeDispatch();

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -570,8 +570,8 @@ describe('claude-code handlers: SessionEnd', () => {
       });
 
       const summaryCall = calls.find((c) => c.cmd === 'session-summary');
-      expect(summaryCall?.args?.content).toContain('src/a.js');
-      expect(summaryCall?.args?.content).not.toContain('/ignored/');
+      expect(summaryCall?.args?.content).toContain('- src/a.js');
+      expect(summaryCall?.args?.content).not.toMatch(/ignored/);
     } finally {
       if (prev === undefined) {
         delete process.env.CLAUDE_PROJECT_DIR;

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -153,6 +153,26 @@ describe('claude-code handlers: SessionStart', () => {
     expect(out.hookSpecificOutput.hookEventName).toBe('SessionStart');
   });
 
+  test('compact refreshes currentProject when cwd resolves to a different indexed repo', async () => {
+    const stateStore = makeStateStore();
+    stateStore.saveState('claude-compact', {
+      ...realStateStore.defaultState(),
+      sessionId: 77,
+      currentProject: 'foo',
+    });
+    const monorepoRepos = () => [{ name: 'my-monorepo', path: '/repos/my-monorepo' }];
+    const { dispatch } = makeFakeDispatch({ context: () => EMPTY_CONTEXT });
+
+    await handleSessionStart({
+      payload: { session_id: 'claude-compact', source: 'compact', cwd: '/repos/my-monorepo/packages/foo' },
+      dispatch,
+      getKnownRepos: monorepoRepos,
+      stateStore,
+    });
+
+    expect(stateStore._peek('claude-compact').currentProject).toBe('my-monorepo');
+  });
+
   test('startup passes the stored numeric sessionId as session-id to context', async () => {
     const { dispatch, calls } = makeFakeDispatch({
       'session-start': () => ({ sessionId: 55, sessionCount: 0 }),

--- a/test/claude-code/handlers.test.js
+++ b/test/claude-code/handlers.test.js
@@ -525,6 +525,8 @@ describe('claude-code handlers: SessionEnd', () => {
     });
 
     expect(hasCall(calls, 'session-end', (a) => a.memories === '2')).toBe(true);
+    const summaryCall = calls.find((c) => c.cmd === 'session-summary');
+    expect(summaryCall?.args?.content).toMatch(/2 memories saved/);
   });
 
   test('no-op when no session was started', async () => {

--- a/test/claude-code/project-resolve.test.js
+++ b/test/claude-code/project-resolve.test.js
@@ -1,0 +1,25 @@
+const { resolveProjectForCwd } = require('../../src/claude-code/project-resolve');
+
+describe('claude-code project-resolve', () => {
+  const repos = [{ name: 'my-monorepo', path: '/repos/my-monorepo' }];
+  const knownProjects = ['legacy-app'];
+
+  test('resolveProjectForCwd prefers indexed repo path over basename', () => {
+    const { project, resolvedCwd } = resolveProjectForCwd(
+      '/repos/my-monorepo/packages/foo',
+      () => repos,
+      () => knownProjects,
+    );
+    expect(resolvedCwd).toBe('/repos/my-monorepo/packages/foo');
+    expect(project).toBe('my-monorepo');
+  });
+
+  test('resolveProjectForCwd uses knownProjects when no code repo matches', () => {
+    const { project } = resolveProjectForCwd(
+      '/home/me/legacy-app/src',
+      () => [],
+      () => knownProjects,
+    );
+    expect(project).toBe('legacy-app');
+  });
+});

--- a/test/claude-code/tool-hooks.test.js
+++ b/test/claude-code/tool-hooks.test.js
@@ -295,6 +295,27 @@ describe('claude-code PostToolUse: edit-track + git-trust', () => {
     expect(calls.some((c) => c.cmd === 'sync-code-trust' && c.args.repo === 'app')).toBe(true);
   });
 
+  test('git pull from a monorepo subdir resolves repo by path prefix (#205 review)', async () => {
+    const monorepoRepos = () => [{ name: 'my-monorepo', path: '/proj/my-monorepo' }];
+    const stateStore = makeStateStore({
+      s: { ...realStateStore.defaultState(), currentProject: 'foo' },
+    });
+    const { dispatch, calls } = makeFakeDispatch();
+    await handlePostToolUse({
+      payload: {
+        session_id: 's',
+        tool_name: 'Bash',
+        tool_input: { command: 'git pull origin main' },
+        cwd: '/proj/my-monorepo/packages/foo',
+      },
+      dispatch,
+      getKnownRepos: monorepoRepos,
+      stateStore,
+      roleFilter: { only: 'git-trust' },
+    });
+    expect(calls.some((c) => c.cmd === 'sync-code-trust' && c.args.repo === 'my-monorepo')).toBe(true);
+  });
+
   test('MultiEdit records each edited file path', async () => {
     const stateStore = makeStateStore();
     const { dispatch } = makeFakeDispatch();

--- a/test/hooks-engine/project.test.js
+++ b/test/hooks-engine/project.test.js
@@ -12,8 +12,13 @@ describe('hooks-engine project: resolveCwd', () => {
     delete process.env.CLAUDE_PROJECT_DIR;
   });
 
-  test('prefers explicit hint', () => {
+  test('prefers CLAUDE_PROJECT_DIR over an explicit hint when set', () => {
     process.env.CLAUDE_PROJECT_DIR = '/from/env';
+    expect(resolveCwd('/hint')).toBe('/from/env');
+  });
+
+  test('uses explicit hint when CLAUDE_PROJECT_DIR is unset', () => {
+    delete process.env.CLAUDE_PROJECT_DIR;
     expect(resolveCwd('/hint')).toBe('/hint');
   });
 

--- a/test/hooks-engine/project.test.js
+++ b/test/hooks-engine/project.test.js
@@ -70,6 +70,14 @@ describe('hooks-engine project: findMatchingRepo', () => {
     const mixed = [{ name: 'win', path: 'C:/repos/win' }];
     expect(findMatchingRepo('C:\\repos\\win\\src', mixed)?.name).toBe('win');
   });
+
+  test('prefers the deepest path when several repos match (nested indexes)', () => {
+    const nested = [
+      { name: 'monorepo', path: '/repos/monorepo' },
+      { name: 'monorepo-pkg', path: '/repos/monorepo/packages/pkg' },
+    ];
+    expect(findMatchingRepo('/repos/monorepo/packages/pkg/src', nested)?.name).toBe('monorepo-pkg');
+  });
 });
 
 describe('hooks-engine project: findMatchingProject', () => {

--- a/test/hooks-engine/project.test.js
+++ b/test/hooks-engine/project.test.js
@@ -1,4 +1,11 @@
-const { resolveCwd, projectFromCwd, findMatchingRepo, findMatchingProject } = require('../../src/hooks-engine/project');
+const {
+  resolveCwd,
+  projectFromCwd,
+  findMatchingRepo,
+  findMatchingProject,
+  resolveIndexedRepo,
+  resolveProjectKey,
+} = require('../../src/hooks-engine/project');
 
 describe('hooks-engine project: resolveCwd', () => {
   afterEach(() => {
@@ -76,5 +83,36 @@ describe('hooks-engine project: findMatchingProject', () => {
 
   test('returns null when no ancestor matches', () => {
     expect(findMatchingProject('/home/unknown', ['lapis'])).toBeNull();
+  });
+});
+
+describe('hooks-engine project: resolveIndexedRepo', () => {
+  const repos = [
+    { name: 'my-monorepo', path: '/repos/my-monorepo' },
+    { name: 'other', path: '/repos/other' },
+  ];
+
+  test('prefers path prefix over mismatched currentProject basename', () => {
+    expect(resolveIndexedRepo('/repos/my-monorepo/packages/foo', repos, 'foo')?.name).toBe('my-monorepo');
+  });
+
+  test('falls back to currentProject name when cwd is outside indexed paths', () => {
+    expect(resolveIndexedRepo('/elsewhere', repos, 'other')?.name).toBe('other');
+  });
+});
+
+describe('hooks-engine project: resolveProjectKey', () => {
+  const repos = [{ name: 'my-monorepo', path: '/repos/my-monorepo' }];
+
+  test('returns indexed repo name for monorepo subdirectories', () => {
+    expect(resolveProjectKey('/repos/my-monorepo/packages/foo', repos)).toBe('my-monorepo');
+  });
+
+  test('falls back to basename when no repo matches', () => {
+    expect(resolveProjectKey('/tmp/standalone', repos)).toBe('standalone');
+  });
+
+  test('uses knownProjects up-tree walk before basename', () => {
+    expect(resolveProjectKey('/home/me/lapis/src', [], ['lapis'])).toBe('lapis');
   });
 });

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -280,6 +280,9 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
         if (sql.includes('code_repos')) {
           return [{ name: 'my-monorepo', path: '/repos/my-monorepo', indexed_at: '2026-01-01' }];
         }
+        if (sql.includes('FROM observations')) {
+          return [];
+        }
         return realDb.sqlJson ? realDb.sqlJson(sql) : [];
       },
     };

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -269,6 +269,27 @@ describe('MCP server end-to-end (InMemoryTransport)', () => {
     expect(projectFromCwd('/home/user/MyProject')).toBe('myproject');
     expect(projectFromCwd('/tmp/lapis-test')).toBe('lapis-test');
   });
+
+  it('detectMcpProject prefers indexed repo path over cwd basename', () => {
+    const dbPath = require.resolve('../db');
+    const realDb = require(dbPath);
+    const prev = require.cache[dbPath].exports;
+    require.cache[dbPath].exports = {
+      ...realDb,
+      sqlJson: (sql) => {
+        if (sql.includes('code_repos')) {
+          return [{ name: 'my-monorepo', path: '/repos/my-monorepo', indexed_at: '2026-01-01' }];
+        }
+        return realDb.sqlJson ? realDb.sqlJson(sql) : [];
+      },
+    };
+    try {
+      const { detectMcpProject } = require('../src/mcp/server');
+      expect(detectMcpProject('/repos/my-monorepo/packages/foo')).toBe('my-monorepo');
+    } finally {
+      require.cache[dbPath].exports = prev;
+    }
+  });
 });
 
 // --- startMcpServer error handling ---

--- a/test/platform/project-db.test.js
+++ b/test/platform/project-db.test.js
@@ -1,0 +1,88 @@
+const {
+  getKnownRepos,
+  getKnownProjects,
+  clearProjectDbCache,
+  CACHE_TTL_MS,
+} = require('../../src/platform/project-db');
+
+describe('platform project-db', () => {
+  afterEach(() => {
+    clearProjectDbCache();
+  });
+
+  test('getKnownRepos returns [] when the DB is unavailable', () => {
+    const dbPath = require.resolve('../../db');
+    require(dbPath);
+    const prev = require.cache[dbPath].exports;
+    require.cache[dbPath].exports = {
+      sqlJson: () => {
+        throw new Error('no db');
+      },
+    };
+    try {
+      expect(getKnownRepos()).toEqual([]);
+    } finally {
+      require.cache[dbPath].exports = prev;
+      clearProjectDbCache();
+    }
+  });
+
+  test('getKnownRepos caches results within TTL', () => {
+    const dbPath = require.resolve('../../db');
+    require(dbPath);
+    const prev = require.cache[dbPath].exports;
+    let calls = 0;
+    require.cache[dbPath].exports = {
+      sqlJson: (sql) => {
+        if (sql.includes('code_repos')) {
+          calls++;
+          return [{ name: 'app', path: '/app', indexed_at: 'now' }];
+        }
+        return [];
+      },
+    };
+    try {
+      expect(getKnownRepos()).toEqual([{ name: 'app', path: '/app', indexed_at: 'now' }]);
+      expect(getKnownRepos()).toEqual([{ name: 'app', path: '/app', indexed_at: 'now' }]);
+      expect(calls).toBe(1);
+    } finally {
+      require.cache[dbPath].exports = prev;
+      clearProjectDbCache();
+    }
+  });
+
+  test('clearProjectDbCache forces a reload', () => {
+    const dbPath = require.resolve('../../db');
+    require(dbPath);
+    const prev = require.cache[dbPath].exports;
+    let calls = 0;
+    require.cache[dbPath].exports = {
+      sqlJson: (sql) => {
+        if (sql.includes('code_repos')) {
+          calls++;
+          return [];
+        }
+        if (sql.includes('FROM observations')) {
+          return [{ project: 'legacy' }];
+        }
+        return [];
+      },
+    };
+    try {
+      getKnownRepos();
+      getKnownProjects();
+      clearProjectDbCache();
+      getKnownRepos();
+      getKnownProjects();
+      expect(calls).toBe(2);
+      expect(getKnownProjects()).toEqual(['legacy']);
+    } finally {
+      require.cache[dbPath].exports = prev;
+      clearProjectDbCache();
+    }
+  });
+
+  test('exports CACHE_TTL_MS matching Pi REPO_CACHE_TTL (5 min)', () => {
+    expect(CACHE_TTL_MS).toBe(5 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up fixes from the [issue #205 implementation review](https://github.com/GeneGulanesJr/LaPis/issues/205): monorepo project detection, session summary consistency, Stop checkpoint locking, and MCP project-key alignment.

Fixes #205 (review follow-ups)

## Changes

### Monorepo project / repo resolution
- `resolveProjectKey()` / `resolveIndexedRepo()` in `hooks-engine/project.js`
- Path-prefix match wins over cwd basename; deepest nested repo preferred
- `getKnownProjects()` wired through handlers (list-projects parity)
- `project-resolve.js` centralizes `resolveProjectForCwd()`

### Session summary & cwd
- DB-derived memory count in both summary text and `session-end` dispatch
- `resolveCwd` prefers `CLAUDE_PROJECT_DIR` over payload `cwd` when set
- `assembleContextLines` uses `resolveCwd` for repo matching and index hints

### Concurrency
- Stop checkpoints snapshot under `mutateState`; lock timeout 5s

### Shared platform layer
- **`src/platform/project-db.js`** — `getKnownRepos` / `getKnownProjects` with 5min in-process cache
- MCP imports from `platform/project-db` (no `claude-code/` dependency)
- `dispatch-client` re-exports the same helpers for hook injection

### Other
- `SessionStart(compact)` refreshes `currentProject` on cwd change

## Type of Change

- [x] Bug fix
- [x] Refactoring (shared project-db module)

## How Has This Been Tested?

- `npx vitest run test/claude-code test/hooks-engine test/mcp-server.test.js test/platform` — **326 passed**

## Reviewer notes

- Core: `hooks-engine/project.js`, `platform/project-db.js`, `claude-code/project-resolve.js`
- `resolveCwd` behavior change: env wins over payload hint (matches hooks-engine contract comment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e30fb49-979d-4d07-aa28-d1bb5b4601c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e30fb49-979d-4d07-aa28-d1bb5b4601c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

