### PR TITLE
fix: address code review security and correctness issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Session quit waits up to 2s for shutdown persistence work.
   - `schema.sql` synced with `expires_at` on observations and the `index_jobs` table.
   - crosshash `serve` refuses unspecified bind addresses without `--api-key`.
+  - Full reindex parses to memory first, then clears and writes in one SQLite transaction.
+  - Cross-process repo index locks stored in `repo_index_locks` (SQLite).
+  - Incremental `changed-paths` responses include `rejected_paths` for blocked entries.
+  - HTTP auth documented in `docs/CONFIGURATION.md`; `::` bind requires API key.
 
-- **Documentation review nits (PR #240)**
+- **Documentation review nits (PR #241)**
   - [`docs/MCP.md`](docs/MCP.md) — `lapis-mcp` requires the `mcp` subcommand; fix source links for `hooks-engine/project` and `project-db`; add `index-status` tool; clarify no `./mcp` npm export.
   - [`docs/COMMANDS.md`](docs/COMMANDS.md), [`docs/INDEX.md`](docs/INDEX.md) — align MCP bin invocation with CLI routing.
   - [`docs/TUTORIAL.md`](docs/TUTORIAL.md) — tidy See Also list formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Cross-process repo index locks stored in `repo_index_locks` (SQLite).
   - Incremental `changed-paths` responses include `rejected_paths` for blocked entries.
   - HTTP auth documented in `docs/CONFIGURATION.md`; `::` bind requires API key.
+  - Second review pass: defer diagnostics during buffered full rebuild; git delta path guards; derived-phase failure returns partial error; constant-time API key compare.
 
 - **Documentation review nits (PR #241)**
   - [`docs/MCP.md`](docs/MCP.md) — `lapis-mcp` requires the `mcp` subcommand; fix source links for `hooks-engine/project` and `project-db`; add `index-status` tool; clarify no `./mcp` npm export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - HTTP auth documented in `docs/CONFIGURATION.md`; `::` bind requires API key.
   - Second review pass: defer diagnostics during buffered full rebuild; git delta path guards; derived-phase failure returns partial error; constant-time API key compare.
   - Third review pass: `updateRepoStats` runs after derived indexes succeed; incremental no-op reindex advances `head_commit` when git moved; trust sync resolves git-relative paths to indexed absolute paths; shared git-trust matcher supports quoted `-C` paths; HTTP auth accepts array-shaped headers.
+  - Fourth review pass: trust sync uses `git diff --name-status` (rename old+new paths); scan-hash no-op reindex advances `head_commit`; HTTP Bearer scheme is case-insensitive.
 
 - **Documentation review nits (PR #241)**
   - [`docs/MCP.md`](docs/MCP.md) — `lapis-mcp` requires the `mcp` subcommand; fix source links for `hooks-engine/project` and `project-db`; add `index-status` tool; clarify no `./mcp` npm export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Code review security and correctness fixes**
+  - Incremental reindex `changed-paths` now enforces repo path boundaries and secret-file skips (parity with full scanner).
+  - Full reindex defers `clearRepoIndex` until the first successful write batch so parse failures preserve the existing index.
+  - Per-repo index locks prevent concurrent full/incremental rebuilds from interleaving writes.
+  - Dream Cycle "never recalled" cleanup now counts only `was_useful = 1` recalls; context injection logs passive recalls as not useful.
+  - `markDuplicate` rejects identical source/target IDs.
+  - Pi trust-sync hook recognizes `git -C <path>` commands (parity with Claude Code bridge).
+  - Trust sync applies adjustments in a transaction and initializes `head_commit` on first sync without a one-commit diff penalty.
+  - Trust sync adapter notifies only after successful sync.
+  - HTTP server supports optional API key auth (`--api-key`, `LAPIS_HTTP_API_KEY`) and refuses `0.0.0.0` binds without a key.
+  - `claimNextReadyTodo` uses an atomic update to prevent duplicate claims.
+  - Bash guardrail no longer blocks grep outside indexed repos based on `currentProject` alone.
+  - Session quit waits up to 2s for shutdown persistence work.
+  - `schema.sql` synced with `expires_at` on observations and the `index_jobs` table.
+  - crosshash `serve` refuses unspecified bind addresses without `--api-key`.
+
 - **Documentation review nits (PR #240)**
   - [`docs/MCP.md`](docs/MCP.md) — `lapis-mcp` requires the `mcp` subcommand; fix source links for `hooks-engine/project` and `project-db`; add `index-status` tool; clarify no `./mcp` npm export.
   - [`docs/COMMANDS.md`](docs/COMMANDS.md), [`docs/INDEX.md`](docs/INDEX.md) — align MCP bin invocation with CLI routing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Incremental `changed-paths` responses include `rejected_paths` for blocked entries.
   - HTTP auth documented in `docs/CONFIGURATION.md`; `::` bind requires API key.
   - Second review pass: defer diagnostics during buffered full rebuild; git delta path guards; derived-phase failure returns partial error; constant-time API key compare.
+  - Third review pass: `updateRepoStats` runs after derived indexes succeed; incremental no-op reindex advances `head_commit` when git moved; trust sync resolves git-relative paths to indexed absolute paths; shared git-trust matcher supports quoted `-C` paths; HTTP auth accepts array-shaped headers.
 
 - **Documentation review nits (PR #241)**
   - [`docs/MCP.md`](docs/MCP.md) — `lapis-mcp` requires the `mcp` subcommand; fix source links for `hooks-engine/project` and `project-db`; add `index-status` tool; clarify no `./mcp` npm export.

--- a/cli.js
+++ b/cli.js
@@ -122,6 +122,7 @@ if (isHelpRequest) {
     await startHttpServer({
       host: args.host ?? '127.0.0.1',
       port: Number(args.port ?? 9100),
+      apiKey: args['api-key'] ?? args.apiKey ?? null,
     });
     return;
   }

--- a/config.js
+++ b/config.js
@@ -27,6 +27,7 @@ const DEFAULTS = {
   // Auto-switch `index-repo` to async when file count exceeds this threshold.
   // Override with the LAPIS_ASYNC_INDEX_THRESHOLD env var or via config.jsonc.
   async_index_file_threshold: 500,
+  http_api_key: null,
   output_compression: {
     enabled: true,               // Master toggle — set false to disable auto-compression
     min_chars: 2000,             // Don't compress output shorter than this

--- a/crosshash/crates/crosshash-ai/src/config.rs
+++ b/crosshash/crates/crosshash-ai/src/config.rs
@@ -105,10 +105,14 @@ impl AiConfig {
             config.api_key_env = v;
         }
         if let Ok(v) = std::env::var("CROSSHASH_AI_TEMPERATURE") {
-            if let Ok(t) = v.parse() { config.temperature = t; }
+            if let Ok(t) = v.parse() {
+                config.temperature = t;
+            }
         }
         if let Ok(v) = std::env::var("CROSSHASH_AI_MAX_TOKENS") {
-            if let Ok(t) = v.parse() { config.max_tokens = t; }
+            if let Ok(t) = v.parse() {
+                config.max_tokens = t;
+            }
         }
         Ok(config)
     }

--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -1554,12 +1554,17 @@ async fn execute_serve(
     cmd: ServeCommand,
 ) -> Result<()> {
     let storage = open_storage(db)?;
+    let addr: std::net::SocketAddr = cmd.addr.parse()?;
+    if addr.ip().is_unspecified() && cmd.api_key.is_none() {
+        anyhow::bail!(
+            "refusing to bind crosshash API to {addr} without --api-key; use 127.0.0.1 or pass --api-key"
+        );
+    }
     let config = crosshash_api::ApiConfig {
         api_key: cmd.api_key,
         max_requests_per_minute: 60,
     };
     let app = crosshash_api::api_router_with_storage(config, storage);
-    let addr: std::net::SocketAddr = cmd.addr.parse()?;
     eprintln!("crosshash API server listening on {addr}");
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;

--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -1533,11 +1533,14 @@ fn detect_workspace_type(root: &Path, workspace_aware: bool) -> WorkspaceType {
 fn load_ai_config() -> crosshash_ai::AiConfig {
     let candidates: Vec<PathBuf> = [
         Some(PathBuf::from("config/default.toml")),
-        std::env::current_exe().ok().and_then(|exe| {
-            exe.parent().map(|p| p.join("config").join("default.toml"))
-        }),
+        std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent().map(|p| p.join("config").join("default.toml"))),
         std::env::var("CROSSHASH_CONFIG").ok().map(PathBuf::from),
-    ].into_iter().flatten().collect();
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
     for candidate in &candidates {
         if candidate.exists() {
             if let Ok(config) = crosshash_ai::AiConfig::load(candidate) {

--- a/db.js
+++ b/db.js
@@ -354,6 +354,10 @@ const _CRITICAL_TABLES = [
     'scope_resolution',
     `CREATE TABLE IF NOT EXISTS scope_resolution (binding_id INTEGER PRIMARY KEY REFERENCES file_scope_bindings(id) ON DELETE CASCADE, resolved_symbol_id INTEGER NULL, resolved_file_id INTEGER NULL, status TEXT NOT NULL, resolved_at_pass INTEGER NOT NULL, confidence REAL NOT NULL DEFAULT 1.0)`,
   ],
+  [
+    'repo_index_locks',
+    `CREATE TABLE IF NOT EXISTS repo_index_locks (repo_name TEXT PRIMARY KEY, holder_id TEXT NOT NULL, host TEXT NOT NULL DEFAULT '', acquired_at TEXT NOT NULL DEFAULT (datetime('now')))`,
+  ],
 ];
 
 function ensureCriticalTables() {
@@ -411,6 +415,7 @@ function _createTableIndexes(name, db) {
       'CREATE INDEX IF NOT EXISTS idx_sr_status ON scope_resolution(status)',
       'CREATE INDEX IF NOT EXISTS idx_sr_pass ON scope_resolution(resolved_at_pass)',
     ],
+    repo_index_locks: ['CREATE INDEX IF NOT EXISTS idx_repo_index_locks_acquired ON repo_index_locks(acquired_at)'],
     doc_sections: [
       'CREATE INDEX IF NOT EXISTS idx_ds_file ON doc_sections(file_id)',
       'CREATE INDEX IF NOT EXISTS idx_ds_parent ON doc_sections(parent_id)',
@@ -475,6 +480,7 @@ function runMigrations() {
     { to: 20, run: runMigrationV20 },
     { to: 21, run: runMigrationV21 },
     { to: 22, run: runMigrationV22 },
+    { to: 23, run: runMigrationV23 },
   ];
 
   const fromVersion = version;
@@ -1350,6 +1356,25 @@ function runMigrationV22() {
     });
   } catch (e) {
     errors.push(`V22: ${e.message}`);
+  }
+  return errors;
+}
+
+function runMigrationV23() {
+  const errors = [];
+  try {
+    withTransaction(() => {
+      sqlRaw(`CREATE TABLE IF NOT EXISTS repo_index_locks (
+        repo_name   TEXT PRIMARY KEY,
+        holder_id   TEXT NOT NULL,
+        host        TEXT NOT NULL DEFAULT '',
+        acquired_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )`);
+      sqlRaw('CREATE INDEX IF NOT EXISTS idx_repo_index_locks_acquired ON repo_index_locks(acquired_at)');
+      sqlRaw('PRAGMA user_version = 23');
+    });
+  } catch (e) {
+    errors.push(`V23: ${e.message}`);
   }
   return errors;
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,15 +89,35 @@ LaPis supports tool access tiers to control which commands are available to the 
 The optional HTTP server can be started via the `serve` command:
 
 ```bash
-node memory-store.js serve [--host HOST] [--port PORT]
+node memory-store.js serve [--host HOST] [--port PORT] [--api-key KEY]
 ```
 
-| Option   | Default       | Description                                         |
-| -------- | ------------- | --------------------------------------------------- |
-| `--host` | `127.0.0.1`   | Bind address. Use `0.0.0.0` to expose on network (prints warning). |
-| `--port` | `9100`        | Port number.                                        |
+| Option      | Default     | Description                                                                 |
+| ----------- | ----------- | --------------------------------------------------------------------------- |
+| `--host`    | `127.0.0.1` | Bind address. Use `0.0.0.0` or `::` to expose on the network.               |
+| `--port`    | `9100`      | Port number.                                                                |
+| `--api-key` | (unset)     | Require `x-api-key` or `Authorization: Bearer` on all routes except `/health`. |
 
-Binding to `0.0.0.0` exposes memory APIs on your network. Use only on trusted networks or behind a proxy.
+### HTTP authentication
+
+When an API key is configured, every route except `GET /health` requires one of:
+
+- Header: `x-api-key: <your-key>`
+- Header: `Authorization: Bearer <your-key>`
+
+Configure the key via (first match wins):
+
+1. CLI flag: `--api-key`
+2. Environment variable: `LAPIS_HTTP_API_KEY`
+3. Config file: `http_api_key` in `~/.pi/memory/config.jsonc`
+
+**Security defaults:**
+
+- `127.0.0.1` without a key remains open to local processes (intentional for single-user dev).
+- Binding to `0.0.0.0` or `::` **without** an API key is refused at startup.
+- When exposed on the network, always set an API key or place the server behind a reverse proxy with auth.
+
+Binding to an unrestricted address exposes memory APIs on your network. Use only on trusted networks or behind a proxy.
 
 ## Claude Code bridge configuration
 

--- a/extensions/memory-layer/hooks/session-lifecycle.ts
+++ b/extensions/memory-layer/hooks/session-lifecycle.ts
@@ -186,10 +186,10 @@ export function registerSessionShutdown(pi: ExtensionAPI, deps: SessionDeps) {
     };
 
     if (isQuit) {
-      // Fire-and-forget: let Pi exit immediately. Give the in-process gateway
-      // a short grace window to flush the cheap deletes (no VACUUM on most
-      // exits thanks to the session-count gate), but never block on it.
-      void runShutdownWork();
+      await Promise.race([
+        runShutdownWork(),
+        new Promise((resolve) => setTimeout(resolve, 2000)),
+      ]);
     } else {
       // Reload / new / resume / fork: the next session needs this data in place.
       await runShutdownWork();

--- a/extensions/memory-layer/hooks/tool-guardrails.ts
+++ b/extensions/memory-layer/hooks/tool-guardrails.ts
@@ -81,9 +81,7 @@ export function registerToolGuardrails(pi: ExtensionAPI, deps: GuardrailsDeps) {
       if (RAW_CODE_DISCOVERY_RE.test(cmd)) {
         const repos = await deps.getKnownRepos();
         const resolvedCwd = path.resolve(process.cwd());
-        const matchedRepo =
-          repos.find((r) => resolvedCwd.startsWith(path.resolve(r.path))) ||
-          repos.find((r) => deps.state.currentProject?.toLowerCase() === r.name.toLowerCase());
+        const matchedRepo = repos.find((r) => resolvedCwd.startsWith(path.resolve(r.path)));
         if (matchedRepo) {
           // Allow grep/rg/etc. When they are only filtering another command's stdout,
           // Such as `npx oxlint 2>&1 | grep -i unused`.

--- a/extensions/memory-layer/hooks/trust-sync.ts
+++ b/extensions/memory-layer/hooks/trust-sync.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { createGitTrustSyncAdapter } from '../../../src/trust-sync/change-detector';
+import { matchesGitTrustOperation } from '../../../src/hooks-engine/git-trust.js';
 import { getKnownRepos } from '../host/project-detector';
 import { mem } from '../host/memory-client';
 import { state } from '../state';
@@ -15,7 +16,7 @@ export function registerTrustSync(pi: ExtensionAPI, deps: TrustSyncDeps) {
     if (event.toolName === 'bash') {
       const input = event.input as { command?: string };
       const cmd = input?.command || '';
-      if (/\bgit(?:\s+-C\s+\S+)?\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/.test(cmd) && deps.state.currentProject) {
+      if (matchesGitTrustOperation(cmd) && deps.state.currentProject) {
         const repos = await deps.getKnownRepos();
         const repo = repos.find((r) => r.name.toLowerCase() === deps.state.currentProject!.toLowerCase());
         if (repo) {

--- a/extensions/memory-layer/hooks/trust-sync.ts
+++ b/extensions/memory-layer/hooks/trust-sync.ts
@@ -15,7 +15,7 @@ export function registerTrustSync(pi: ExtensionAPI, deps: TrustSyncDeps) {
     if (event.toolName === 'bash') {
       const input = event.input as { command?: string };
       const cmd = input?.command || '';
-      if (/\bgit\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/.test(cmd) && deps.state.currentProject) {
+      if (/\bgit(?:\s+-C\s+\S+)?\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/.test(cmd) && deps.state.currentProject) {
         const repos = await deps.getKnownRepos();
         const repo = repos.find((r) => r.name.toLowerCase() === deps.state.currentProject!.toLowerCase());
         if (repo) {

--- a/schema.sql
+++ b/schema.sql
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS observations (
   project    TEXT,
   scope      TEXT    NOT NULL DEFAULT 'project',
   topic_key  TEXT,
+  expires_at TEXT,
   created_at TEXT    NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT    NOT NULL DEFAULT (datetime('now')),
   deleted_at TEXT
@@ -45,6 +46,7 @@ CREATE INDEX IF NOT EXISTS idx_obs_scope     ON observations(scope);
 CREATE INDEX IF NOT EXISTS idx_obs_topic    ON observations(topic_key, project, scope, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_obs_created  ON observations(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_obs_deleted  ON observations(deleted_at);
+CREATE INDEX IF NOT EXISTS idx_obs_expires ON observations(expires_at) WHERE expires_at IS NOT NULL;
 
 -- FTS5 for observations
 CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
@@ -209,6 +211,22 @@ CREATE TABLE IF NOT EXISTS code_repos (
   current_branch TEXT,
   base_head     TEXT
 );
+
+CREATE TABLE IF NOT EXISTS index_jobs (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  repo_name           TEXT NOT NULL,
+  mode                TEXT NOT NULL DEFAULT 'full',
+  status              TEXT NOT NULL DEFAULT 'pending',
+  files_total         INTEGER NOT NULL DEFAULT 0,
+  files_done          INTEGER NOT NULL DEFAULT 0,
+  current_file        TEXT,
+  language_breakdown  TEXT NOT NULL DEFAULT '{}',
+  started_at          TEXT NOT NULL DEFAULT (datetime('now')),
+  completed_at        TEXT,
+  error               TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_index_jobs_status ON index_jobs(status);
+CREATE INDEX IF NOT EXISTS idx_index_jobs_repo ON index_jobs(repo_name, started_at DESC);
 
 -- ═══════════════════════════════════════════════════════════
 -- CODE-INDEX REPOSITORY: CODE FILES  (v3 — raw content + mtime tracking)

--- a/schema.sql
+++ b/schema.sql
@@ -228,6 +228,14 @@ CREATE TABLE IF NOT EXISTS index_jobs (
 CREATE INDEX IF NOT EXISTS idx_index_jobs_status ON index_jobs(status);
 CREATE INDEX IF NOT EXISTS idx_index_jobs_repo ON index_jobs(repo_name, started_at DESC);
 
+CREATE TABLE IF NOT EXISTS repo_index_locks (
+  repo_name   TEXT PRIMARY KEY,
+  holder_id   TEXT NOT NULL,
+  host        TEXT NOT NULL DEFAULT '',
+  acquired_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_repo_index_locks_acquired ON repo_index_locks(acquired_at);
+
 -- ═══════════════════════════════════════════════════════════
 -- CODE-INDEX REPOSITORY: CODE FILES  (v3 — raw content + mtime tracking)
 -- ═══════════════════════════════════════════════════════════

--- a/src/claude-code/handlers/post-tool-use.js
+++ b/src/claude-code/handlers/post-tool-use.js
@@ -34,7 +34,7 @@ const { CODE_EXTENSIONS } = require('../../hooks-engine/guardrail-utils');
 const { addNormalized } = require('../file-keys');
 const { postToolRole } = require('../tool-map');
 
-const GIT_TRUST_OP_RE = /\bgit(?:\s+-C\s+\S+)?\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/;
+const { matchesGitTrustOperation, GIT_TRUST_OP_RE } = require('../../hooks-engine/git-trust');
 // Harvest relative code paths from a memory-code response (parity with the Pi
 // tool_result handler in tool-guardrails.ts). The extension alternation is the
 // same list SPECIFIC_CODE_FILE_RE uses so the harvest never lags the
@@ -103,7 +103,7 @@ function consumeRecall(state, ids) {
  */
 async function gitTrustSync({ input, dispatch, repos, state, cwd }) {
   const cmd = typeof input.command === 'string' ? input.command : '';
-  if (!cmd || !GIT_TRUST_OP_RE.test(cmd)) {
+  if (!cmd || !matchesGitTrustOperation(cmd)) {
     return;
   }
   const repo = resolveIndexedRepo(path.resolve(cwd), repos, state.currentProject);

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -1013,7 +1013,6 @@ async function indexRepository(deps, repoPath, repoName) {
     });
     const derivedT0 = Date.now();
     const headCommit = getHeadCommit(absPath);
-    repository.updateRepoStats({ repoId, headCommit, currentBranch: getCurrentBranch(absPath), baseHead: headCommit });
     let derived;
     try {
       derived = await derivedPhase(db, repoId, args, files.length, parseResult.fileCount, parseResult.symbolCount);
@@ -1031,6 +1030,12 @@ async function indexRepository(deps, repoPath, repoName) {
         symbols_extracted: parseResult.symbolCount,
       };
     }
+    repository.updateRepoStats({
+      repoId,
+      headCommit,
+      currentBranch: getCurrentBranch(absPath),
+      baseHead: headCommit,
+    });
     const derivedMs = Date.now() - derivedT0;
 
     const totalMs = Date.now() - t0;
@@ -1341,6 +1346,14 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
 
   if (changedRecords.length === 0 && unchanged === totalFiles && staleFiles.length === 0) {
     const totalMs = Date.now() - t0;
+    if (gitDelta?.currentHead && gitDelta.currentHead !== existing.head_commit) {
+      repository.updateRepoStats({
+        repoId: existing.id,
+        headCommit: gitDelta.currentHead,
+        currentBranch: getCurrentBranch(existing.path),
+        baseHead: existing.head_commit || null,
+      });
+    }
     const existingSymbolCount = (() => {
       try {
         const r = db.prepare('SELECT symbol_count FROM code_repos WHERE id = ?').get(existing.id);
@@ -1394,12 +1407,6 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
     step: 'derived-indexes',
     message: 'Step 5/5: rebuilding derived indexes (imports, calls, complexity)...',
   });
-  repository.updateRepoStats({
-    repoId: existing.id,
-    headCommit: gitDelta?.currentHead || getHeadCommit(existing.path),
-    currentBranch: getCurrentBranch(existing.path),
-    baseHead: existing.head_commit || null,
-  });
   const derived = rebuildDerivedIndexes(
     db,
     existing.id,
@@ -1410,6 +1417,12 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
     changedFileIds,
     deletedFileIds,
   );
+  repository.updateRepoStats({
+    repoId: existing.id,
+    headCommit: gitDelta?.currentHead || getHeadCommit(existing.path),
+    currentBranch: getCurrentBranch(existing.path),
+    baseHead: existing.head_commit || null,
+  });
 
   const totalMs = Date.now() - t0;
   emitProgress(

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -6,6 +6,8 @@ const { hashContent } = require('../../utils');
 const { createCodeIndexRepository } = require('./repos');
 const { scanRepository } = require('./scanner');
 const { SKIP_FILE_RE } = require('./scanner');
+const { resolveRepoScopedPath } = require('./path-guards');
+const { withRepoIndexLock } = require('./repo-lock');
 const { createParserRegistry, getLanguageForFile } = require('./parser-registry');
 const { extractSymbolsSplit, normalizeSymbolHot } = require('./symbol-extractor');
 const {
@@ -160,7 +162,11 @@ function parseChangedPathsInput(input, repoPath) {
       // oxlint-disable-next-line no-continue
       continue;
     }
-    const abs = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(repoPath, filePath);
+    const abs = resolveRepoScopedPath(repoPath, filePath);
+    if (!abs) {
+      // oxlint-disable-next-line no-continue
+      continue;
+    }
     if (/delete|remove|unlink/i.test(status) || !fs.existsSync(abs)) {
       deleted.add(abs);
     } else {
@@ -589,6 +595,7 @@ async function parsePhase(files, deps, repoId, args) {
   let symbolCount = 0;
   let fileCount = 0;
   const skipped = [];
+  let fullRebuildPrepared = false;
 
   function validateSymbols(record, symbols) {
     if (symbols.length === 0 && record.content.trim().length > 0) {
@@ -821,8 +828,18 @@ async function parsePhase(files, deps, repoId, args) {
       };
 
       if (typeof repository.withTransaction === 'function') {
-        repository.withTransaction(() => writeRecords(true));
+        repository.withTransaction(() => {
+          if (!fullRebuildPrepared && typeof args.fullRebuildPrepare === 'function') {
+            args.fullRebuildPrepare();
+            fullRebuildPrepared = true;
+          }
+          writeRecords(true);
+        });
       } else {
+        if (!fullRebuildPrepared && typeof args.fullRebuildPrepare === 'function') {
+          args.fullRebuildPrepare();
+          fullRebuildPrepared = true;
+        }
         writeRecords(false);
       }
     }
@@ -848,129 +865,130 @@ async function derivedPhase(db, repoId, args, totalFiles, fileCount, symbolCount
 }
 
 async function indexRepository(deps, repoPath, repoName) {
-  const { db } = deps;
-  const args = deps.args || {};
-  const repository = deps.repository || createCodeIndexRepository(require('../../db'));
-  const registry = deps.parserRegistry || createParserRegistry();
-  const t0 = Date.now();
+  return withRepoIndexLock(repoName, async () => {
+    const { db } = deps;
+    const args = deps.args || {};
+    const repository = deps.repository || createCodeIndexRepository(require('../../db'));
+    const registry = deps.parserRegistry || createParserRegistry();
+    const t0 = Date.now();
 
-  if (!(await registry.ensureReady())) {
-    return {
-      error: `WASM tree-sitter parser not available. Run: cd ${path.resolve(__dirname, '..', '..')} && npm install web-tree-sitter`,
-    };
-  }
+    if (!(await registry.ensureReady())) {
+      return {
+        error: `WASM tree-sitter parser not available. Run: cd ${path.resolve(__dirname, '..', '..')} && npm install web-tree-sitter`,
+      };
+    }
 
-  emitProgress(args, 'init', { step: 'prepare-parser', message: 'Step 1/5: preparing tree-sitter parsers...' });
-  emitProgress(args, 'discovery', { step: 'discover-files', message: 'Step 2/5: discovering code files to index...' });
-  const scanResult = await scanPhase(repoPath, {}, args);
-  if (scanResult.error) {
-    return { error: scanResult.error };
-  }
-  const { files, absPath, skipReport } = scanResult;
-  const scanMs = Date.now() - t0;
-  const skipSummary = formatSkipReport(skipReport);
+    emitProgress(args, 'init', { step: 'prepare-parser', message: 'Step 1/5: preparing tree-sitter parsers...' });
+    emitProgress(args, 'discovery', { step: 'discover-files', message: 'Step 2/5: discovering code files to index...' });
+    const scanResult = await scanPhase(repoPath, {}, args);
+    if (scanResult.error) {
+      return { error: scanResult.error };
+    }
+    const { files, absPath, skipReport } = scanResult;
+    const scanMs = Date.now() - t0;
+    const skipSummary = formatSkipReport(skipReport);
 
-  emitProgress(args, 'discovery', {
-    message: `Found ${files.length} code files to index (${scanMs}ms)`,
-    files_total: files.length,
-    detail: skipSummary,
-  });
-  if (skipSummary) {
-    emitProgress(args, 'discovery', { message: skipSummary });
-  }
+    emitProgress(args, 'discovery', {
+      message: `Found ${files.length} code files to index (${scanMs}ms)`,
+      files_total: files.length,
+      detail: skipSummary,
+    });
+    if (skipSummary) {
+      emitProgress(args, 'discovery', { message: skipSummary });
+    }
 
-  const repoId = repository.upsertRepo({ name: repoName, path: absPath });
-  emitProgress(args, 'reset-index', {
-    step: 'clear-index',
-    message: `Step 3/5: clearing existing index rows for ${repoName}...`,
-  });
-  const clearT0 = Date.now();
-  const clearTotals = repository.clearRepoIndex(repoId, {
-    onProgress: (progress) => {
-      emitProgress(args, 'reset-index', {
-        step: 'clear-index',
-        message: `Step 3/5: ${progress.message}`,
-        rows_deleted: progress.deleted,
+    const repoId = repository.upsertRepo({ name: repoName, path: absPath });
+    emitProgress(args, 'reset-index', {
+      step: 'clear-index',
+      message: `Step 3/5: will clear existing index rows for ${repoName} immediately before writing rebuilt data...`,
+    });
+
+    emitProgress(args, 'parsing', {
+      step: 'parse-and-store',
+      message: `Step 4/5: reading files, extracting symbols, and storing index rows for ${files.length} files...`,
+      files_total: files.length,
+    });
+    const parseT0 = Date.now();
+    let parseResult;
+    try {
+      parseResult = await parsePhase(files, { parserRegistry: registry, repository }, repoId, {
+        ...args,
+        repoRoot: absPath,
+        fullRebuildPrepare: () => {
+          const clearT0 = Date.now();
+          const clearTotals = repository.clearRepoIndex(repoId, {
+            onProgress: (progress) => {
+              emitProgress(args, 'reset-index', {
+                step: 'clear-index',
+                message: `Step 3/5: ${progress.message}`,
+                rows_deleted: progress.deleted,
+              });
+            },
+          });
+          emitProgress(args, 'reset-index', {
+            step: 'clear-index',
+            message: `Step 3/5: cleared existing index rows for ${repoName} (${Date.now() - clearT0}ms)`,
+            clear_totals: clearTotals,
+          });
+        },
       });
-    },
-  });
-  emitProgress(args, 'reset-index', {
-    step: 'clear-index',
-    message: `Step 3/5: cleared existing index rows for ${repoName} (${Date.now() - clearT0}ms)`,
-    clear_totals: clearTotals,
-  });
+    } catch (parseError) {
+      console.error(`[indexer] indexRepository: parsePhase threw before index write completed: ${parseError.message}`);
+      emitProgress(args, 'error', {
+        step: 'parse-failed',
+        message: `Fatal: parse phase failed before index write: ${parseError.message}. Existing index preserved.`,
+      });
+      return {
+        error: `Index rebuild failed during parse phase: ${parseError.message}. The existing index for "${repoName}" was preserved.`,
+        repo: repoName,
+      };
+    }
+    const parseMs = Date.now() - parseT0;
 
-  emitProgress(args, 'parsing', {
-    step: 'parse-and-store',
-    message: `Step 4/5: reading files, extracting symbols, and storing index rows for ${files.length} files...`,
-    files_total: files.length,
-  });
-  const parseT0 = Date.now();
-  let parseResult;
-  try {
-    parseResult = await parsePhase(files, { parserRegistry: registry, repository }, repoId, {
-      ...args,
-      repoRoot: absPath,
+    emitProgress(args, 'analysis', {
+      step: 'derived-indexes',
+      message: 'Step 5/5: building derived indexes (imports, calls, complexity)...',
     });
-  } catch (parseError) {
-    console.error(
-      `[indexer] indexRepository: parsePhase threw after clearRepoIndex - repo may be empty: ${parseError.message}`,
-    );
-    emitProgress(args, 'error', {
-      step: 'parse-failed',
-      message: `Fatal: parse phase failed after clearing index: ${parseError.message}. Run reindex again to restore.`,
-    });
-    // Return error so caller knows index is empty
-    return {
-      error: `Index rebuild failed during parse phase: ${parseError.message}. The index for "${repoName}" is now empty. Please re-run reindex to restore it.`,
+    const derivedT0 = Date.now();
+    const headCommit = getHeadCommit(absPath);
+    repository.updateRepoStats({ repoId, headCommit, currentBranch: getCurrentBranch(absPath), baseHead: headCommit });
+    const derived = await derivedPhase(db, repoId, args, files.length, parseResult.fileCount, parseResult.symbolCount);
+    const derivedMs = Date.now() - derivedT0;
+
+    const totalMs = Date.now() - t0;
+    const result = {
+      success: true,
       repo: repoName,
-      files_cleared: clearTotals,
+      path: absPath,
+      files_indexed: parseResult.fileCount,
+      symbols_extracted: parseResult.symbolCount,
+      files_skipped: parseResult.skipped.length,
+      import_edges: derived.importEdges,
+      call_edges: derived.callEdges,
+      complexity_symbols: derived.complexityCount,
+      name: repoName,
+      file_count: parseResult.fileCount,
+      symbol_count: parseResult.symbolCount,
+      skipped: parseResult.skipped,
+      skip_report: skipReport,
+      timing_ms: { scan: scanMs, parse: parseMs, derived: derivedMs, total: totalMs },
     };
-  }
-  const parseMs = Date.now() - parseT0;
 
-  emitProgress(args, 'analysis', {
-    step: 'derived-indexes',
-    message: 'Step 5/5: building derived indexes (imports, calls, complexity)...',
+    emitProgress(
+      args,
+      'done',
+      {
+        message: `Done: ${parseResult.fileCount} files, ${parseResult.symbolCount} symbols (${(totalMs / 1000).toFixed(1)}s)`,
+      },
+      { files_total: files.length, files_done: parseResult.fileCount, symbols: parseResult.symbolCount },
+    );
+    return result;
   });
-  const derivedT0 = Date.now();
-  const headCommit = getHeadCommit(absPath);
-  repository.updateRepoStats({ repoId, headCommit, currentBranch: getCurrentBranch(absPath), baseHead: headCommit });
-  const derived = await derivedPhase(db, repoId, args, files.length, parseResult.fileCount, parseResult.symbolCount);
-  const derivedMs = Date.now() - derivedT0;
-
-  const totalMs = Date.now() - t0;
-  const result = {
-    success: true,
-    repo: repoName,
-    path: absPath,
-    files_indexed: parseResult.fileCount,
-    symbols_extracted: parseResult.symbolCount,
-    files_skipped: parseResult.skipped.length,
-    import_edges: derived.importEdges,
-    call_edges: derived.callEdges,
-    complexity_symbols: derived.complexityCount,
-    name: repoName,
-    file_count: parseResult.fileCount,
-    symbol_count: parseResult.symbolCount,
-    skipped: parseResult.skipped,
-    skip_report: skipReport,
-    timing_ms: { scan: scanMs, parse: parseMs, derived: derivedMs, total: totalMs },
-  };
-
-  emitProgress(
-    args,
-    'done',
-    {
-      message: `Done: ${parseResult.fileCount} files, ${parseResult.symbolCount} symbols (${(totalMs / 1000).toFixed(1)}s)`,
-    },
-    { files_total: files.length, files_done: parseResult.fileCount, symbols: parseResult.symbolCount },
-  );
-  return result;
 }
 
 async function reindexRepository(deps, repo, mode = 'incremental') {
-  const { db } = deps;
+  return withRepoIndexLock(repo, async () => {
+    const { db } = deps;
   const args = deps.args || {};
   const repository = deps.repository || createCodeIndexRepository(require('../../db'));
   const registry = deps.parserRegistry || createParserRegistry();
@@ -1003,6 +1021,7 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
   const gitChangedFiles = gitDelta
     ? gitDelta.changed.filter(
         (filePath) =>
+          resolveRepoScopedPath(existing.path, filePath) &&
           fs.existsSync(filePath) &&
           registry.canParseFile(filePath) &&
           !SKIP_FILE_RE.test(filePath.replace(/\\/g, '/')),
@@ -1349,6 +1368,7 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
     skip_report: skipReport,
     timing_ms: { total: totalMs },
   };
+  });
 }
 
 async function getCodeRepoHealth(deps, repo) {

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -1346,10 +1346,11 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
 
   if (changedRecords.length === 0 && unchanged === totalFiles && staleFiles.length === 0) {
     const totalMs = Date.now() - t0;
-    if (gitDelta?.currentHead && gitDelta.currentHead !== existing.head_commit) {
+    const currentHead = gitDelta?.currentHead || getHeadCommit(existing.path);
+    if (currentHead && currentHead !== existing.head_commit) {
       repository.updateRepoStats({
         repoId: existing.id,
-        headCommit: gitDelta.currentHead,
+        headCommit: currentHead,
         currentBranch: getCurrentBranch(existing.path),
         baseHead: existing.head_commit || null,
       });
@@ -1386,8 +1387,8 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
       symbols_extracted: 0,
       strategy: gitDelta ? 'git-diff' : 'scan-hash',
       derived_scope: 'none',
-      git_base: gitDelta ? existing.head_commit : null,
-      git_head: gitDelta ? gitDelta.currentHead : null,
+      git_base: existing.head_commit || null,
+      git_head: gitDelta?.currentHead || getHeadCommit(existing.path),
       git_renames: gitDelta ? gitDelta.renamed : [],
       import_edges: 0,
       call_edges: 0,

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -151,6 +151,7 @@ function parseChangedPathsInput(input, repoPath) {
   }
   const changed = new Set();
   const deleted = new Set();
+  const rejected = [];
   for (const entry of entries) {
     let status = 'modified';
     let filePath = entry;
@@ -162,7 +163,7 @@ function parseChangedPathsInput(input, repoPath) {
       // oxlint-disable-next-line no-continue
       continue;
     }
-    const abs = resolveRepoScopedPath(repoPath, filePath);
+    const abs = resolveRepoScopedPath(repoPath, filePath, rejected);
     if (!abs) {
       // oxlint-disable-next-line no-continue
       continue;
@@ -176,6 +177,7 @@ function parseChangedPathsInput(input, repoPath) {
   return {
     changed: [...changed],
     deleted: [...deleted],
+    rejected,
     renamed: [],
     currentHead: getHeadCommit(repoPath),
     source: 'changed-paths',
@@ -565,6 +567,90 @@ async function scanPhase(repoPath, options, args) {
   return { files: scanResult.files, absPath, skipReport: scanResult.skipReport };
 }
 
+function commitParsedBatch(repository, repoId, parsedRecords, ctx) {
+  const { args, repoRoot, registry, scopeDb, insideTransaction = false } = ctx;
+  const batchSymbols = [];
+
+  for (const { record, hotSymbols, coldSymbols, tree: parsedTree } of parsedRecords) {
+    try {
+      const fileId = repository.insertFile(fileRecordToParams(repoId, record));
+      for (let si = 0; si < hotSymbols.length; si++) {
+        const hot = hotSymbols[si];
+        const cold = coldSymbols[si] || {};
+        batchSymbols.push({
+          repoId,
+          fileId,
+          filePath: record.filePath,
+          name: hot.name,
+          kind: hot.kind,
+          qualifiedName: hot.qualified_name,
+          startLine: hot.start_line,
+          endLine: hot.end_line,
+          startByte: hot.start_byte,
+          endByte: hot.end_byte,
+          signature: cold.signature || '',
+          docstring: cold.docstring || '',
+          bodyPreview: cold.body_preview || '',
+          language: cold.language || '',
+          parentName: cold.parent_name || '',
+          stableSymbolId: cold.stable_symbol_id || '',
+          contentHash: cold.content_hash || '',
+          summary: cold.summary || '',
+          decoratorsJson: cold.decorators_json || '[]',
+          keywordsJson: cold.keywords_json || '[]',
+          callReferencesJson: cold.call_references_json || '[]',
+          ecosystemContext: cold.ecosystem_context || '',
+        });
+      }
+      ctx.symbolCount += hotSymbols.length;
+      ctx.fileCount++;
+
+      try {
+        const scopeBuilder = require('./scope-builder').getScopeBuilder;
+        const builder = scopeBuilder(record.filePath);
+        if (builder && scopeDb) {
+          let tree = parsedTree || null;
+          if (!tree) {
+            const fallback = registry.parseTree(record.filePath, record.content);
+            tree = fallback ? fallback.tree : null;
+          }
+          if (tree) {
+            const scopeBindings = builder(tree, record.content, record.filePath);
+            if (scopeBindings.length > 0) {
+              insertScopeBindings(scopeDb, repoId, fileId, scopeBindings);
+            }
+            tree.delete();
+          }
+        }
+      } catch {}
+
+      if (args && shouldEmitFileProgress(ctx.fileCount, ctx.totalFiles)) {
+        emitProgress(
+          args,
+          'parsing',
+          {
+            step: 'store-index',
+            current_file: progressPath(record.filePath, repoRoot),
+            message: `Stored index ${ctx.fileCount}/${ctx.totalFiles}: ${progressPath(record.filePath, repoRoot)} (${hotSymbols.length} symbols)`,
+          },
+          { files_total: ctx.totalFiles, files_done: ctx.fileCount, symbols: ctx.symbolCount },
+        );
+      }
+    } catch (e) {
+      ctx.skipped.push({ file: record.filePath, error: e.message });
+      recordDiagnostic(repository, repoId, record, 'error', e.message, 0);
+    }
+  }
+
+  if (batchSymbols.length > 0) {
+    if (insideTransaction) {
+      repository.insertSymbolBulk(batchSymbols);
+    } else {
+      repository.insertSymbolBatch(batchSymbols);
+    }
+  }
+}
+
 async function parsePhase(files, deps, repoId, args) {
   const registry = deps.parserRegistry || createParserRegistry();
   const repository = deps.repository || createCodeIndexRepository(require('../../db'));
@@ -595,7 +681,9 @@ async function parsePhase(files, deps, repoId, args) {
   let symbolCount = 0;
   let fileCount = 0;
   const skipped = [];
-  let fullRebuildPrepared = false;
+  const deferredBatches = [];
+  const deferIndexWrites = Boolean(args.deferIndexWrites);
+  const scopeDb = args.scopeDb || null;
 
   function validateSymbols(record, symbols) {
     if (symbols.length === 0 && record.content.trim().length > 0) {
@@ -725,122 +813,47 @@ async function parsePhase(files, deps, repoId, args) {
         args,
         'parsing',
         {
-          step: 'store-index',
+          step: deferIndexWrites ? 'buffer-index' : 'store-index',
           current_file: parsedRecords[0] ? progressPath(parsedRecords[0].record.filePath, repoRoot) : firstBatchPath,
-          message: `Storing index records for batch ${batchNum}/${totalBatches}: ${parsedRecords.length} files`,
+          message: deferIndexWrites
+            ? `Buffered index records for batch ${batchNum}/${totalBatches}: ${parsedRecords.length} files`
+            : `Storing index records for batch ${batchNum}/${totalBatches}: ${parsedRecords.length} files`,
         },
         { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
       );
 
-      // PERF: AoS→SoA split (issue #130) — hot loop iterates compact 8-field objects;
-      // Cold data (JSON blobs, hashes, summaries) is read from a parallel array only
-      // When building the insert payload. Do NOT merge hot/cold back into a single
-      // Object before this loop; the split exists to reduce cache-line waste during
-      // The tight file×symbol iteration.
-      const batchSymbols = [];
-      const writeRecords = (insideTransaction = false) => {
-        for (const { record, hotSymbols, coldSymbols, tree: parsedTree } of parsedRecords) {
-          try {
-            const fileId = repository.insertFile(fileRecordToParams(repoId, record));
-            for (let si = 0; si < hotSymbols.length; si++) {
-              const hot = hotSymbols[si];
-              const cold = coldSymbols[si] || {};
-              batchSymbols.push({
-                repoId,
-                fileId,
-                filePath: record.filePath,
-                name: hot.name,
-                kind: hot.kind,
-                qualifiedName: hot.qualified_name,
-                startLine: hot.start_line,
-                endLine: hot.end_line,
-                startByte: hot.start_byte,
-                endByte: hot.end_byte,
-                signature: cold.signature || '',
-                docstring: cold.docstring || '',
-                bodyPreview: cold.body_preview || '',
-                language: cold.language || '',
-                parentName: cold.parent_name || '',
-                stableSymbolId: cold.stable_symbol_id || '',
-                contentHash: cold.content_hash || '',
-                summary: cold.summary || '',
-                decoratorsJson: cold.decorators_json || '[]',
-                keywordsJson: cold.keywords_json || '[]',
-                callReferencesJson: cold.call_references_json || '[]',
-                ecosystemContext: cold.ecosystem_context || '',
-              });
-            }
-            symbolCount += hotSymbols.length;
-            fileCount++;
-
-            // ── Scope bindings extraction (v10) ──────────────
-            // Build scope bindings from the same tree-sitter AST.
-            try {
-              const scopeBuilder = require('./scope-builder').getScopeBuilder;
-              const builder = scopeBuilder(record.filePath);
-              if (builder) {
-                let tree = parsedTree || null;
-                if (!tree) {
-                  const fallback = registry.parseTree(record.filePath, record.content);
-                  tree = fallback ? fallback.tree : null;
-                }
-                if (tree) {
-                  const scopeBindings = builder(tree, record.content, record.filePath);
-                  if (scopeBindings.length > 0) {
-                    insertScopeBindings(db, repoId, fileId, scopeBindings);
-                  }
-                  tree.delete();
-                }
-              }
-            } catch {
-              // Scope binding extraction is best-effort; don't fail the batch
-            }
-            if (shouldEmitFileProgress(fileCount, totalFiles)) {
-              emitProgress(
-                args,
-                'parsing',
-                {
-                  step: 'store-index',
-                  current_file: progressPath(record.filePath, repoRoot),
-                  message: `Stored index ${fileCount}/${totalFiles}: ${progressPath(record.filePath, repoRoot)} (${hotSymbols.length} symbols)`,
-                },
-                { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
-              );
-            }
-          } catch (e) {
-            skipped.push({ file: record.filePath, error: e.message });
-            recordDiagnostic(repository, repoId, record, 'error', e.message, 0);
-          }
+      if (deferIndexWrites) {
+        for (const entry of parsedRecords) {
+          symbolCount += entry.hotSymbols.length;
+          fileCount++;
         }
+        deferredBatches.push(parsedRecords);
+        // oxlint-disable-next-line no-continue
+        continue;
+      }
 
-        if (batchSymbols.length > 0) {
-          // PERF: Use prepared-statement bulk insert (issue #139).
-          // InsertSymbolBulk reuses a single prepared statement for all symbols,
-          // Avoiding 10K+ redundant prepare() calls per batch. The transactional
-          // Path already has an outer withTransaction(), so insertSymbolBulk skips
-          // Its own transaction wrapper. Do NOT revert to per-symbol insertSymbol().
-          if (insideTransaction) {
-            repository.insertSymbolBulk(batchSymbols);
-          } else {
-            repository.insertSymbolBatch(batchSymbols);
-          }
-        }
+      const writeCtx = {
+        fileCount,
+        symbolCount,
+        skipped,
+        totalFiles,
+        args,
+        repoRoot,
+        registry,
+        scopeDb,
+        insideTransaction: false,
       };
-
       if (typeof repository.withTransaction === 'function') {
         repository.withTransaction(() => {
-          if (!fullRebuildPrepared && typeof args.fullRebuildPrepare === 'function') {
-            args.fullRebuildPrepare();
-            fullRebuildPrepared = true;
-          }
-          writeRecords(true);
+          writeCtx.insideTransaction = true;
+          commitParsedBatch(repository, repoId, parsedRecords, writeCtx);
+          fileCount = writeCtx.fileCount;
+          symbolCount = writeCtx.symbolCount;
         });
       } else {
-        if (!fullRebuildPrepared && typeof args.fullRebuildPrepare === 'function') {
-          args.fullRebuildPrepare();
-          fullRebuildPrepared = true;
-        }
-        writeRecords(false);
+        commitParsedBatch(repository, repoId, parsedRecords, writeCtx);
+        fileCount = writeCtx.fileCount;
+        symbolCount = writeCtx.symbolCount;
       }
     }
   } catch (parseError) {
@@ -857,7 +870,7 @@ async function parsePhase(files, deps, repoId, args) {
     }
   }
 
-  return { fileCount, symbolCount, skipped };
+  return { fileCount, symbolCount, skipped, deferredBatches };
 }
 
 async function derivedPhase(db, repoId, args, totalFiles, fileCount, symbolCount, changedFileIds, deletedFileIds) {
@@ -914,32 +927,60 @@ async function indexRepository(deps, repoPath, repoName) {
       parseResult = await parsePhase(files, { parserRegistry: registry, repository }, repoId, {
         ...args,
         repoRoot: absPath,
-        fullRebuildPrepare: () => {
-          const clearT0 = Date.now();
-          const clearTotals = repository.clearRepoIndex(repoId, {
-            onProgress: (progress) => {
-              emitProgress(args, 'reset-index', {
-                step: 'clear-index',
-                message: `Step 3/5: ${progress.message}`,
-                rows_deleted: progress.deleted,
-              });
-            },
-          });
-          emitProgress(args, 'reset-index', {
-            step: 'clear-index',
-            message: `Step 3/5: cleared existing index rows for ${repoName} (${Date.now() - clearT0}ms)`,
-            clear_totals: clearTotals,
-          });
-        },
+        deferIndexWrites: true,
+        scopeDb: db,
       });
+      emitProgress(args, 'reset-index', {
+        step: 'clear-index',
+        message: `Step 3/5: committing rebuilt index for ${repoName} in a single transaction...`,
+      });
+      const writeCtx = {
+        fileCount: 0,
+        symbolCount: 0,
+        skipped: parseResult.skipped,
+        totalFiles: files.length,
+        args,
+        repoRoot: absPath,
+        registry,
+        scopeDb: db,
+        insideTransaction: true,
+      };
+      const clearT0 = Date.now();
+      let clearTotals = {};
+      repository.withTransaction(() => {
+        clearTotals = repository.clearRepoIndexCore(repoId, {
+          onProgress: (progress) => {
+            emitProgress(args, 'reset-index', {
+              step: 'clear-index',
+              message: `Step 3/5: ${progress.message}`,
+              rows_deleted: progress.deleted,
+            });
+          },
+        });
+        for (const batch of parseResult.deferredBatches) {
+          commitParsedBatch(repository, repoId, batch, writeCtx);
+        }
+      });
+      emitProgress(args, 'reset-index', {
+        step: 'clear-index',
+        message: `Step 3/5: committed rebuilt index rows for ${repoName} (${Date.now() - clearT0}ms)`,
+        clear_totals: clearTotals,
+      });
+      parseResult.fileCount = writeCtx.fileCount;
+      parseResult.symbolCount = writeCtx.symbolCount;
+      parseResult.skipped = writeCtx.skipped;
     } catch (parseError) {
-      console.error(`[indexer] indexRepository: parsePhase threw before index write completed: ${parseError.message}`);
+      const phase = parseResult ? 'commit' : 'parse';
+      console.error(`[indexer] indexRepository: ${phase} phase failed: ${parseError.message}`);
       emitProgress(args, 'error', {
-        step: 'parse-failed',
-        message: `Fatal: parse phase failed before index write: ${parseError.message}. Existing index preserved.`,
+        step: phase === 'parse' ? 'parse-failed' : 'commit-failed',
+        message:
+          phase === 'parse'
+            ? `Fatal: parse phase failed before index write: ${parseError.message}. Existing index preserved.`
+            : `Fatal: index commit failed: ${parseError.message}. Existing index preserved.`,
       });
       return {
-        error: `Index rebuild failed during parse phase: ${parseError.message}. The existing index for "${repoName}" was preserved.`,
+        error: `Index rebuild failed during ${phase} phase: ${parseError.message}. The existing index for "${repoName}" was preserved.`,
         repo: repoName,
       };
     }
@@ -1053,6 +1094,12 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
   });
   if (skipSummary) {
     emitProgress(args, 'discovery', { message: skipSummary });
+  }
+  if (gitDelta?.rejected?.length) {
+    emitProgress(args, 'discovery', {
+      message: `Skipped ${gitDelta.rejected.length} changed-path entries outside the repo or blocked as secret files`,
+      rejected_paths: gitDelta.rejected,
+    });
   }
 
   const existingFiles = new Map(repository.listFiles(existing.id).map((file) => [file.path, file]));
@@ -1367,6 +1414,7 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
     skipped,
     skip_report: skipReport,
     timing_ms: { total: totalMs },
+    ...(gitDelta?.rejected?.length ? { rejected_paths: gitDelta.rejected } : {}),
   };
   });
 }

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -160,6 +160,7 @@ function parseChangedPathsInput(input, repoPath) {
       filePath = entry.path || entry.file || entry.filePath || entry[1];
     }
     if (!filePath || typeof filePath !== 'string') {
+      rejected.push({ path: String(filePath), reason: 'invalid_path' });
       // oxlint-disable-next-line no-continue
       continue;
     }
@@ -203,6 +204,7 @@ function getGitDelta(repoPath, baseCommit) {
     const changed = new Set();
     const deleted = new Set();
     const renamed = [];
+    const rejected = [];
     for (const line of output.split('\n')) {
       const trimmed = line.trim();
       if (!trimmed) {
@@ -212,16 +214,28 @@ function getGitDelta(repoPath, baseCommit) {
       const parts = trimmed.split('\t');
       const status = parts[0];
       if (status.startsWith('D') && parts[1]) {
-        deleted.add(path.resolve(repoPath, parts[1]));
+        const abs = resolveRepoScopedPath(repoPath, parts[1], rejected);
+        if (abs) {
+          deleted.add(abs);
+        }
       } else if (status.startsWith('R') && parts[1] && parts[2]) {
-        deleted.add(path.resolve(repoPath, parts[1]));
-        changed.add(path.resolve(repoPath, parts[2]));
+        const fromAbs = resolveRepoScopedPath(repoPath, parts[1], rejected);
+        const toAbs = resolveRepoScopedPath(repoPath, parts[2], rejected);
+        if (fromAbs) {
+          deleted.add(fromAbs);
+        }
+        if (toAbs) {
+          changed.add(toAbs);
+        }
         renamed.push({ from: parts[1], to: parts[2], status });
       } else if (parts[1]) {
-        changed.add(path.resolve(repoPath, parts[1]));
+        const abs = resolveRepoScopedPath(repoPath, parts[1], rejected);
+        if (abs) {
+          changed.add(abs);
+        }
       }
     }
-    return { currentHead, changed: [...changed], deleted: [...deleted], renamed };
+    return { currentHead, changed: [...changed], deleted: [...deleted], renamed, rejected };
   } catch {
     return null;
   }
@@ -248,7 +262,10 @@ function fileRecordToParams(repoId, record) {
   };
 }
 
-function recordDiagnostic(repository, repoId, record, status, message, symbolCount = 0) {
+function recordDiagnostic(repository, repoId, record, status, message, symbolCount = 0, options = {}) {
+  if (options.defer) {
+    return;
+  }
   if (typeof repository.upsertFileDiagnostic !== 'function') {
     return;
   }
@@ -723,7 +740,9 @@ async function parsePhase(files, deps, repoId, args) {
             return await readFileRecord(fp);
           } catch (e) {
             skipped.push({ file: fp, error: e.message });
-            recordDiagnostic(repository, repoId, { filePath: fp, content: '' }, 'error', e.message, 0);
+            recordDiagnostic(repository, repoId, { filePath: fp, content: '' }, 'error', e.message, 0, {
+              defer: args.deferIndexWrites,
+            });
             return null;
           }
         }),
@@ -760,6 +779,7 @@ async function parsePhase(files, deps, repoId, args) {
                 ? 'No symbols extracted from non-empty file'
                 : '',
               symbols.length,
+              { defer: args.deferIndexWrites },
             );
             const hotSymbols = symbols.map((s) => normalizeSymbolHot(s, record.filePath));
             parsedRecords.push({ record, hotSymbols, coldSymbols: symbols, tree: null });
@@ -790,6 +810,7 @@ async function parsePhase(files, deps, repoId, args) {
             symbols.length === 0 && record.content.trim().length > 0 ? 'zero_symbols' : 'ok',
             symbols.length === 0 && record.content.trim().length > 0 ? 'No symbols extracted from non-empty file' : '',
             symbols.length,
+            { defer: args.deferIndexWrites },
           );
           parsedRecords.push({ record, hotSymbols, coldSymbols, tree });
           parsedInBatch++;
@@ -957,7 +978,7 @@ async function indexRepository(deps, repoPath, repoName) {
             });
           },
         });
-        for (const batch of parseResult.deferredBatches) {
+        for (const batch of parseResult.deferredBatches || []) {
           commitParsedBatch(repository, repoId, batch, writeCtx);
         }
       });
@@ -993,7 +1014,23 @@ async function indexRepository(deps, repoPath, repoName) {
     const derivedT0 = Date.now();
     const headCommit = getHeadCommit(absPath);
     repository.updateRepoStats({ repoId, headCommit, currentBranch: getCurrentBranch(absPath), baseHead: headCommit });
-    const derived = await derivedPhase(db, repoId, args, files.length, parseResult.fileCount, parseResult.symbolCount);
+    let derived;
+    try {
+      derived = await derivedPhase(db, repoId, args, files.length, parseResult.fileCount, parseResult.symbolCount);
+    } catch (derivedError) {
+      console.error(`[indexer] indexRepository: derived phase failed after commit: ${derivedError.message}`);
+      emitProgress(args, 'error', {
+        step: 'derived-failed',
+        message: `Symbols committed but derived indexes failed: ${derivedError.message}. Run reindex-repo to rebuild derived indexes.`,
+      });
+      return {
+        error: `Index symbols committed but derived indexes failed: ${derivedError.message}. Run reindex-repo to rebuild derived indexes.`,
+        repo: repoName,
+        partial: true,
+        files_indexed: parseResult.fileCount,
+        symbols_extracted: parseResult.symbolCount,
+      };
+    }
     const derivedMs = Date.now() - derivedT0;
 
     const totalMs = Date.now() - t0;
@@ -1097,7 +1134,7 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
   }
   if (gitDelta?.rejected?.length) {
     emitProgress(args, 'discovery', {
-      message: `Skipped ${gitDelta.rejected.length} changed-path entries outside the repo or blocked as secret files`,
+      message: `Skipped ${gitDelta.rejected.length} git/changed-path entries outside the repo or blocked as secret files`,
       rejected_paths: gitDelta.rejected,
     });
   }

--- a/src/code-index/path-guards.js
+++ b/src/code-index/path-guards.js
@@ -6,22 +6,42 @@ const { pathIsInside, SECRET_FILE_RE } = require('./scanner');
  * Resolve a changed-path entry to an absolute path inside repoRoot.
  * Returns null when the path escapes the repo or matches secret-file patterns.
  */
-function resolveRepoScopedPath(repoPath, filePath) {
+function resolveRepoScopedPath(repoPath, filePath, rejections) {
   if (!filePath || typeof filePath !== 'string') {
+    if (rejections) {
+      rejections.push({ path: filePath, reason: 'invalid_path' });
+    }
     return null;
   }
-  const absRoot = path.resolve(repoPath);
+  let absRoot;
+  try {
+    absRoot = fs.realpathSync(path.resolve(repoPath));
+  } catch {
+    if (rejections) {
+      rejections.push({ path: filePath, reason: 'repo_unavailable' });
+    }
+    return null;
+  }
   const abs = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(absRoot, filePath);
   let resolved = abs;
   try {
     resolved = fs.realpathSync(abs);
   } catch {
+    if (rejections) {
+      rejections.push({ path: filePath, reason: 'unreadable' });
+    }
     return null;
   }
   if (!pathIsInside(absRoot, resolved)) {
+    if (rejections) {
+      rejections.push({ path: filePath, reason: 'outside_repo' });
+    }
     return null;
   }
   if (SECRET_FILE_RE.test(resolved.replace(/\\/g, '/'))) {
+    if (rejections) {
+      rejections.push({ path: filePath, reason: 'secret_file' });
+    }
     return null;
   }
   return resolved;

--- a/src/code-index/path-guards.js
+++ b/src/code-index/path-guards.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const { pathIsInside, SECRET_FILE_RE } = require('./scanner');
+
+/**
+ * Resolve a changed-path entry to an absolute path inside repoRoot.
+ * Returns null when the path escapes the repo or matches secret-file patterns.
+ */
+function resolveRepoScopedPath(repoPath, filePath) {
+  if (!filePath || typeof filePath !== 'string') {
+    return null;
+  }
+  const absRoot = path.resolve(repoPath);
+  const abs = path.isAbsolute(filePath) ? path.resolve(filePath) : path.resolve(absRoot, filePath);
+  let resolved = abs;
+  try {
+    resolved = fs.realpathSync(abs);
+  } catch {
+    return null;
+  }
+  if (!pathIsInside(absRoot, resolved)) {
+    return null;
+  }
+  if (SECRET_FILE_RE.test(resolved.replace(/\\/g, '/'))) {
+    return null;
+  }
+  return resolved;
+}
+
+module.exports = { resolveRepoScopedPath };

--- a/src/code-index/repo-lock.js
+++ b/src/code-index/repo-lock.js
@@ -1,32 +1,113 @@
-const waiters = new Map();
-const holding = new Set();
+const crypto = require('crypto');
+const os = require('os');
 
-/**
- * Serialize full/incremental index operations per repo name.
- * Reentrant for nested calls (e.g. reindex full mode -> indexRepository).
- */
-async function withRepoIndexLock(repoName, fn) {
-  const key = String(repoName || '').toLowerCase();
-  if (holding.has(key)) {
-    return fn();
+const localHolding = new Set();
+const DEFAULT_LOCK_TIMEOUT_MS = 10 * 60 * 1000;
+const LOCK_POLL_MS = 200;
+
+function makeHolderId() {
+  return `${process.pid}:${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessAlive(pid) {
+  if (!pid || Number.isNaN(pid)) {
+    return false;
   }
-  while (waiters.has(key)) {
-    // oxlint-disable-next-line no-await-in-loop
-    await waiters.get(key);
-  }
-  let release;
-  const gate = new Promise((resolve) => {
-    release = resolve;
-  });
-  waiters.set(key, gate);
-  holding.add(key);
   try {
-    return await fn();
-  } finally {
-    holding.delete(key);
-    waiters.delete(key);
-    release();
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
   }
 }
 
-module.exports = { withRepoIndexLock };
+function getDbApi() {
+  const db = require('../../db');
+  db.ensureDb();
+  return db;
+}
+
+function reclaimStaleLock(sqlJson, sqlRun, repoName) {
+  const rows = sqlJson('SELECT holder_id FROM repo_index_locks WHERE repo_name = ?', [repoName]);
+  if (rows.length === 0) {
+    return false;
+  }
+  const pid = parseInt(String(rows[0].holder_id).split(':')[0], 10);
+  if (isProcessAlive(pid)) {
+    return false;
+  }
+  sqlRun('DELETE FROM repo_index_locks WHERE repo_name = ?', [repoName]);
+  return true;
+}
+
+function tryAcquireSqliteLock(repoName, holderId) {
+  const { sqlRun, sqlJson, withTransaction } = getDbApi();
+  return withTransaction(() => {
+    if (!reclaimStaleLock(sqlJson, sqlRun, repoName)) {
+      const existing = sqlJson('SELECT holder_id FROM repo_index_locks WHERE repo_name = ?', [repoName]);
+      if (existing.length > 0) {
+        return false;
+      }
+    }
+    sqlRun('INSERT INTO repo_index_locks (repo_name, holder_id, host) VALUES (?, ?, ?)', [
+      repoName,
+      holderId,
+      os.hostname(),
+    ]);
+    return true;
+  });
+}
+
+async function acquireSqliteLock(repoName, holderId, timeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (tryAcquireSqliteLock(repoName, holderId)) {
+        return;
+      }
+    } catch (e) {
+      if (!/UNIQUE|constraint/i.test(e.message)) {
+        throw e;
+      }
+    }
+    // oxlint-disable-next-line no-await-in-loop
+    await sleep(LOCK_POLL_MS);
+  }
+  throw new Error(`Timed out waiting for index lock on repo "${repoName}" after ${timeoutMs}ms`);
+}
+
+function releaseSqliteLock(repoName, holderId) {
+  const { sqlRun } = getDbApi();
+  sqlRun('DELETE FROM repo_index_locks WHERE repo_name = ? AND holder_id = ?', [repoName, holderId]);
+}
+
+/**
+ * Serialize full/incremental index operations per repo across processes via SQLite.
+ * Reentrant within the same process (nested full reindex -> indexRepository).
+ */
+async function withRepoIndexLock(repoName, fn) {
+  const key = String(repoName || '').toLowerCase();
+  if (localHolding.has(key)) {
+    return fn();
+  }
+
+  const holderId = makeHolderId();
+  await acquireSqliteLock(key, holderId);
+  localHolding.add(key);
+  try {
+    return await fn();
+  } finally {
+    localHolding.delete(key);
+    try {
+      releaseSqliteLock(key, holderId);
+    } catch (e) {
+      console.error(`[repo-lock] failed to release lock for ${key}: ${e.message}`);
+    }
+  }
+}
+
+module.exports = { withRepoIndexLock, makeHolderId, tryAcquireSqliteLock, releaseSqliteLock };

--- a/src/code-index/repo-lock.js
+++ b/src/code-index/repo-lock.js
@@ -1,0 +1,32 @@
+const waiters = new Map();
+const holding = new Set();
+
+/**
+ * Serialize full/incremental index operations per repo name.
+ * Reentrant for nested calls (e.g. reindex full mode -> indexRepository).
+ */
+async function withRepoIndexLock(repoName, fn) {
+  const key = String(repoName || '').toLowerCase();
+  if (holding.has(key)) {
+    return fn();
+  }
+  while (waiters.has(key)) {
+    // oxlint-disable-next-line no-await-in-loop
+    await waiters.get(key);
+  }
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  waiters.set(key, gate);
+  holding.add(key);
+  try {
+    return await fn();
+  } finally {
+    holding.delete(key);
+    waiters.delete(key);
+    release();
+  }
+}
+
+module.exports = { withRepoIndexLock };

--- a/src/code-index/repos.js
+++ b/src/code-index/repos.js
@@ -85,7 +85,7 @@ function createCodeIndexRepository(deps) {
       }
       return this.createRepo({ name, path });
     },
-    clearRepoIndex(repoId, options = {}) {
+    clearRepoIndexCore(repoId, options = {}) {
       const onProgress = typeof options.onProgress === 'function' ? options.onProgress : null;
       const emit = (message, extra = {}) => {
         if (onProgress) {
@@ -94,48 +94,53 @@ function createCodeIndexRepository(deps) {
       };
 
       const totals = {};
+      emit('Clearing complexity rows...');
+      const complexityResult = sqlRun(
+        'DELETE FROM symbol_complexity WHERE symbol_id IN (SELECT id FROM code_symbols WHERE repo_id = ?)',
+        [repoId],
+      );
+      totals.symbolComplexity = complexityResult.changes || 0;
+
+      emit('Clearing call edges...');
+      const callsResult = sqlRun('DELETE FROM code_calls WHERE repo_id = ?', [repoId]);
+      totals.calls = callsResult.changes || 0;
+
+      emit('Clearing import edges...');
+      const importsResult = sqlRun('DELETE FROM code_imports WHERE repo_id = ?', [repoId]);
+      totals.imports = importsResult.changes || 0;
+
+      emit('Clearing churn rows...');
+      const churnResult = sqlRun('DELETE FROM churn_metrics WHERE repo_id = ?', [repoId]);
+      totals.churn = churnResult.changes || 0;
+
+      emit('Clearing diagnostics...');
+      const diagResult = sqlRun('DELETE FROM code_file_diagnostics WHERE repo_id = ?', [repoId]);
+      totals.diagnostics = diagResult.changes || 0;
+
+      emit('Clearing scope resolutions...');
+      const scopeResResult = sqlRun(
+        'DELETE FROM scope_resolution WHERE binding_id IN (SELECT id FROM file_scope_bindings WHERE repo_id = ?)',
+        [repoId],
+      );
+      totals.scopeResolution = scopeResResult.changes || 0;
+
+      emit('Clearing scope bindings...');
+      const scopeBindResult = sqlRun('DELETE FROM file_scope_bindings WHERE repo_id = ?', [repoId]);
+      totals.scopeBindings = scopeBindResult.changes || 0;
+
+      emit('Clearing symbols...');
+      const symbolsResult = sqlRun('DELETE FROM code_symbols WHERE repo_id = ?', [repoId]);
+      totals.symbols = symbolsResult.changes || 0;
+
+      emit('Clearing files...');
+      const filesResult = sqlRun('DELETE FROM code_files WHERE repo_id = ?', [repoId]);
+      totals.files = filesResult.changes || 0;
+      return totals;
+    },
+    clearRepoIndex(repoId, options = {}) {
+      const totals = {};
       _withTransaction(() => {
-        emit('Clearing complexity rows...');
-        const complexityResult = sqlRun(
-          'DELETE FROM symbol_complexity WHERE symbol_id IN (SELECT id FROM code_symbols WHERE repo_id = ?)',
-          [repoId],
-        );
-        totals.symbolComplexity = complexityResult.changes || 0;
-
-        emit('Clearing call edges...');
-        const callsResult = sqlRun('DELETE FROM code_calls WHERE repo_id = ?', [repoId]);
-        totals.calls = callsResult.changes || 0;
-
-        emit('Clearing import edges...');
-        const importsResult = sqlRun('DELETE FROM code_imports WHERE repo_id = ?', [repoId]);
-        totals.imports = importsResult.changes || 0;
-
-        emit('Clearing churn rows...');
-        const churnResult = sqlRun('DELETE FROM churn_metrics WHERE repo_id = ?', [repoId]);
-        totals.churn = churnResult.changes || 0;
-
-        emit('Clearing diagnostics...');
-        const diagResult = sqlRun('DELETE FROM code_file_diagnostics WHERE repo_id = ?', [repoId]);
-        totals.diagnostics = diagResult.changes || 0;
-
-        emit('Clearing scope resolutions...');
-        const scopeResResult = sqlRun(
-          'DELETE FROM scope_resolution WHERE binding_id IN (SELECT id FROM file_scope_bindings WHERE repo_id = ?)',
-          [repoId],
-        );
-        totals.scopeResolution = scopeResResult.changes || 0;
-
-        emit('Clearing scope bindings...');
-        const scopeBindResult = sqlRun('DELETE FROM file_scope_bindings WHERE repo_id = ?', [repoId]);
-        totals.scopeBindings = scopeBindResult.changes || 0;
-
-        emit('Clearing symbols...');
-        const symbolsResult = sqlRun('DELETE FROM code_symbols WHERE repo_id = ?', [repoId]);
-        totals.symbols = symbolsResult.changes || 0;
-
-        emit('Clearing files...');
-        const filesResult = sqlRun('DELETE FROM code_files WHERE repo_id = ?', [repoId]);
-        totals.files = filesResult.changes || 0;
+        Object.assign(totals, this.clearRepoIndexCore(repoId, options));
       });
       return totals;
     },

--- a/src/code-index/scanner.js
+++ b/src/code-index/scanner.js
@@ -325,4 +325,13 @@ function scanRepository(repoPath, options = {}) {
   return { files: results, skipReport };
 }
 
-module.exports = { isBinaryFile, isCodeFile, scanRepository, shouldSkipDir, loadGitignoreRules, SKIP_FILE_RE };
+module.exports = {
+  isBinaryFile,
+  isCodeFile,
+  scanRepository,
+  shouldSkipDir,
+  loadGitignoreRules,
+  pathIsInside,
+  SECRET_FILE_RE,
+  SKIP_FILE_RE,
+};

--- a/src/hooks-engine/git-trust.js
+++ b/src/hooks-engine/git-trust.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * Matches git operations that should trigger trust-score sync after Bash tools.
+ * Supports optional `git -C <path>` with quoted or unquoted paths.
+ */
+const GIT_TRUST_OP_RE =
+  /\bgit(?:\s+-C\s+(?:"[^"]+"|'[^']+'|[^\s"']+))?\s+(pull|checkout|merge|rebase|reset|stash\s+pop)\b/;
+
+function matchesGitTrustOperation(command) {
+  return typeof command === 'string' && GIT_TRUST_OP_RE.test(command);
+}
+
+module.exports = { GIT_TRUST_OP_RE, matchesGitTrustOperation };

--- a/src/http/auth.js
+++ b/src/http/auth.js
@@ -1,0 +1,63 @@
+const { jsonError } = require('./errors');
+
+function resolveHttpApiKey(opts = {}) {
+  if (opts.apiKey) {
+    return opts.apiKey;
+  }
+  if (process.env.LAPIS_HTTP_API_KEY) {
+    return process.env.LAPIS_HTTP_API_KEY;
+  }
+  try {
+    const { getConfig } = require('../../config');
+    const config = getConfig();
+    return config.http_api_key || null;
+  } catch {
+    return null;
+  }
+}
+
+function isAuthorized(req, apiKey) {
+  if (!apiKey) {
+    return true;
+  }
+  const headerKey = req.headers['x-api-key'];
+  if (typeof headerKey === 'string' && headerKey === apiKey) {
+    return true;
+  }
+  const auth = req.headers.authorization;
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
+    return auth.slice('Bearer '.length) === apiKey;
+  }
+  return false;
+}
+
+function requireHttpAuth(apiKey) {
+  return (req, res) => {
+    if (!apiKey) {
+      return true;
+    }
+    if (req.method === 'GET' && new URL(req.url, 'http://localhost').pathname === '/health') {
+      return true;
+    }
+    if (isAuthorized(req, apiKey)) {
+      return true;
+    }
+    jsonError(res, 401, 'unauthorized', 'Missing or invalid API key');
+    return false;
+  };
+}
+
+function assertServeHostPolicy(host, apiKey) {
+  if (host === '0.0.0.0' && !apiKey) {
+    throw new Error(
+      'Refusing to bind HTTP server to 0.0.0.0 without an API key. Pass --api-key, set LAPIS_HTTP_API_KEY, or bind to 127.0.0.1.',
+    );
+  }
+}
+
+module.exports = {
+  resolveHttpApiKey,
+  isAuthorized,
+  requireHttpAuth,
+  assertServeHostPolicy,
+};

--- a/src/http/auth.js
+++ b/src/http/auth.js
@@ -48,9 +48,10 @@ function requireHttpAuth(apiKey) {
 }
 
 function assertServeHostPolicy(host, apiKey) {
-  if (host === '0.0.0.0' && !apiKey) {
+  const unrestricted = host === '0.0.0.0' || host === '::';
+  if (unrestricted && !apiKey) {
     throw new Error(
-      'Refusing to bind HTTP server to 0.0.0.0 without an API key. Pass --api-key, set LAPIS_HTTP_API_KEY, or bind to 127.0.0.1.',
+      'Refusing to bind HTTP server to an unrestricted address without an API key. Pass --api-key, set LAPIS_HTTP_API_KEY, or bind to 127.0.0.1.',
     );
   }
 }

--- a/src/http/auth.js
+++ b/src/http/auth.js
@@ -29,16 +29,26 @@ function keysMatch(provided, expected) {
   return crypto.timingSafeEqual(providedBuf, expectedBuf);
 }
 
+function headerValue(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value) && typeof value[0] === 'string') {
+    return value[0];
+  }
+  return null;
+}
+
 function isAuthorized(req, apiKey) {
   if (!apiKey) {
     return true;
   }
-  const headerKey = req.headers['x-api-key'];
-  if (typeof headerKey === 'string' && keysMatch(headerKey, apiKey)) {
+  const headerKey = headerValue(req.headers['x-api-key']);
+  if (headerKey && keysMatch(headerKey, apiKey)) {
     return true;
   }
-  const auth = req.headers.authorization;
-  if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
+  const auth = headerValue(req.headers.authorization);
+  if (auth && auth.startsWith('Bearer ')) {
     return keysMatch(auth.slice('Bearer '.length), apiKey);
   }
   return false;

--- a/src/http/auth.js
+++ b/src/http/auth.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const { jsonError } = require('./errors');
 
 function resolveHttpApiKey(opts = {}) {
@@ -16,17 +17,29 @@ function resolveHttpApiKey(opts = {}) {
   }
 }
 
+function keysMatch(provided, expected) {
+  if (typeof provided !== 'string' || typeof expected !== 'string') {
+    return false;
+  }
+  const providedBuf = Buffer.from(provided);
+  const expectedBuf = Buffer.from(expected);
+  if (providedBuf.length !== expectedBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(providedBuf, expectedBuf);
+}
+
 function isAuthorized(req, apiKey) {
   if (!apiKey) {
     return true;
   }
   const headerKey = req.headers['x-api-key'];
-  if (typeof headerKey === 'string' && headerKey === apiKey) {
+  if (typeof headerKey === 'string' && keysMatch(headerKey, apiKey)) {
     return true;
   }
   const auth = req.headers.authorization;
   if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
-    return auth.slice('Bearer '.length) === apiKey;
+    return keysMatch(auth.slice('Bearer '.length), apiKey);
   }
   return false;
 }
@@ -61,4 +74,5 @@ module.exports = {
   isAuthorized,
   requireHttpAuth,
   assertServeHostPolicy,
+  keysMatch,
 };

--- a/src/http/auth.js
+++ b/src/http/auth.js
@@ -48,8 +48,11 @@ function isAuthorized(req, apiKey) {
     return true;
   }
   const auth = headerValue(req.headers.authorization);
-  if (auth && auth.startsWith('Bearer ')) {
-    return keysMatch(auth.slice('Bearer '.length), apiKey);
+  if (auth) {
+    const bearerMatch = auth.match(/^Bearer\s+(.+)$/i);
+    if (bearerMatch && keysMatch(bearerMatch[1], apiKey)) {
+      return true;
+    }
   }
   return false;
 }

--- a/src/http/server.js
+++ b/src/http/server.js
@@ -1,11 +1,17 @@
 const http = require('http');
 const { matchRoute } = require('./routes');
 const { jsonError } = require('./errors');
+const { resolveHttpApiKey, requireHttpAuth, assertServeHostPolicy } = require('./auth');
 
 function createHttpServer(deps) {
   const routes = buildRoutes(deps);
+  const authorize = requireHttpAuth(deps.apiKey || null);
 
   const server = http.createServer(async (req, res) => {
+    if (!authorize(req, res)) {
+      return;
+    }
+
     const parsed = new URL(req.url, `http://${req.headers.host}`);
     const match = matchRoute(req.method, parsed.pathname, routes);
 
@@ -190,7 +196,10 @@ function buildRoutes(deps) {
 }
 
 async function startHttpServer(opts) {
-  const { host = '127.0.0.1', port = 9100 } = opts;
+  const host = opts.host ?? '127.0.0.1';
+  const port = Number(opts.port ?? 9100);
+  const apiKey = resolveHttpApiKey(opts);
+  assertServeHostPolicy(host, apiKey);
 
   const db = require('../../db');
   db.ensureDb();
@@ -203,11 +212,17 @@ async function startHttpServer(opts) {
     repositories: { aurex },
     sqlJson,
     sqlRun,
+    apiKey,
   });
 
   if (host === '0.0.0.0') {
     console.log('[lapis serve] WARNING: binding to 0.0.0.0 exposes memory APIs on your network.');
     console.log('[lapis serve] Use only on trusted networks or behind a proxy.');
+    if (apiKey) {
+      console.log('[lapis serve] API key authentication is enabled (x-api-key or Authorization: Bearer).');
+    }
+  } else if (apiKey) {
+    console.log('[lapis serve] API key authentication is enabled (x-api-key or Authorization: Bearer).');
   }
 
   await new Promise((resolve) => server.listen(port, host, resolve));

--- a/src/memory-domain/compaction.js
+++ b/src/memory-domain/compaction.js
@@ -162,7 +162,9 @@ function dream(deps, args = {}) {
       FROM observations o
       LEFT JOIN (
         SELECT memory_id, COUNT(*) as recall_count
-        FROM recall_log GROUP BY memory_id
+        FROM recall_log
+        WHERE was_useful = 1
+        GROUP BY memory_id
       ) rl ON rl.memory_id = o.id
       WHERE o.type = ? AND o.deleted_at IS NULL
         AND (rl.recall_count IS NULL OR rl.recall_count = 0)
@@ -186,7 +188,9 @@ function dream(deps, args = {}) {
       FROM observations o
       LEFT JOIN (
         SELECT memory_id, COUNT(*) as recall_count
-        FROM recall_log GROUP BY memory_id
+        FROM recall_log
+        WHERE was_useful = 1
+        GROUP BY memory_id
       ) rl ON rl.memory_id = o.id
       LEFT JOIN (
         SELECT memory_id, MAX(trust_score) as trust_score

--- a/src/memory-domain/context.js
+++ b/src/memory-domain/context.js
@@ -204,6 +204,7 @@ function context(deps, args) {
       memoryId: o.id,
       sessionId: String(sessionId),
       query: recallQuery,
+      wasUseful: false,
     }));
     insertRecallLog(entries);
   }

--- a/src/memory-domain/dedupe.js
+++ b/src/memory-domain/dedupe.js
@@ -73,6 +73,9 @@ function markDuplicate(deps, args) {
   if (!source || !target) {
     return { error: 'Missing --source and --target' };
   }
+  if (source === target) {
+    return { error: 'Source and target must be different observations' };
+  }
 
   sqlRun(
     'INSERT OR REPLACE INTO observation_relations (source_id, target_id, relation, confidence) VALUES (?, ?, ?, ?)',

--- a/src/platform/storage/repositories/aurex.js
+++ b/src/platform/storage/repositories/aurex.js
@@ -588,15 +588,32 @@ function createAurexRepository(deps) {
     },
     claimNextReadyTodo(missionId, workerId) {
       const rows = sqlJson(
-        "SELECT * FROM todo_items WHERE mission_id = ? AND status = 'ready' ORDER BY priority DESC, created_at LIMIT 1",
-        [missionId],
+        `UPDATE todo_items
+         SET status = 'in_progress',
+             assigned_worker_id = ?,
+             updated_at = datetime('now')
+         WHERE id = (
+           SELECT id FROM todo_items
+           WHERE mission_id = ? AND status = 'ready'
+           ORDER BY priority DESC, created_at
+           LIMIT 1
+         )
+         RETURNING *`,
+        [workerId, missionId],
       ).map(mapTodoRow);
       if (rows.length === 0) {
         return [];
       }
       const todo = rows[0];
-      this.assignTodo(todo.id, workerId);
-      return this.setTodoStatus(todo.id, 'in_progress');
+      this.recordTodoEvent(todo.id, {
+        eventType: 'todo_assigned',
+        payload: { from: null, to: workerId || null },
+      });
+      this.recordTodoEvent(todo.id, {
+        eventType: 'todo_status_changed',
+        payload: { from: 'ready', to: 'in_progress' },
+      });
+      return this.getTodo(todo.id);
     },
     getTodoContextQuery(todoId) {
       const todo = this.getTodo(todoId)[0];

--- a/src/trust-sync/change-detector.js
+++ b/src/trust-sync/change-detector.js
@@ -28,6 +28,50 @@ function resolveIndexedFilePaths(repoPath, gitPaths) {
 }
 
 /**
+ * Parse `git diff --name-status` output into repo-relative changed paths.
+ * Includes both sides of renames so indexed symbols on old paths are detected.
+ */
+function parseGitDiffNameStatus(output) {
+  const changed = new Set();
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      // oxlint-disable-next-line no-continue
+      continue;
+    }
+    const parts = trimmed.split('\t');
+    const status = parts[0];
+    if (status.startsWith('R') && parts[1] && parts[2]) {
+      changed.add(parts[1]);
+      changed.add(parts[2]);
+    } else if (status.startsWith('D') && parts[1]) {
+      changed.add(parts[1]);
+    } else if (parts[1]) {
+      changed.add(parts[1]);
+    }
+  }
+  return [...changed];
+}
+
+function updateHeadCommit(deps, repoId, headCommit) {
+  let withTransaction = deps.withTransaction;
+  if (!withTransaction) {
+    try {
+      withTransaction = require('../../db').withTransaction;
+    } catch {
+      withTransaction = null;
+    }
+  }
+  if (typeof withTransaction === 'function') {
+    withTransaction(() => {
+      deps.sqlRun('UPDATE code_repos SET head_commit = ? WHERE id = ?', [headCommit, repoId]);
+    });
+  } else {
+    deps.sqlRun('UPDATE code_repos SET head_commit = ? WHERE id = ?', [headCommit, repoId]);
+  }
+}
+
+/**
  * Detects changed symbols by comparing stored head_commit against current HEAD.
  * Uses git diff + the built-in code index (zero external dependencies).
  */
@@ -55,7 +99,7 @@ function detectChangedSymbols(deps, repoName) {
 
   // No stored baseline — establish head_commit without penalizing linked memories.
   if (!storedHead) {
-    sqlRun('UPDATE code_repos SET head_commit = ? WHERE id = ?', [currentHead, repoId]);
+    updateHeadCommit(deps, repoId, currentHead);
     return {
       ok: true,
       repo: repoName,
@@ -81,28 +125,24 @@ function detectChangedSymbols(deps, repoName) {
   // Determine the base commit for diff
   const baseCommit = storedHead;
 
-  // Get changed files via git diff
+  // Get changed files via git diff (name-status captures renames and deletes).
   let changedFiles = [];
   try {
     const diffRange = `${baseCommit}..HEAD`;
-    const output = execFileSync('git', ['diff', '--name-only', diffRange], {
+    const output = execFileSync('git', ['diff', '--name-status', diffRange], {
       cwd: repoPath,
       encoding: 'utf-8',
       timeout: 10000,
       maxBuffer: 10 * 1024 * 1024,
     });
-    changedFiles = output
-      .trim()
-      .split('\n')
-      .map((f) => f.trim())
-      .filter(Boolean);
+    changedFiles = parseGitDiffNameStatus(output);
   } catch {
     return { error: jsonErrNoExit('Failed to run git diff to determine changed files') };
   }
 
   if (changedFiles.length === 0) {
     // Update head_commit even if no file changes
-    sqlRun('UPDATE code_repos SET head_commit = ? WHERE id = ?', [currentHead, repoId]);
+    updateHeadCommit(deps, repoId, currentHead);
     return {
       ok: true,
       repo: repoName,
@@ -247,6 +287,7 @@ function createGitTrustSyncAdapter(mem, notify) {
 module.exports = {
   detectChangedSymbols,
   resolveIndexedFilePaths,
+  parseGitDiffNameStatus,
   extractSymbolKey,
   collectChangedSymbols,
   parseChangedSymbolsJson,

--- a/src/trust-sync/change-detector.js
+++ b/src/trust-sync/change-detector.js
@@ -26,8 +26,21 @@ function detectChangedSymbols(deps, repoName) {
     return { error: jsonErrNoExit(`Cannot read HEAD commit from ${repoPath}. Is it a git repo?`) };
   }
 
+  // No stored baseline — establish head_commit without penalizing linked memories.
+  if (!storedHead) {
+    sqlRun('UPDATE code_repos SET head_commit = ? WHERE id = ?', [currentHead, repoId]);
+    return {
+      ok: true,
+      repo: repoName,
+      message: 'Initialized head_commit baseline',
+      old_head: null,
+      new_head: currentHead,
+      changedSet: new Set(),
+    };
+  }
+
   // No changes if HEAD hasn't moved
-  if (storedHead && storedHead === currentHead) {
+  if (storedHead === currentHead) {
     return {
       ok: true,
       repo: repoName,
@@ -39,12 +52,12 @@ function detectChangedSymbols(deps, repoName) {
   }
 
   // Determine the base commit for diff
-  const baseCommit = storedHead || null;
+  const baseCommit = storedHead;
 
   // Get changed files via git diff
   let changedFiles = [];
   try {
-    const diffRange = baseCommit ? `${baseCommit}..HEAD` : 'HEAD~1..HEAD';
+    const diffRange = `${baseCommit}..HEAD`;
     const output = execFileSync('git', ['diff', '--name-only', diffRange], {
       cwd: repoPath,
       encoding: 'utf-8',
@@ -182,11 +195,11 @@ function createGitTrustSyncAdapter(mem, notify) {
         // Repo not indexed yet — silently skip
         return;
       }
+      if (notify) {
+        notify(`Memory: synced trust scores after git operation on ${repo}`, 'info');
+      }
     } catch {
       // Non-critical — trust sync failure should not break the session
-    }
-    if (notify) {
-      notify(`Memory: syncing trust scores after git operation on ${repo}`, 'info');
     }
   };
 }

--- a/src/trust-sync/change-detector.js
+++ b/src/trust-sync/change-detector.js
@@ -1,4 +1,31 @@
+const fs = require('fs');
+const path = require('path');
 const { execFileSync } = require('child_process');
+
+/**
+ * Map git-relative paths to absolute paths stored in the code index.
+ * Includes realpath variants so symlinked repo roots still match indexed rows.
+ */
+function resolveIndexedFilePaths(repoPath, gitPaths) {
+  const root = path.resolve(repoPath);
+  const resolved = new Set();
+  for (const entry of gitPaths) {
+    if (!entry || typeof entry !== 'string') {
+      // oxlint-disable-next-line no-continue
+      continue;
+    }
+    const candidates = path.isAbsolute(entry) ? [path.resolve(entry)] : [path.resolve(root, entry)];
+    for (const candidate of candidates) {
+      resolved.add(candidate);
+      try {
+        resolved.add(fs.realpathSync(candidate));
+      } catch {
+        // Best-effort: indexed paths may not exist on disk anymore.
+      }
+    }
+  }
+  return [...resolved];
+}
 
 /**
  * Detects changed symbols by comparing stored head_commit against current HEAD.
@@ -86,13 +113,26 @@ function detectChangedSymbols(deps, repoName) {
     };
   }
 
-  // Build set of changed symbol names from the code index
+  // Build set of changed symbol names from the code index.
+  // Git reports repo-relative paths; the index stores absolute file paths.
+  const indexedPaths = resolveIndexedFilePaths(repoPath, changedFiles);
   const changedSet = new Set();
-  const placeholders = changedFiles.map(() => '?').join(',');
+  if (indexedPaths.length === 0) {
+    return {
+      ok: true,
+      repo: repoName,
+      old_head: storedHead,
+      new_head: currentHead,
+      changed_files: changedFiles.length,
+      changed_symbols: 0,
+      changedSet,
+    };
+  }
+  const placeholders = indexedPaths.map(() => '?').join(',');
   const changedSymbols = sqlJson(
     `SELECT DISTINCT name, qualified_name FROM code_symbols
      WHERE repo_id = ? AND file_path IN (${placeholders})`,
-    [repoId, ...changedFiles],
+    [repoId, ...indexedPaths],
   );
   for (const sym of changedSymbols) {
     changedSet.add(sym.name);
@@ -206,6 +246,7 @@ function createGitTrustSyncAdapter(mem, notify) {
 
 module.exports = {
   detectChangedSymbols,
+  resolveIndexedFilePaths,
   extractSymbolKey,
   collectChangedSymbols,
   parseChangedSymbolsJson,

--- a/src/trust-sync/symbol-links.js
+++ b/src/trust-sync/symbol-links.js
@@ -149,7 +149,10 @@ function syncCodeTrust(deps, args) {
 
   // No changed symbols in the index — update head_commit and return
   if (detected.changedSet.size === 0) {
-    deps.sqlRun('UPDATE code_repos SET head_commit = ? WHERE name = ?', [detected.new_head, repo]);
+    const tx = deps.withTransaction || require('../../db').withTransaction;
+    tx(() => {
+      deps.sqlRun('UPDATE code_repos SET head_commit = ? WHERE name = ?', [detected.new_head, repo]);
+    });
     return {
       ok: true,
       repo,

--- a/src/trust-sync/symbol-links.js
+++ b/src/trust-sync/symbol-links.js
@@ -165,21 +165,24 @@ function syncCodeTrust(deps, args) {
   const allLinks = repository.getAnchoredLinks(repo);
   const evaluated = evaluateTrustSync(allLinks, detected.changedSet);
 
-  for (const operation of evaluated.operations) {
-    repository.updateLinkTrust({
-      memoryId: operation.link.memory_id,
-      symbolId: operation.link.symbol_id,
-      newTrust: operation.newTrust,
-    });
-    repository.insertTrustAdjustment({
-      memoryId: operation.link.memory_id,
-      reason: operation.reason,
-      delta: operation.delta,
-    });
-  }
+  const applyTrustUpdates = () => {
+    for (const operation of evaluated.operations) {
+      repository.updateLinkTrust({
+        memoryId: operation.link.memory_id,
+        symbolId: operation.link.symbol_id,
+        newTrust: operation.newTrust,
+      });
+      repository.insertTrustAdjustment({
+        memoryId: operation.link.memory_id,
+        reason: operation.reason,
+        delta: operation.delta,
+      });
+    }
+    deps.sqlRun('UPDATE code_repos SET head_commit = ? WHERE name = ?', [detected.new_head, repo]);
+  };
 
-  // Update head_commit to current
-  deps.sqlRun('UPDATE code_repos SET head_commit = ? WHERE name = ?', [detected.new_head, repo]);
+  const tx = deps.withTransaction || require('../../db').withTransaction;
+  tx(applyTrustUpdates);
 
   const result = stripOperations(evaluated);
   result.changed_symbols = detected.changedSet.size;

--- a/test/changed-paths.test.js
+++ b/test/changed-paths.test.js
@@ -1,0 +1,29 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { parseChangedPathsInput } = require('../src/code-index/incremental-indexer');
+
+describe('parseChangedPathsInput rejected paths', () => {
+  let repoRoot;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-changed-paths-'));
+    fs.writeFileSync(path.join(repoRoot, 'inside.js'), 'export const ok = 1;');
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns rejected paths for entries outside the repo', () => {
+    const outside = path.join(os.tmpdir(), 'outside.js');
+    fs.writeFileSync(outside, 'export const nope = 1;');
+    const delta = parseChangedPathsInput(
+      JSON.stringify([{ path: 'inside.js' }, { path: outside }]),
+      repoRoot,
+    );
+    expect(delta.changed).toHaveLength(1);
+    expect(delta.rejected).toHaveLength(1);
+    expect(delta.rejected[0].reason).toBe('outside_repo');
+  });
+});

--- a/test/changed-paths.test.js
+++ b/test/changed-paths.test.js
@@ -19,11 +19,12 @@ describe('parseChangedPathsInput rejected paths', () => {
     const outside = path.join(os.tmpdir(), 'outside.js');
     fs.writeFileSync(outside, 'export const nope = 1;');
     const delta = parseChangedPathsInput(
-      JSON.stringify([{ path: 'inside.js' }, { path: outside }]),
+      JSON.stringify([{ path: 'inside.js' }, { path: outside }, { path: 123 }]),
       repoRoot,
     );
     expect(delta.changed).toHaveLength(1);
-    expect(delta.rejected).toHaveLength(1);
-    expect(delta.rejected[0].reason).toBe('outside_repo');
+    expect(delta.rejected).toHaveLength(2);
+    expect(delta.rejected.some((r) => r.reason === 'outside_repo')).toBe(true);
+    expect(delta.rejected.some((r) => r.reason === 'invalid_path')).toBe(true);
   });
 });

--- a/test/git-trust.test.js
+++ b/test/git-trust.test.js
@@ -1,0 +1,32 @@
+const { GIT_TRUST_OP_RE, matchesGitTrustOperation } = require('../src/hooks-engine/git-trust');
+
+describe('git trust operation matcher', () => {
+  it('matches bare git pull', () => {
+    expect(matchesGitTrustOperation('git pull origin main')).toBe(true);
+  });
+
+  it('matches compound commands', () => {
+    expect(matchesGitTrustOperation('cd /proj && git pull')).toBe(true);
+  });
+
+  it('matches git -C with unquoted path', () => {
+    expect(matchesGitTrustOperation('git -C /proj/app pull origin main')).toBe(true);
+  });
+
+  it('matches git -C with double-quoted path containing spaces', () => {
+    expect(matchesGitTrustOperation('git -C "/path/with spaces" pull')).toBe(true);
+  });
+
+  it('matches git -C with single-quoted path', () => {
+    expect(matchesGitTrustOperation("git -C '/path/with spaces' checkout main")).toBe(true);
+  });
+
+  it('does not match unrelated commands', () => {
+    expect(matchesGitTrustOperation('npm install')).toBe(false);
+    expect(matchesGitTrustOperation('git status')).toBe(false);
+  });
+
+  it('exports the regex for legacy tests', () => {
+    expect(GIT_TRUST_OP_RE).toBeInstanceOf(RegExp);
+  });
+});

--- a/test/http-auth.test.js
+++ b/test/http-auth.test.js
@@ -75,8 +75,13 @@ describe('HTTP auth middleware', () => {
 });
 
 describe('HTTP serve host policy', () => {
-  it('refuses 0.0.0.0 without api key', async () => {
+  it('refuses 0.0.0.0 without api key', () => {
     const { assertServeHostPolicy } = require('../src/http/auth');
     expect(() => assertServeHostPolicy('0.0.0.0', null)).toThrow(/API key/);
+  });
+
+  it('refuses :: without api key', () => {
+    const { assertServeHostPolicy } = require('../src/http/auth');
+    expect(() => assertServeHostPolicy('::', null)).toThrow(/API key/);
   });
 });

--- a/test/http-auth.test.js
+++ b/test/http-auth.test.js
@@ -85,3 +85,12 @@ describe('HTTP serve host policy', () => {
     expect(() => assertServeHostPolicy('::', null)).toThrow(/API key/);
   });
 });
+
+describe('HTTP key comparison', () => {
+  it('uses constant-time comparison', () => {
+    const { keysMatch } = require('../src/http/auth');
+    expect(keysMatch('secret-key', 'secret-key')).toBe(true);
+    expect(keysMatch('secret-key', 'secret-kez')).toBe(false);
+    expect(keysMatch('short', 'much-longer-key')).toBe(false);
+  });
+});

--- a/test/http-auth.test.js
+++ b/test/http-auth.test.js
@@ -72,6 +72,22 @@ describe('HTTP auth middleware', () => {
     });
     expect(res.status).not.toBe(401);
   });
+
+  it('accepts case-insensitive Bearer authorization', async () => {
+    server = createHttpServer({
+      repositories: { aurex: {} },
+      sqlJson: () => [],
+      sqlRun: () => {},
+      apiKey: 'test-key',
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const res = await request(server, {
+      method: 'POST',
+      path: '/dispatch',
+      headers: { authorization: 'bearer test-key', 'content-type': 'application/json' },
+    });
+    expect(res.status).not.toBe(401);
+  });
 });
 
 describe('HTTP serve host policy', () => {

--- a/test/http-auth.test.js
+++ b/test/http-auth.test.js
@@ -1,0 +1,82 @@
+const { createHttpServer } = require('../src/http/server');
+const http = require('http');
+
+function request(server, { method = 'GET', path = '/health', headers = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const addr = server.address();
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port: addr.port,
+        path,
+        method,
+        headers,
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => resolve({ status: res.statusCode, body }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('HTTP auth middleware', () => {
+  let server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+      server = null;
+    }
+  });
+
+  it('allows unauthenticated health checks when api key is configured', async () => {
+    server = createHttpServer({
+      repositories: { aurex: {} },
+      sqlJson: () => [],
+      sqlRun: () => {},
+      apiKey: 'test-key',
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const res = await request(server, { path: '/health' });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects protected routes without api key', async () => {
+    server = createHttpServer({
+      repositories: { aurex: {} },
+      sqlJson: () => [],
+      sqlRun: () => {},
+      apiKey: 'test-key',
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const res = await request(server, { method: 'POST', path: '/dispatch' });
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts x-api-key header', async () => {
+    server = createHttpServer({
+      repositories: { aurex: {} },
+      sqlJson: () => [],
+      sqlRun: () => {},
+      apiKey: 'test-key',
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const res = await request(server, {
+      method: 'POST',
+      path: '/dispatch',
+      headers: { 'x-api-key': 'test-key', 'content-type': 'application/json' },
+    });
+    expect(res.status).not.toBe(401);
+  });
+});
+
+describe('HTTP serve host policy', () => {
+  it('refuses 0.0.0.0 without api key', async () => {
+    const { assertServeHostPolicy } = require('../src/http/auth');
+    expect(() => assertServeHostPolicy('0.0.0.0', null)).toThrow(/API key/);
+  });
+});

--- a/test/mutation-killers.test.js
+++ b/test/mutation-killers.test.js
@@ -248,6 +248,11 @@ describe('dedupe.js mutation killers', () => {
     expect(softDelete).toHaveBeenCalledWith(20);
   });
 
+  it('markDuplicate: rejects identical source and target', () => {
+    const result = markDuplicate(mockDeps(), { source: '7', target: '7' });
+    expect(result.error).toMatch(/different/i);
+  });
+
   it('markDuplicate: returns ok with merged info', () => {
     const result = markDuplicate(
       { sqlRun: vi.fn(), softDeleteObservation: vi.fn() },

--- a/test/path-guards.test.js
+++ b/test/path-guards.test.js
@@ -1,0 +1,37 @@
+const { resolveRepoScopedPath } = require('../src/code-index/path-guards');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+describe('code-index path guards', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-path-guard-'));
+    fs.writeFileSync(path.join(tmpRoot, 'inside.js'), 'export const ok = 1;');
+    fs.writeFileSync(path.join(os.tmpdir(), 'outside-secret.env'), 'SECRET=1');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    try {
+      fs.unlinkSync(path.join(os.tmpdir(), 'outside-secret.env'));
+    } catch {}
+  });
+
+  it('allows paths inside the repo', () => {
+    const resolved = resolveRepoScopedPath(tmpRoot, 'inside.js');
+    expect(resolved).toContain('inside.js');
+  });
+
+  it('rejects paths that escape the repo', () => {
+    const outside = path.join(os.tmpdir(), 'outside-secret.env');
+    expect(resolveRepoScopedPath(tmpRoot, outside)).toBeNull();
+    expect(resolveRepoScopedPath(tmpRoot, '../outside-secret.env')).toBeNull();
+  });
+
+  it('rejects secret filenames even when inside the repo', () => {
+    fs.writeFileSync(path.join(tmpRoot, '.env'), 'SECRET=1');
+    expect(resolveRepoScopedPath(tmpRoot, '.env')).toBeNull();
+  });
+});

--- a/test/path-guards.test.js
+++ b/test/path-guards.test.js
@@ -26,12 +26,16 @@ describe('code-index path guards', () => {
 
   it('rejects paths that escape the repo', () => {
     const outside = path.join(os.tmpdir(), 'outside-secret.env');
-    expect(resolveRepoScopedPath(tmpRoot, outside)).toBeNull();
-    expect(resolveRepoScopedPath(tmpRoot, '../outside-secret.env')).toBeNull();
+    const rejections = [];
+    expect(resolveRepoScopedPath(tmpRoot, outside, rejections)).toBeNull();
+    expect(resolveRepoScopedPath(tmpRoot, '../outside-secret.env', rejections)).toBeNull();
+    expect(rejections.some((r) => r.reason === 'outside_repo')).toBe(true);
   });
 
   it('rejects secret filenames even when inside the repo', () => {
     fs.writeFileSync(path.join(tmpRoot, '.env'), 'SECRET=1');
-    expect(resolveRepoScopedPath(tmpRoot, '.env')).toBeNull();
+    const rejections = [];
+    expect(resolveRepoScopedPath(tmpRoot, '.env', rejections)).toBeNull();
+    expect(rejections[0].reason).toBe('secret_file');
   });
 });

--- a/test/repo-lock.test.js
+++ b/test/repo-lock.test.js
@@ -1,0 +1,29 @@
+const { createDb, resetDb, sqlJson } = require('../db');
+const { tryAcquireSqliteLock, releaseSqliteLock, makeHolderId } = require('../src/code-index/repo-lock');
+
+describe('repo-index lock', () => {
+  beforeEach(() => {
+    resetDb();
+    createDb({ db_path: ':memory:' });
+  });
+
+  afterEach(() => resetDb());
+
+  it('acquires and releases a sqlite-backed lock', () => {
+    const holder = makeHolderId();
+    expect(tryAcquireSqliteLock('my-repo', holder)).toBe(true);
+    const rows = sqlJson('SELECT holder_id FROM repo_index_locks WHERE repo_name = ?', ['my-repo']);
+    expect(rows[0].holder_id).toBe(holder);
+    releaseSqliteLock('my-repo', holder);
+    expect(sqlJson('SELECT holder_id FROM repo_index_locks WHERE repo_name = ?', ['my-repo'])).toHaveLength(0);
+  });
+
+  it('blocks a second holder until release', () => {
+    const first = makeHolderId();
+    const second = makeHolderId();
+    expect(tryAcquireSqliteLock('shared-repo', first)).toBe(true);
+    expect(tryAcquireSqliteLock('shared-repo', second)).toBe(false);
+    releaseSqliteLock('shared-repo', first);
+    expect(tryAcquireSqliteLock('shared-repo', second)).toBe(true);
+  });
+});

--- a/test/services-dedup.test.js
+++ b/test/services-dedup.test.js
@@ -101,6 +101,17 @@ describe('services/dedup: markDuplicate', () => {
     expect(result.error).toContain('source');
   });
 
+  it('should reject identical source and target', () => {
+    const deps = {
+      sqlJson: vi.fn(),
+      sqlRun: vi.fn(),
+      softDeleteObservation: vi.fn(),
+    };
+    const result = markDuplicate(deps, { source: '10', target: '10' });
+    expect(result.error).toMatch(/different/i);
+    expect(deps.softDeleteObservation).not.toHaveBeenCalled();
+  });
+
   it('should call softDeleteObservation with target', () => {
     const deps = {
       sqlJson: vi.fn(),

--- a/test/trust-sync-paths.test.js
+++ b/test/trust-sync-paths.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { resolveIndexedFilePaths } = require('../src/trust-sync/change-detector');
+const { resolveIndexedFilePaths, parseGitDiffNameStatus } = require('../src/trust-sync/change-detector');
 
 describe('resolveIndexedFilePaths', () => {
   it('maps git-relative paths to absolute indexed paths', () => {
@@ -31,5 +31,17 @@ describe('resolveIndexedFilePaths', () => {
         // ignore
       }
     }
+  });
+});
+
+describe('parseGitDiffNameStatus', () => {
+  it('includes both sides of a rename', () => {
+    const paths = parseGitDiffNameStatus('R100\told.js\tnew.js\n');
+    expect(paths.sort()).toEqual(['new.js', 'old.js']);
+  });
+
+  it('includes deleted and modified paths', () => {
+    const paths = parseGitDiffNameStatus('M\tsrc/a.js\nD\tsrc/b.js\nA\tsrc/c.js\n');
+    expect(paths.sort()).toEqual(['src/a.js', 'src/b.js', 'src/c.js']);
   });
 });

--- a/test/trust-sync-paths.test.js
+++ b/test/trust-sync-paths.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { resolveIndexedFilePaths } = require('../src/trust-sync/change-detector');
+
+describe('resolveIndexedFilePaths', () => {
+  it('maps git-relative paths to absolute indexed paths', () => {
+    const repo = path.join(os.tmpdir(), 'lapis-trust-paths');
+    const file = path.join(repo, 'src', 'app.js');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, 'export const app = 1;\n');
+
+    const resolved = resolveIndexedFilePaths(repo, ['src/app.js']);
+    expect(resolved).toContain(file);
+  });
+
+  it('includes realpath variants for symlinked repo roots', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-trust-real-'));
+    const link = path.join(os.tmpdir(), `lapis-trust-link-${Date.now()}`);
+    try {
+      fs.symlinkSync(repo, link);
+      const file = path.join(repo, 'lib.js');
+      fs.writeFileSync(file, 'module.exports = {};\n');
+
+      const resolved = resolveIndexedFilePaths(link, ['lib.js']);
+      expect(resolved).toContain(file);
+    } finally {
+      try {
+        fs.unlinkSync(link);
+      } catch {
+        // ignore
+      }
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fourth review pass on PR #241 — three additional correctness fixes.

### New fixes (fourth pass)

1. **Trust sync missed renames** — `detectChangedSymbols` used `git diff --name-only`, which omits the old path on renames. Switched to `--name-status` and include both sides of renames (parity with incremental reindex `getGitDelta`).

2. **Scan-hash no-op left `head_commit` stale** — The third-pass fix only advanced `head_commit` when `gitDelta` was present. Scan-hash mode (no stored baseline or git unavailable) could still leave `head_commit` stale after a no-op reindex. Now falls back to `getHeadCommit()`.

3. **HTTP Bearer case sensitivity** — Authorization header now accepts `bearer` / `Bearer` per RFC 7235.

### Prior passes (still included)

- Security: path guards, HTTP API key auth, cross-process index locks
- Data integrity: atomic full rebuild, transactional trust sync
- Logic: Dream Cycle recall counting, bash guardrail cwd fix, session quit grace

### Tests

**1,851 tests passing** (+3 new)

### Commits

1. Initial review fixes
2. Follow-ups (atomic rebuild, SQLite locks)
3. Second pass (diagnostics defer, derived errors)
4. Third pass (head_commit timing, trust paths, git-trust regex)
5. **Fourth pass** (this update)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40ddfc75-56d6-4872-95de-68fcd84f606c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40ddfc75-56d6-4872-95de-68fcd84f606c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

