### PR TITLE
fix: code review issues — ranking, trust recovery, migrations, security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Code review correctness fixes (ranking, trust, migrations, security)**
   - Stop passive context injection from writing to `recall_log` (was poisoning `useful_ratio` ranking every turn).
   - FTS search path now includes `useful_count` (parity with LIKE fallback).
-  - `trustRecovery` reads recalled memories from `recall_log` as well as `session_recalls`.
+  - `trustRecovery` reads useful recalls from `recall_log` (`was_useful = 1`) plus `session_recalls`.
   - Migration guard corrected (`version >= 23`) so V23 (`repo_index_locks`) runs for DBs at version 22.
   - Consolidated orphan recovery uses a real `session_log.id` instead of an observation id.
   - Dream cycle uses cheap compact only (no mid-session `VACUUM`); `report.ok` reflects compact success.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Code review correctness fixes (ranking, trust, migrations, security)**
+  - Stop passive context injection from writing to `recall_log` (was poisoning `useful_ratio` ranking every turn).
+  - FTS search path now includes `useful_count` (parity with LIKE fallback).
+  - `trustRecovery` reads recalled memories from `recall_log` as well as `session_recalls`.
+  - Migration guard corrected (`version >= 23`) so V23 (`repo_index_locks`) runs for DBs at version 22.
+  - Consolidated orphan recovery uses a real `session_log.id` instead of an observation id.
+  - Dream cycle uses cheap compact only (no mid-session `VACUUM`); `report.ok` reflects compact success.
+  - Dream config cleanup requires an explicit `supersedes`/`duplicate` relation (not topic_key alone).
+  - `pr-risk` uses `execFileSync` with git ref validation (prevents shell injection via `--branch`/`--base`).
+  - HTTP server rejects request bodies larger than 1MB.
+  - Ranking handles timestamps that already include a `Z` suffix.
+  - Index worker wraps `ensureDb()` in error handling.
+
 - **Code review security and correctness fixes**
   - Incremental reindex `changed-paths` now enforces repo path boundaries and secret-file skips (parity with full scanner).
   - Full reindex defers `clearRepoIndex` until the first successful write batch so parse failures preserve the existing index.
   - Per-repo index locks prevent concurrent full/incremental rebuilds from interleaving writes.
-  - Dream Cycle "never recalled" cleanup now counts only `was_useful = 1` recalls; context injection logs passive recalls as not useful.
+  - Dream Cycle "never recalled" cleanup counts only `was_useful = 1` recalls.
   - `markDuplicate` rejects identical source/target IDs.
   - Pi trust-sync hook recognizes `git -C <path>` commands (parity with Claude Code bridge).
   - Trust sync applies adjustments in a transaction and initializes `head_commit` on first sync without a one-commit diff penalty.

--- a/data-access/symbols.js
+++ b/data-access/symbols.js
@@ -85,7 +85,7 @@ function getRecalledMemoryIds(deps, sessionId) {
   const { sqlJson } = deps;
   return sqlJson(
     `SELECT DISTINCT memory_id FROM (
-       SELECT memory_id FROM recall_log WHERE session_id = ?
+       SELECT memory_id FROM recall_log WHERE session_id = ? AND was_useful = 1
        UNION
        SELECT memory_id FROM session_recalls WHERE session_id = ?
      )`,

--- a/data-access/symbols.js
+++ b/data-access/symbols.js
@@ -83,7 +83,14 @@ function insertTrustAdjustment(deps, { memoryId, reason, delta }) {
 
 function getRecalledMemoryIds(deps, sessionId) {
   const { sqlJson } = deps;
-  return sqlJson('SELECT memory_id FROM session_recalls WHERE session_id = ?', [sessionId]);
+  return sqlJson(
+    `SELECT DISTINCT memory_id FROM (
+       SELECT memory_id FROM recall_log WHERE session_id = ?
+       UNION
+       SELECT memory_id FROM session_recalls WHERE session_id = ?
+     )`,
+    [sessionId, sessionId],
+  );
 }
 
 function updateLinkTrustByMemoryId(deps, { memoryId, newTrust }) {

--- a/db.js
+++ b/db.js
@@ -454,7 +454,7 @@ function runMigrations() {
     console.error('[db] Failed to read user_version:', e.message);
   }
 
-  if (version >= 22) {
+  if (version >= 23) {
     return { migrated: false, version };
   }
 

--- a/services/recovery.js
+++ b/services/recovery.js
@@ -123,7 +123,7 @@ function recoverOrphans(deps) {
         `INSERT INTO observations (session_id, type, title, content, project, scope)
          VALUES (?, 'session_summary', 'Consolidated Recovery Summary', ?, ?, 'project')
          RETURNING id`,
-        [recentSummaries[0].id, consolidatedContent, orphans[0].project],
+        [orphans[0].id, consolidatedContent, orphans[0].project],
       );
     }
   }

--- a/src/code-analysis/risk-impl.js
+++ b/src/code-analysis/risk-impl.js
@@ -1,4 +1,4 @@
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 // PR risk profiling and untested symbol detection.
 
 const {
@@ -9,6 +9,27 @@ const {
   COMPLEXITY /* oxlint-disable-line no-unused-vars */,
   HOTSPOT_THRESHOLDS /* oxlint-disable-line no-unused-vars */,
 } = require('./shared-deps');
+
+const GIT_REF_RE = /^[A-Za-z0-9._^~/-]+$/;
+
+function isValidGitRef(ref) {
+  return typeof ref === 'string' && ref.length > 0 && GIT_REF_RE.test(ref);
+}
+
+function gitDiffOutput(repoPath, base, branch, stat = false) {
+  if (!isValidGitRef(base) || !isValidGitRef(branch)) {
+    return '';
+  }
+  const range = `${base}...${branch}`;
+  const args = stat
+    ? ['-C', repoPath, 'diff', '--stat', range]
+    : ['-C', repoPath, 'diff', '--name-only', range];
+  return execFileSync('git', args, {
+    encoding: 'utf-8',
+    timeout: 10000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
 
 function getUntestedSymbols(db, repoId, opts = {}) {
   const guard = _requireNativeDb(db);
@@ -165,11 +186,7 @@ function getPrRiskProfile(db, repoId, opts = {}) {
 
   let changedFiles = [];
   try {
-    const diffOutput = execSync(`git -C "${repo.path}" diff --name-only ${base}...${branch}`, {
-      encoding: 'utf-8',
-      timeout: 10000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    const diffOutput = gitDiffOutput(repo.path, base, branch, false);
     changedFiles = diffOutput ? diffOutput.split('\n').filter(Boolean) : [];
   } catch {
     changedFiles = [];
@@ -280,11 +297,7 @@ function getPrRiskProfile(db, repoId, opts = {}) {
   // Signal 5: Change volume (10%)
   let changeVolumeScore = 0;
   try {
-    const diffStat = execSync(`git -C "${repo.path}" diff --stat ${base}...${branch}`, {
-      encoding: 'utf-8',
-      timeout: 10000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
+    const diffStat = gitDiffOutput(repo.path, base, branch, true);
     // Parse the last line which has the total: "X files changed, Y insertions(+), Z deletions(-)"
     const totalMatch = diffStat.match(/(\d+) insertions?.*?(\d+) deletions?/);
     if (totalMatch) {

--- a/src/code-index/index-worker.js
+++ b/src/code-index/index-worker.js
@@ -27,39 +27,39 @@ function emit(type, payload = {}) {
 async function main() {
   const { jobId, mode, repoPath, repoName } = workerData;
 
-  // Open the database. ensureDb() is idempotent; it migrates the schema
-  // (including the V18 index_jobs table) before we touch it.
-  dbModule.ensureDb();
-  const rawDb = dbModule.getDb();
-  const deps = { sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun };
-
-  const languageCounters = new Map();
-  let lastWrite = 0;
-  const writeThrottleMs = 1000;
-
-  function onProgress({ phase, files_total, files_done, current_file, language }) {
-    if (cancelled) throw new Error('cancelled');
-    // Derive language from current_file if not provided by the indexer.
-    const lang = language || (current_file ? safeGetLanguage(current_file) : null);
-    if (lang) {
-      languageCounters.set(lang, (languageCounters.get(lang) || 0) + 1);
-    }
-    const now = Date.now();
-    // Throttle SQLite writes — at most once per second, plus a final write at completion.
-    if (now - lastWrite >= writeThrottleMs || (files_total && files_done >= files_total)) {
-      try {
-        jobStore.updateProgress(deps, jobId, {
-          filesDone: files_done || 0,
-          currentFile: current_file,
-          languageBreakdown: Object.fromEntries(languageCounters),
-        });
-      } catch (_) { /* best-effort */ }
-      lastWrite = now;
-    }
-    emit('progress', { phase, files_total, files_done, current_file, language });
-  }
-
   try {
+    // Open the database. ensureDb() is idempotent; it migrates the schema
+    // (including the V18 index_jobs table) before we touch it.
+    dbModule.ensureDb();
+    const rawDb = dbModule.getDb();
+    const deps = { sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun };
+
+    const languageCounters = new Map();
+    let lastWrite = 0;
+    const writeThrottleMs = 1000;
+
+    function onProgress({ phase, files_total, files_done, current_file, language }) {
+      if (cancelled) throw new Error('cancelled');
+      // Derive language from current_file if not provided by the indexer.
+      const lang = language || (current_file ? safeGetLanguage(current_file) : null);
+      if (lang) {
+        languageCounters.set(lang, (languageCounters.get(lang) || 0) + 1);
+      }
+      const now = Date.now();
+      // Throttle SQLite writes — at most once per second, plus a final write at completion.
+      if (now - lastWrite >= writeThrottleMs || (files_total && files_done >= files_total)) {
+        try {
+          jobStore.updateProgress(deps, jobId, {
+            filesDone: files_done || 0,
+            currentFile: current_file,
+            languageBreakdown: Object.fromEntries(languageCounters),
+          });
+        } catch (_) { /* best-effort */ }
+        lastWrite = now;
+      }
+      emit('progress', { phase, files_total, files_done, current_file, language });
+    }
+
     // We pass the raw better-sqlite3 handle as `db` because the indexer
     // uses db.exec/db.prepare/db.transaction directly. `args.onProgress` is
     // the new hook Task 4 wires through emitProgress.
@@ -90,7 +90,10 @@ async function main() {
     emit('done', { result, languageBreakdown: Object.fromEntries(languageCounters) });
   } catch (e) {
     const status = cancelled ? 'cancelled' : 'error';
-    try { jobStore.completeJob(deps, jobId, { status, error: e.message }); } catch (_) {}
+    try {
+      const deps = { sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun };
+      jobStore.completeJob(deps, jobId, { status, error: e.message });
+    } catch (_) {}
     if (cancelled) emit('cancelled');
     else emit('error', { error: e.message });
   } finally {
@@ -98,4 +101,7 @@ async function main() {
   }
 }
 
-main();
+main().catch((e) => {
+  emit('error', { error: e.message });
+  process.exit(1);
+});

--- a/src/http/server.js
+++ b/src/http/server.js
@@ -3,6 +3,8 @@ const { matchRoute } = require('./routes');
 const { jsonError } = require('./errors');
 const { resolveHttpApiKey, requireHttpAuth, assertServeHostPolicy } = require('./auth');
 
+const MAX_BODY_BYTES = 1024 * 1024;
+
 function createHttpServer(deps) {
   const routes = buildRoutes(deps);
   const authorize = requireHttpAuth(deps.apiKey || null);
@@ -40,17 +42,39 @@ function createHttpServer(deps) {
 function parseBody(req, res) {
   return new Promise((resolve) => {
     let raw = '';
-    req.on('data', (chunk) => (raw += chunk));
+    let totalBytes = 0;
+    let settled = false;
+    const finish = (value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(value);
+    };
+
+    req.on('data', (chunk) => {
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_BODY_BYTES) {
+        jsonError(res, 413, 'payload_too_large', 'Request body exceeds 1MB limit');
+        req.destroy();
+        finish(undefined);
+        return;
+      }
+      raw += chunk;
+    });
     req.on('end', () => {
+      if (settled) {
+        return;
+      }
       if (!raw) {
-        resolve({});
+        finish({});
         return;
       }
       try {
-        resolve(JSON.parse(raw));
+        finish(JSON.parse(raw));
       } catch {
         jsonError(res, 400, 'bad_request', 'Invalid JSON body');
-        resolve(undefined);
+        finish(undefined);
       }
     });
   });

--- a/src/memory-domain/compaction.js
+++ b/src/memory-domain/compaction.js
@@ -257,6 +257,8 @@ function dream(deps, args = {}) {
       AND o2.deleted_at IS NULL
       AND o1.type IN ('decision', 'config', 'architecture')
       AND o2.type IN ('decision', 'config', 'architecture')
+    JOIN observation_relations r2 ON r2.target_id = o1.id AND r2.source_id = o2.id
+      AND r2.relation IN ('duplicate', 'supersedes')
     WHERE o1.deleted_at IS NULL
       AND o1.topic_key IS NOT NULL AND o1.topic_key != ''
       AND o1.topic_key = o2.topic_key
@@ -405,12 +407,12 @@ function dream(deps, args = {}) {
   };
   totalCleaned += sessionsCompacted;
 
-  // Run compact as final step
-  const compactResult = runCompact(deps);
+  // Run cheap compact only — dream may run mid-session; skip VACUUM/FTS optimize.
+  const compactResult = runCompactCheap(deps);
   report.phases.compact = compactResult;
 
   report.completedAt = new Date().toISOString();
-  report.ok = true;
+  report.ok = compactResult.ok !== false;
   report.totalCleaned = totalCleaned;
   report.cleaned = cleanedIds;
 

--- a/src/memory-domain/context.js
+++ b/src/memory-domain/context.js
@@ -70,7 +70,6 @@ function buildTopicQueryMatch(needles) {
 
 function context(deps, args) {
   const { sqlJson, jsonErrNoExit } = deps;
-  const insertRecallLog = deps.insertRecallLog || (() => {});
   const countObservationsByProjectAndType = deps.countObservationsByProjectAndType || (() => 0);
 
   const project = args.project || null;
@@ -78,7 +77,6 @@ function context(deps, args) {
   const rawBudget = parseInt(args['token-budget'], 10);
   const tokenBudget = Number.isFinite(rawBudget) && rawBudget > 0 ? rawBudget : 0;
   const fetchCeiling = tokenBudget > 0 ? Math.max(limit, limit * 3) : limit;
-  const sessionId = args['session-id'] ? parseInt(args['session-id'], 10) : null;
   const topicKey = args['topic-key'] || null;
   const topicQuery = args.query || null;
   const deep = args.deep === 'true' || args.deep === true;
@@ -198,16 +196,8 @@ function context(deps, args) {
   const budgeted = tokenBudget > 0 ? applyTokenBudget(filtered, tokenBudget) : filtered;
   const truncatedCount = budgeted.filter((o) => o._truncated).length;
 
-  if (sessionId && budgeted.length > 0) {
-    const recallQuery = topicQuery || topicKey || 'context-auto';
-    const entries = budgeted.map((o) => ({
-      memoryId: o.id,
-      sessionId: String(sessionId),
-      query: recallQuery,
-      wasUseful: false,
-    }));
-    insertRecallLog(entries);
-  }
+  // Passive context injection does not write to recall_log — it is not a search
+  // recall and logging here (even as was_useful=0) poisons ranking useful_ratio.
 
   // Supplemental cross-project suggestions: when project-scoped, also find
   // relevant memories from other projects so insights transfer across projects.
@@ -221,7 +211,7 @@ function context(deps, args) {
                COALESCE(sl.trust_score, ${RANKING.DEFAULT_TRUST_SCORE}) as trust_score,
                ${match.scoreSql} as match_score
         FROM observations o
-        LEFT JOIN symbol_links sl ON sl.memory_id = o.id
+        LEFT JOIN symbol_links sl ON sl.memory_id = CAST(o.id AS TEXT)
         WHERE o.deleted_at IS NULL AND o.type != 'skill'
           AND o.scope = 'project' AND o.project != ?
           AND (o.expires_at IS NULL OR o.expires_at > datetime('now'))

--- a/src/memory-domain/search.js
+++ b/src/memory-domain/search.js
@@ -43,7 +43,8 @@ function rankObservations(rows, query = '') {
         const hits = queryWords.filter((w) => title.includes(w)).length;
         ftsScore = queryWords.length > 0 ? (hits / queryWords.length) * 2 : 0;
       }
-      const ageMs = now - new Date(`${row.created_at}Z`).getTime();
+      const createdAt = row.created_at || '';
+      const ageMs = now - new Date(createdAt.endsWith('Z') ? createdAt : `${createdAt}Z`).getTime();
       const recencyScore = Math.exp(-ageMs / TIME_WINDOWS.RECENCY_HALF_LIFE_MS);
       const trustScore =
         row.trust_score !== undefined && row.trust_score !== null ? row.trust_score : RANKING.DEFAULT_TRUST_SCORE;
@@ -226,7 +227,8 @@ function search(deps, args) {
                snippet(observations_fts, 0, '»', '«', '…', 32) as snippet,
                rank,
                sl.trust_score,
-               COALESCE(rl.recall_count, 0) as recall_count
+               COALESCE(rl.recall_count, 0) as recall_count,
+               COALESCE(rl.useful_count, 0) as useful_count
         FROM observations o
         JOIN observations_fts fts ON o.id = fts.rowid
         ${TRUST_RECALL_JOINS}

--- a/test/data-access-symbols.test.js
+++ b/test/data-access-symbols.test.js
@@ -58,7 +58,7 @@ describe('data-access/symbols', () => {
       deps.sqlJson.mockReturnValue([{ memory_id: '42' }]);
       const result = getRecalledMemoryIds(deps, 7);
       expect(deps.sqlJson).toHaveBeenCalledWith(
-        expect.stringContaining('recall_log'),
+        expect.stringContaining('was_useful = 1'),
         [7, 7],
       );
       expect(result).toEqual([{ memory_id: '42' }]);

--- a/test/data-access-symbols.test.js
+++ b/test/data-access-symbols.test.js
@@ -2,6 +2,7 @@ const {
   linkSymbol,
   adjustTrust,
   recordRecall,
+  getRecalledMemoryIds,
   getStaleLinks,
   getSymbolsForMemory,
   findUnlinked,
@@ -48,6 +49,19 @@ describe('data-access/symbols', () => {
         expect.stringContaining('INSERT OR IGNORE INTO session_recalls'),
         expect.any(Array),
       );
+    });
+  });
+
+  describe('getRecalledMemoryIds', () => {
+    it('queries recall_log and session_recalls', () => {
+      const deps = mockDeps();
+      deps.sqlJson.mockReturnValue([{ memory_id: '42' }]);
+      const result = getRecalledMemoryIds(deps, 7);
+      expect(deps.sqlJson).toHaveBeenCalledWith(
+        expect.stringContaining('recall_log'),
+        [7, 7],
+      );
+      expect(result).toEqual([{ memory_id: '42' }]);
     });
   });
 

--- a/test/mutation-killers.test.js
+++ b/test/mutation-killers.test.js
@@ -559,14 +559,14 @@ describe('context.js mutation killers', () => {
     expect(r.stats.budget_used).toBeGreaterThan(0);
   });
 
-  it('recall log recorded with session-id', () => {
+  it('passive context does not write recall log (avoids ranking poison)', () => {
     const irl = vi.fn();
     const sqlJson = vi.fn((q) => {
       if (q.includes('session_log') || q.includes("scope = 'personal'")) return [];
       return [{ id: 1, title: 't', type: 'decision', content: 'c', scope: 'project', topic_key: null, created_at: new Date().toISOString().replace('Z', ''), trust_score: 0.5, recall_count: 0 }];
     });
     context(mockDeps({ sqlJson, insertRecallLog: irl }), { project: 'p', 'session-id': '10' });
-    expect(irl).toHaveBeenCalled();
+    expect(irl).not.toHaveBeenCalled();
   });
 
   it('cross-project suggestions with query', () => {
@@ -1504,20 +1504,17 @@ describe('context.js exact SQL verification', () => {
     expect(crossCall).toBeUndefined();
   });
 
-  it('context: recall log query is "context-auto" when no topic', () => {
+  it('context: passive injection does not write recall log', () => {
     const irlMock = vi.fn();
     const sqlJson = vi.fn((q) => {
       if (q.includes('session_log') || q.includes("scope = 'personal'")) return [];
       return [{ id: 1, title: 't', type: 'decision', content: 'c', scope: 'project', topic_key: null, created_at: new Date().toISOString().replace('Z', ''), trust_score: 0.5, recall_count: 0 }];
     });
     context(mockDeps({ sqlJson, insertRecallLog: irlMock }), { project: 'p', 'session-id': '1' });
-    if (irlMock.mock.calls.length > 0) {
-      const entries = irlMock.mock.calls[0][0];
-      expect(entries[0].query).toBe('context-auto');
-    }
+    expect(irlMock).not.toHaveBeenCalled();
   });
 
-  it('context: recall log query uses topicQuery when present', () => {
+  it('context: topic query path does not write recall log', () => {
     const irlMock = vi.fn();
     const sqlJson = vi.fn((q) => {
       if (q.includes('session_log') || q.includes("scope = 'personal'")) return [];
@@ -1525,13 +1522,10 @@ describe('context.js exact SQL verification', () => {
       return [];
     });
     context(mockDeps({ sqlJson, insertRecallLog: irlMock }), { project: 'p', query: 'jwt auth', 'session-id': '1' });
-    if (irlMock.mock.calls.length > 0) {
-      const entries = irlMock.mock.calls[0][0];
-      expect(entries[0].query).toBe('jwt auth');
-    }
+    expect(irlMock).not.toHaveBeenCalled();
   });
 
-  it('context: recall log query uses topicKey when present (no query)', () => {
+  it('context: topic-key path does not write recall log', () => {
     const irlMock = vi.fn();
     const sqlJson = vi.fn((q) => {
       if (q.includes('session_log') || q.includes("scope = 'personal'")) return [];
@@ -1539,10 +1533,7 @@ describe('context.js exact SQL verification', () => {
       return [];
     });
     context(mockDeps({ sqlJson, insertRecallLog: irlMock }), { project: 'p', 'topic-key': 'auth', 'session-id': '1' });
-    if (irlMock.mock.calls.length > 0) {
-      const entries = irlMock.mock.calls[0][0];
-      expect(entries[0].query).toBe('auth');
-    }
+    expect(irlMock).not.toHaveBeenCalled();
   });
 });
 
@@ -2794,20 +2785,14 @@ describe('context.js boundary condition killers', () => {
     expect(r.stats.budget_used).toBeUndefined();
   });
 
-  it('context: session-id is parseInt-ed', () => {
-    const sqlJson = vi.fn(() => []);
-    // session-id='42' should be parsed to 42
-    // Then used in recall log as String(42)
+  it('context: session-id does not trigger passive recall logging', () => {
     const irlMock = vi.fn();
     const sqlJson2 = vi.fn((q) => {
       if (q.includes('session_log') || q.includes("scope = 'personal'")) return [];
       return [{ id: 1, title: 't', type: 'decision', content: 'c', scope: 'project', topic_key: null, created_at: new Date().toISOString().replace('Z', ''), trust_score: 0.5, recall_count: 0 }];
     });
     context(mockDeps({ sqlJson: sqlJson2, insertRecallLog: irlMock }), { project: 'p', 'session-id': '42' });
-    if (irlMock.mock.calls.length > 0) {
-      // sessionId is parsed to 42, then String(42) = '42'
-      expect(irlMock.mock.calls[0][0][0].sessionId).toBe('42');
-    }
+    expect(irlMock).not.toHaveBeenCalled();
   });
 
   it('context: session-id is null when not provided', () => {

--- a/test/review-fixes.test.js
+++ b/test/review-fixes.test.js
@@ -1,0 +1,134 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const dbModule = require('../db');
+const { getRecalledMemoryIds } = require('../data-access/symbols');
+const { trustRecovery } = require('../services/dream');
+const { getPrRiskProfile } = require('../src/code-analysis/risk-impl');
+const { createHttpServer } = require('../src/http/server');
+
+describe('review fixes', () => {
+  describe('migration V23', () => {
+    let tmpDb;
+
+    afterEach(() => {
+      if (tmpDb && fs.existsSync(tmpDb)) {
+        fs.unlinkSync(tmpDb);
+      }
+      dbModule.resetDb();
+      dbModule.ensureDb();
+    });
+
+    it('advances user_version from 22 to 23 and creates repo_index_locks', () => {
+      tmpDb = path.join(os.tmpdir(), `lapis-v23-${Date.now()}.db`);
+      dbModule.resetDb();
+      dbModule.createDb({ db_path: tmpDb });
+
+      const db = dbModule.getDb();
+      db.exec('PRAGMA user_version = 22');
+      db.exec('DROP TABLE IF EXISTS repo_index_locks');
+
+      dbModule.resetDb();
+      dbModule.createDb({ db_path: tmpDb });
+
+      const reopened = dbModule.getDb();
+      const version = reopened.prepare('PRAGMA user_version').get().user_version;
+      const table = reopened
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='repo_index_locks'")
+        .get();
+      expect(version).toBe(23);
+      expect(table).toBeTruthy();
+    });
+  });
+
+  describe('trust recovery from recall_log', () => {
+    let sessionId;
+    let memoryId;
+
+    beforeAll(() => {
+      dbModule.ensureDb();
+      const session = dbModule.sqlJson(
+        "INSERT INTO session_log (project, started_at) VALUES (?, datetime('now')) RETURNING id",
+        ['review-fixes-trust'],
+      );
+      sessionId = session[0].id;
+      const obs = dbModule.sqlJson(
+        `INSERT INTO observations (session_id, type, title, content, project, scope)
+         VALUES (?, 'decision', 'Trust test', 'content', 'review-fixes-trust', 'project')
+         RETURNING id`,
+        [sessionId],
+      );
+      memoryId = obs[0].id;
+      dbModule.sqlRun(
+        'INSERT INTO recall_log (memory_id, session_id, query, was_useful) VALUES (?, ?, ?, 1)',
+        [memoryId, sessionId, 'test-query'],
+      );
+      dbModule.sqlRun(
+        'INSERT INTO symbol_links (memory_id, symbol_id, repo, trust_score) VALUES (?, ?, ?, ?)',
+        [String(memoryId), '__unlinked__', 'review-fixes-trust', 0.5],
+      );
+    });
+
+    it('getRecalledMemoryIds includes recall_log entries', () => {
+      const rows = getRecalledMemoryIds(
+        { sqlJson: dbModule.sqlJson },
+        sessionId,
+      );
+      expect(rows.some((r) => String(r.memory_id) === String(memoryId))).toBe(true);
+    });
+
+    it('trustRecovery boosts trust for recalled memories', () => {
+      const result = trustRecovery({ session: String(sessionId) });
+      expect(result.ok).toBe(true);
+      expect(result.memoriesRecovered).toBeGreaterThan(0);
+    });
+  });
+
+  describe('pr-risk git ref validation', () => {
+    it('rejects shell metacharacters in branch/base without executing', () => {
+      const db = dbModule.getDb();
+      const repo = db.prepare('SELECT id FROM code_repos LIMIT 1').get();
+      if (!repo) {
+        return;
+      }
+      const result = getPrRiskProfile(db, repo.id, {
+        branch: 'HEAD; echo pwned',
+        base: 'main',
+      });
+      expect(result.note).toBe('No changed files detected.');
+    });
+  });
+
+  describe('HTTP body size limit', () => {
+    let server;
+    let baseUrl;
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise((resolve) => server.close(resolve));
+      }
+    });
+
+    it('returns 413 when request body exceeds 1MB', async () => {
+      const { createAurexRepository } = require('../src/platform/storage/repositories/aurex');
+      server = createHttpServer({
+        apiKey: null,
+        repositories: {
+          aurex: createAurexRepository({ sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun }),
+        },
+      });
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address();
+      baseUrl = `http://127.0.0.1:${port}`;
+
+      const oversized = 'x'.repeat(1024 * 1024 + 1);
+      const res = await fetch(`${baseUrl}/missions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ data: oversized }),
+      });
+      expect(res.status).toBe(413);
+    });
+  });
+});

--- a/test/review-fixes.test.js
+++ b/test/review-fixes.test.js
@@ -83,16 +83,58 @@ describe('review fixes', () => {
       expect(result.ok).toBe(true);
       expect(result.memoriesRecovered).toBeGreaterThan(0);
     });
+
+    it('trustRecovery ignores memories only recalled with was_useful = 0', () => {
+      const session = dbModule.sqlJson(
+        "INSERT INTO session_log (project, started_at) VALUES (?, datetime('now')) RETURNING id",
+        ['review-fixes-trust-negative'],
+      );
+      const negativeSessionId = session[0].id;
+      const obs = dbModule.sqlJson(
+        `INSERT INTO observations (session_id, type, title, content, project, scope)
+         VALUES (?, 'decision', 'Ignored recall', 'content', 'review-fixes-trust-negative', 'project')
+         RETURNING id`,
+        [negativeSessionId],
+      );
+      const ignoredMemoryId = obs[0].id;
+      dbModule.sqlRun(
+        'INSERT INTO recall_log (memory_id, session_id, query, was_useful) VALUES (?, ?, ?, 0)',
+        [ignoredMemoryId, negativeSessionId, 'ignored-search'],
+      );
+      dbModule.sqlRun(
+        'INSERT INTO symbol_links (memory_id, symbol_id, repo, trust_score) VALUES (?, ?, ?, ?)',
+        [String(ignoredMemoryId), '__unlinked__', 'review-fixes-trust-negative', 0.5],
+      );
+
+      const recalled = getRecalledMemoryIds({ sqlJson: dbModule.sqlJson }, negativeSessionId);
+      expect(recalled.some((r) => String(r.memory_id) === String(ignoredMemoryId))).toBe(false);
+
+      const result = trustRecovery({ session: String(negativeSessionId) });
+      expect(result.ok).toBe(true);
+      expect(result.memoriesRecovered).toBe(0);
+    });
   });
 
   describe('pr-risk git ref validation', () => {
-    it('rejects shell metacharacters in branch/base without executing', () => {
-      const db = dbModule.getDb();
-      const repo = db.prepare('SELECT id FROM code_repos LIMIT 1').get();
-      if (!repo) {
+    let repoId;
+
+    beforeAll(() => {
+      dbModule.ensureDb();
+      const existing = dbModule.sqlJson('SELECT id FROM code_repos WHERE name = ?', ['review-fixes-pr-risk']);
+      if (existing.length > 0) {
+        repoId = existing[0].id;
         return;
       }
-      const result = getPrRiskProfile(db, repo.id, {
+      const inserted = dbModule.sqlJson(
+        'INSERT INTO code_repos (name, path) VALUES (?, ?) RETURNING id',
+        ['review-fixes-pr-risk', process.cwd()],
+      );
+      repoId = inserted[0].id;
+    });
+
+    it('rejects shell metacharacters in branch/base without executing', () => {
+      const db = dbModule.getDb();
+      const result = getPrRiskProfile(db, repoId, {
         branch: 'HEAD; echo pwned',
         base: 'main',
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes legitimate issues found in the LaPis code review across memory ranking, trust recovery, schema migrations, dream cycle behavior, and security hardening.

## Type of Change

- [x] Bug fix

## Changes

### Memory ranking & trust (P0)
- **Context injection** no longer writes to `recall_log` on every turn — passive injection was logging `was_useful=0`, driving `useful_ratio` toward zero and down-ranking frequently shown memories.
- **FTS search** now selects `useful_count` (parity with LIKE fallback) so ranking is consistent on the common FTS path.
- **`trustRecovery`** reads useful recalls from `recall_log` (`was_useful = 1`) plus `session_recalls`, so session-end passive survival works in Pi/MCP usage without boosting ignored search results.

### Data integrity & migrations (P0/P1)
- **Migration guard** corrected from `version >= 22` to `version >= 23` so V23 (`repo_index_locks`) runs for upgraded databases stuck at version 22.
- **Consolidated recovery summary** uses a real `session_log.id` instead of an observation id for `session_id`.

### Dream cycle & reliability (P1)
- **Dream cycle** uses `runCompactCheap` only (no mid-session `VACUUM`); `report.ok` now reflects compact success.
- **Dream config cleanup** requires an explicit `supersedes`/`duplicate` relation — no longer deletes configs sharing only a `topic_key`.
- **Index worker** wraps `ensureDb()` in error handling with proper worker error emission.

### Security (P1)
- **`pr-risk`** uses `execFileSync` with git ref validation instead of shell-interpolated `execSync` for `--branch`/`--base`.
- **HTTP server** rejects request bodies over 1MB with HTTP 413.

### Minor
- Ranking handles ISO timestamps that already include a `Z` suffix.
- Cross-project context trust join uses `CAST(o.id AS TEXT)` for consistency.

## How Has This Been Tested?

- `npm test` — **1858 / 1858** tests pass
- New `test/review-fixes.test.js` covers V22→V23 migration, trust recovery from `recall_log`, negative recall exclusion, git ref validation, and HTTP body limit
- Updated `test/mutation-killers.test.js` and `test/data-access-symbols.test.js` for new context/recall behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b413fc5-1c58-4aea-ae54-e26d4a0ec112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b413fc5-1c58-4aea-ae54-e26d4a0ec112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

