### PR TITLE
Fix code correctness review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - HTTP `POST /memory/search` and `GET /todos/:id/context` read `search().results` instead of treating the object as an array.
   - `listMissionLedgers` includes todos; `claimNextReadyTodo` honors `depends_on` completion.
   - Incremental reindex progress guards null `head_commit`; derived-index failures log to stderr.
-  - Session-end vacuum gate uses per-project ended-session count (matches `sessionStart` cadence).
+  - Session-end vacuum gate uses per-project session count (same query as `sessionStart`).
   - `log-negative-recall` returns a structured error for invalid `--entries` JSON.
+  - Document `claim-next` dependency semantics in `docs/API.md`; wildcard synthetic bindings inherit `source_module`.
+  - HTTP E2E test asserts non-empty `POST /memory/search` results.
 
 - **Code review correctness fixes (ranking, trust, migrations, security)**
   - Stop passive context injection from writing to `recall_log` (was poisoning `useful_ratio` ranking every turn).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `log-negative-recall` returns a structured error for invalid `--entries` JSON.
   - Document `claim-next` dependency semantics in `docs/API.md`; wildcard synthetic bindings inherit `source_module`.
   - HTTP E2E test asserts non-empty `POST /memory/search` results.
+  - `listMissionLedgers` batch-loads todos in one query (no per-ledger N+1).
+  - `claim-next` treats `implemented` dependencies as satisfied.
+  - V10 migration DDL includes `source_module` on `file_scope_bindings`.
 
 - **Code review correctness fixes (ranking, trust, migrations, security)**
   - Stop passive context injection from writing to `recall_log` (was poisoning `useful_ratio` ranking every turn).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Code correctness review fixes**
+  - Export `runCompactCheap` / `runVacuum` from `services/dream.js` so `session-end` runs cheap compact and gated vacuum again.
+  - Add `source_module` column to `file_scope_bindings` (migration V24); persist module paths in `insertScopeBindings`.
+  - Scope resolver resolves import targets via `source_module` before falling back to `LIMIT 1`.
+  - HTTP `POST /memory/search` and `GET /todos/:id/context` read `search().results` instead of treating the object as an array.
+  - `listMissionLedgers` includes todos; `claimNextReadyTodo` honors `depends_on` completion.
+  - Incremental reindex progress guards null `head_commit`; derived-index failures log to stderr.
+  - Session-end vacuum gate uses per-project ended-session count (matches `sessionStart` cadence).
+  - `log-negative-recall` returns a structured error for invalid `--entries` JSON.
+
 - **Code review correctness fixes (ranking, trust, migrations, security)**
   - Stop passive context injection from writing to `recall_log` (was poisoning `useful_ratio` ranking every turn).
   - FTS search path now includes `useful_count` (parity with LIKE fallback).

--- a/commands/observation.js
+++ b/commands/observation.js
@@ -169,7 +169,12 @@ function getStats(deps) {
 }
 
 function logNegativeRecall(deps, args) {
-  const entries = JSON.parse(args.entries || '[]');
+  let entries;
+  try {
+    entries = JSON.parse(args.entries || '[]');
+  } catch {
+    return { error: 'Invalid --entries JSON' };
+  }
   if (!entries.length) {
     return { logged: 0 };
   }

--- a/db.js
+++ b/db.js
@@ -779,6 +779,7 @@ function runMigrationV10() {
         origin          TEXT NOT NULL,
         source_file_id  INTEGER NULL REFERENCES code_files(id) ON DELETE SET NULL,
         source_name     TEXT NULL,
+        source_module   TEXT NULL,
         line_start      INTEGER NOT NULL,
         line_end        INTEGER NOT NULL,
         scope_depth     INTEGER NOT NULL DEFAULT 0,

--- a/db.js
+++ b/db.js
@@ -348,7 +348,7 @@ const _CRITICAL_TABLES = [
   // V10: scope-aware edge extraction
   [
     'file_scope_bindings',
-    `CREATE TABLE IF NOT EXISTS file_scope_bindings (id INTEGER PRIMARY KEY AUTOINCREMENT, repo_id INTEGER NOT NULL REFERENCES code_repos(id) ON DELETE CASCADE, file_id INTEGER NOT NULL REFERENCES code_files(id) ON DELETE CASCADE, name TEXT NOT NULL, kind TEXT NOT NULL, origin TEXT NOT NULL, source_file_id INTEGER NULL, source_name TEXT NULL, line_start INTEGER NOT NULL, line_end INTEGER NOT NULL, scope_depth INTEGER NOT NULL DEFAULT 0, byte_start INTEGER NULL, byte_end INTEGER NULL, first_seen_pass INTEGER NOT NULL DEFAULT 0)`,
+    `CREATE TABLE IF NOT EXISTS file_scope_bindings (id INTEGER PRIMARY KEY AUTOINCREMENT, repo_id INTEGER NOT NULL REFERENCES code_repos(id) ON DELETE CASCADE, file_id INTEGER NOT NULL REFERENCES code_files(id) ON DELETE CASCADE, name TEXT NOT NULL, kind TEXT NOT NULL, origin TEXT NOT NULL, source_file_id INTEGER NULL, source_name TEXT NULL, source_module TEXT NULL, line_start INTEGER NOT NULL, line_end INTEGER NOT NULL, scope_depth INTEGER NOT NULL DEFAULT 0, byte_start INTEGER NULL, byte_end INTEGER NULL, first_seen_pass INTEGER NOT NULL DEFAULT 0)`,
   ],
   [
     'scope_resolution',
@@ -454,7 +454,7 @@ function runMigrations() {
     console.error('[db] Failed to read user_version:', e.message);
   }
 
-  if (version >= 23) {
+  if (version >= 24) {
     return { migrated: false, version };
   }
 
@@ -481,6 +481,7 @@ function runMigrations() {
     { to: 21, run: runMigrationV21 },
     { to: 22, run: runMigrationV22 },
     { to: 23, run: runMigrationV23 },
+    { to: 24, run: runMigrationV24 },
   ];
 
   const fromVersion = version;
@@ -1375,6 +1376,23 @@ function runMigrationV23() {
     });
   } catch (e) {
     errors.push(`V23: ${e.message}`);
+  }
+  return errors;
+}
+
+function runMigrationV24() {
+  const errors = [];
+  try {
+    withTransaction(() => {
+      const cols = sqlJson('PRAGMA table_info(file_scope_bindings)');
+      const hasSourceModule = cols.some((c) => c.name === 'source_module');
+      if (!hasSourceModule) {
+        sqlRaw('ALTER TABLE file_scope_bindings ADD COLUMN source_module TEXT NULL');
+      }
+      sqlRaw('PRAGMA user_version = 24');
+    });
+  } catch (e) {
+    errors.push(`V24: ${e.message}`);
   }
   return errors;
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -188,7 +188,7 @@ See [`CLAUDE_CODE.md`](CLAUDE_CODE.md) for daemon configuration and lockfile lay
 | GET    | `/missions/:missionId/todos`                      | List todos by mission.               |
 | GET    | `/todos`                                          | List all todos.                      |
 | POST   | `/todos/search`                                   | Search todos.                        |
-| POST   | `/missions/:missionId/todos/claim-next`           | Claim the next ready todo whose `dependsOn` entries are all `passed`, `merged`, or `cancelled`. |
+| POST   | `/missions/:missionId/todos/claim-next`           | Claim the next ready todo whose `dependsOn` entries are all `passed`, `merged`, `cancelled`, or `implemented`. |
 | GET    | `/todos/:todoId`                                  | Get a todo by ID.                    |
 | PATCH  | `/todos/:todoId`                                  | Update a todo.                       |
 | PATCH  | `/todos/:todoId/status`                           | Set todo status.                     |

--- a/docs/API.md
+++ b/docs/API.md
@@ -136,7 +136,7 @@ See [`CLAUDE_CODE.md`](CLAUDE_CODE.md) for daemon configuration and lockfile lay
 
 | Method | Endpoint          | Purpose                      |
 | ------ | ----------------- | ---------------------------- |
-| POST   | `/memory/search`  | Search memories via HTTP.    |
+| POST   | `/memory/search`  | Search memories via HTTP. Returns `{ results: [...] }` mapped from the memory search domain. Missing `query` returns 400. |
 
 ### Costs
 
@@ -188,7 +188,7 @@ See [`CLAUDE_CODE.md`](CLAUDE_CODE.md) for daemon configuration and lockfile lay
 | GET    | `/missions/:missionId/todos`                      | List todos by mission.               |
 | GET    | `/todos`                                          | List all todos.                      |
 | POST   | `/todos/search`                                   | Search todos.                        |
-| POST   | `/missions/:missionId/todos/claim-next`           | Claim the next ready todo.           |
+| POST   | `/missions/:missionId/todos/claim-next`           | Claim the next ready todo whose `dependsOn` entries are all `passed`, `merged`, or `cancelled`. |
 | GET    | `/todos/:todoId`                                  | Get a todo by ID.                    |
 | PATCH  | `/todos/:todoId`                                  | Update a todo.                       |
 | PATCH  | `/todos/:todoId/status`                           | Set todo status.                     |

--- a/schema.sql
+++ b/schema.sql
@@ -563,6 +563,7 @@ CREATE TABLE IF NOT EXISTS file_scope_bindings (
   origin          TEXT NOT NULL,
   source_file_id  INTEGER NULL REFERENCES code_files(id) ON DELETE SET NULL,
   source_name     TEXT NULL,
+  source_module   TEXT NULL,
   line_start      INTEGER NOT NULL,
   line_end        INTEGER NOT NULL,
   scope_depth     INTEGER NOT NULL DEFAULT 0,

--- a/services/dream.js
+++ b/services/dream.js
@@ -27,4 +27,12 @@ function trustRecovery(args) {
   return compactionDomain.trustRecovery(defaultDeps(), args);
 }
 
-module.exports = { runCompact, compact, dream, trustRecovery };
+function runCompactCheap(deps = defaultDeps()) {
+  return compactionDomain.runCompactCheap(deps);
+}
+
+function runVacuum(deps = defaultDeps()) {
+  return compactionDomain.runVacuum(deps);
+}
+
+module.exports = { runCompact, runCompactCheap, runVacuum, compact, dream, trustRecovery };

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -36,8 +36,8 @@ function insertScopeBindings(db, repoId, fileId, bindings) {
   db.prepare('DELETE FROM file_scope_bindings WHERE file_id = ?').run(fileId);
 
   const stmt = db.prepare(
-    `INSERT INTO file_scope_bindings (repo_id, file_id, name, kind, origin, source_file_id, source_name, line_start, line_end, scope_depth, byte_start, byte_end, first_seen_pass)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+    `INSERT INTO file_scope_bindings (repo_id, file_id, name, kind, origin, source_file_id, source_name, source_module, line_start, line_end, scope_depth, byte_start, byte_end, first_seen_pass)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)`,
   );
 
   for (const b of bindings) {
@@ -47,8 +47,9 @@ function insertScopeBindings(db, repoId, fileId, bindings) {
       b.name,
       b.kind,
       b.origin,
-      b.sourceModule ? null : null, // Source_file_id resolved in derived phase
+      null, // source_file_id resolved in derived phase from code_imports
       b.sourceName || null,
+      b.sourceModule || null,
       b.lineStart,
       b.lineEnd,
       b.scopeDepth || 0,
@@ -56,6 +57,10 @@ function insertScopeBindings(db, repoId, fileId, bindings) {
       b.byteEnd || null,
     );
   }
+}
+
+function logDerivedError(step, e) {
+  console.error(`[indexer] derived phase failed (${step}): ${e.message}`);
 }
 
 function emitProgress(args, phase, detail, stats) {
@@ -329,7 +334,9 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     if (ig.success) {
       importEdges = ig.edges;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('import-graph', e);
+  }
 
   // ── Scope resolution (v10) ────────────────────────────────
   let scopeResolved = 0;
@@ -349,7 +356,9 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
       },
     });
     scopeResolved = sr.resolved;
-  } catch {}
+  } catch (e) {
+    logDerivedError('scope-resolution', e);
+  }
 
   emitProgress(args, 'analysis', { step: 'build-call-graph', message: 'Step 5/5: building call graph...' }, stats);
   try {
@@ -369,7 +378,9 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     if (cg.success) {
       callEdges = cg.calls;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('call-graph', e);
+  }
   emitProgress(
     args,
     'analysis',
@@ -381,7 +392,9 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     if (cc.success) {
       complexityCount = cc.symbols;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('complexity', e);
+  }
 
   let relationEdges = 0;
   emitProgress(args, 'analysis', { step: 'build-relations', message: 'Step 5/5: building relation edges...' }, stats);
@@ -390,7 +403,9 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     if (re.success) {
       relationEdges = re.count;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('relations', e);
+  }
 
   let cochangeEdges = 0;
   emitProgress(args, 'analysis', { step: 'build-cochange', message: 'Step 5/5: building co-change edges...' }, stats);
@@ -399,7 +414,9 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     if (cc2.success) {
       cochangeEdges = cc2.count;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('cochange', e);
+  }
 
   return {
     importEdges,
@@ -433,7 +450,9 @@ function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, dele
     if (ig.success) {
       importEdges = ig.edges;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('import-graph-incremental', e);
+  }
 
   // ── Scope resolution (v10) ────────────────────────────────
   let scopeResolved = 0;
@@ -449,7 +468,9 @@ function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, dele
   try {
     const sr = resolveScopeBindingsForFiles(db, repoId, changedFileIds, deletedFileIds);
     scopeResolved = sr.resolved || 0;
-  } catch {}
+  } catch (e) {
+    logDerivedError('scope-resolution-incremental', e);
+  }
 
   emitProgress(
     args,
@@ -477,7 +498,9 @@ function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, dele
     if (cg.success) {
       callEdges = cg.calls;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('call-graph-incremental', e);
+  }
 
   emitProgress(
     args,
@@ -493,7 +516,9 @@ function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, dele
     if (cc.success) {
       complexityCount = cc.symbols;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('complexity-incremental', e);
+  }
 
   let relationEdges = 0;
   try {
@@ -501,7 +526,9 @@ function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, dele
     if (re.success) {
       relationEdges = re.count;
     }
-  } catch {}
+  } catch (e) {
+    logDerivedError('relations-incremental', e);
+  }
 
   return {
     importEdges,
@@ -1129,7 +1156,7 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
   const skipSummary = formatSkipReport(skipReport);
   emitProgress(args, 'discovery', {
     message: gitDelta
-      ? `Git diff from ${existing.head_commit.slice(0, 8)} to ${gitDelta.currentHead.slice(0, 8)} found ${files.length} changed code files and ${gitDeletedFiles.length} deleted files`
+      ? `Git diff from ${String(existing.head_commit || 'unknown').slice(0, 8)} to ${String(gitDelta.currentHead || 'unknown').slice(0, 8)} found ${files.length} changed code files and ${gitDeletedFiles.length} deleted files`
       : `Found ${files.length} code files to check`,
     files_total: files.length,
     detail: skipSummary,

--- a/src/code-index/scope-resolver.js
+++ b/src/code-index/scope-resolver.js
@@ -322,8 +322,8 @@ function runReexportResolution(db, repoId, passNum) {
       .all(repoId);
 
     const insertBinding = db.prepare(
-      `INSERT INTO file_scope_bindings (repo_id, file_id, name, kind, origin, source_file_id, source_name, line_start, line_end, scope_depth, first_seen_pass)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO file_scope_bindings (repo_id, file_id, name, kind, origin, source_file_id, source_name, source_module, line_start, line_end, scope_depth, first_seen_pass)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     const insertResolution = db.prepare(
       `INSERT INTO scope_resolution (binding_id, resolved_symbol_id, resolved_file_id, status, resolved_at_pass, confidence) VALUES (?, ?, ?, ?, ?, ?)`,
@@ -351,6 +351,7 @@ function runReexportResolution(db, repoId, passNum) {
           'external_file',
           binding.source_file_id,
           sym.name,
+          binding.source_module || null,
           // Use the wildcard import's line range
           ...getBindingLineRange(db, binding.id),
           0,

--- a/src/code-index/scope-resolver.js
+++ b/src/code-index/scope-resolver.js
@@ -21,6 +21,28 @@ const _path = require('path');
 const MAX_RESOLUTION_PASSES = 10;
 const WILDCARD_EXPANSION_CAP = 50;
 
+function resolveTargetFileId(db, binding) {
+  if (binding.source_file_id) {
+    return binding.source_file_id;
+  }
+  if (binding.source_module) {
+    const moduleMatch = db
+      .prepare(
+        `SELECT target_file_id FROM code_imports WHERE source_file_id = ? AND target_module = ? AND target_file_id IS NOT NULL LIMIT 1`,
+      )
+      .get(binding.file_id, binding.source_module);
+    if (moduleMatch?.target_file_id) {
+      return moduleMatch.target_file_id;
+    }
+  }
+  const fallback = db
+    .prepare(
+      `SELECT target_file_id FROM code_imports WHERE source_file_id = ? AND target_file_id IS NOT NULL LIMIT 1`,
+    )
+    .get(binding.file_id);
+  return fallback?.target_file_id || null;
+}
+
 /**
  * Run multi-pass scope resolution for a repo.
  * @param {object} db - native database handle
@@ -157,15 +179,7 @@ function runDirectResolution(db, repoId) {
 
         // If no source_file_id yet, try to resolve from import edges
         if (!targetFileId) {
-          // Try via code_imports
-          const impRow = db
-            .prepare(
-              `SELECT target_file_id FROM code_imports WHERE source_file_id = ? AND target_file_id IS NOT NULL LIMIT 1`,
-            )
-            .get(binding.file_id);
-          if (impRow) {
-            targetFileId = impRow.target_file_id;
-          }
+          targetFileId = resolveTargetFileId(db, binding);
         }
 
         if (targetFileId) {
@@ -500,14 +514,7 @@ function resolveBindingDirect(db, binding, passNum) {
   } else if (binding.origin === 'external_file') {
     let targetFileId = binding.source_file_id;
     if (!targetFileId) {
-      const impRow = db
-        .prepare(
-          `SELECT target_file_id FROM code_imports WHERE source_file_id = ? AND target_file_id IS NOT NULL LIMIT 1`,
-        )
-        .get(binding.file_id);
-      if (impRow) {
-        targetFileId = impRow.target_file_id;
-      }
+      targetFileId = resolveTargetFileId(db, binding);
     }
     if (targetFileId) {
       const sourceName = binding.source_name || binding.name;

--- a/src/http/handlers/memory.js
+++ b/src/http/handlers/memory.js
@@ -1,4 +1,15 @@
-const { jsonOk } = require('../errors');
+const { jsonOk, jsonError } = require('../errors');
+
+function mapSearchRows(rows) {
+  return (rows || []).map((r) => ({
+    id: r.id,
+    title: r.title || '',
+    content: r.snippet || r.content || '',
+    type: r.type || '',
+    scope: r.scope || '',
+    topicKey: r.topic_key || null,
+  }));
+}
 
 function searchMemory(deps) {
   return async (req, res, ctx) => {
@@ -6,16 +17,11 @@ function searchMemory(deps) {
     const searchDeps = { sqlJson: deps.sqlJson, sqlRun: deps.sqlRun, jsonErrNoExit: (msg) => ({ error: msg }) };
     const search = require('../../memory-domain/search').search;
     const result = search(searchDeps, { query, limit: String(limit || 10) });
-    const mapped = (Array.isArray(result) ? result : []).map((r) => ({
-      id: r.id,
-      title: r.title || '',
-      content: r.snippet || r.content || '',
-      type: r.type || '',
-      scope: r.scope || '',
-      topicKey: r.topic_key || null,
-    }));
-    jsonOk(res, mapped);
+    if (result?.error) {
+      return jsonError(res, 400, 'invalid_search', result.error);
+    }
+    jsonOk(res, mapSearchRows(result?.results));
   };
 }
 
-module.exports = { searchMemory };
+module.exports = { searchMemory, mapSearchRows };

--- a/src/http/handlers/todos.js
+++ b/src/http/handlers/todos.js
@@ -1,4 +1,5 @@
 const { jsonOk, jsonCreated, jsonError } = require('../errors');
+const { mapSearchRows } = require('./memory');
 
 function createMissionLedger(repo) {
   return async (req, res, ctx) => {
@@ -221,15 +222,11 @@ function getContextForTodo(repo, deps) {
     const search = require('../../memory-domain/search').search;
     const limit = ctx.query.get('limit') || '10';
     const result = search(searchDeps, { query: todo.lapisContextQuery, limit });
-    const context = (Array.isArray(result) ? result : []).map((r) => ({
-      id: r.id,
-      title: r.title || '',
-      content: r.snippet || r.content || '',
-      type: r.type || '',
-      scope: r.scope || '',
-      topicKey: r.topic_key || null,
-    }));
-    jsonOk(res, { todoId: todo.id, query: todo.lapisContextQuery, context });
+    if (result?.error) {
+      jsonError(res, 400, 'search_failed', result.error);
+      return;
+    }
+    jsonOk(res, { todoId: todo.id, query: todo.lapisContextQuery, context: mapSearchRows(result?.results) });
   };
 }
 

--- a/src/memory-domain/sessions.js
+++ b/src/memory-domain/sessions.js
@@ -106,9 +106,8 @@ function sessionEnd(deps, args) {
   ]);
 
   // Always run the cheap, lock-light cleanup (DELETEs + trust decay).
-  // The expensive VACUUM + FTS 'optimize' is gated by session count so quitting
-  // Pi doesn't block for seconds on large DBs. The gate matches sessionStart's
-  // compact_every_n_sessions so the heavy work lands on the same cadence.
+  // The expensive VACUUM + FTS 'optimize' is gated by per-project session count
+  // (same query as sessionStart) so heavy work lands on the same cadence.
   const cheapResult = deps.runCompactCheap ? deps.runCompactCheap() : null;
 
   let vacuumResult = null;
@@ -119,10 +118,10 @@ function sessionEnd(deps, args) {
       const project = sessionRows[0]?.project;
       const compactInterval = getConfig().compact_every_n_sessions || 5;
       const row = project
-        ? deps.sqlJson('SELECT COUNT(*) as cnt FROM session_log WHERE project = ? AND ended_at IS NOT NULL', [project])
-        : deps.sqlJson('SELECT COUNT(*) as cnt FROM session_log WHERE ended_at IS NOT NULL');
-      const ended = row && row[0] ? parseInt(row[0].cnt, 10) : 0;
-      vacuumDue = ended > 0 && ended % compactInterval === 0;
+        ? deps.sqlJson('SELECT COUNT(*) as cnt FROM session_log WHERE project = ?', [project])
+        : deps.sqlJson('SELECT COUNT(*) as cnt FROM session_log');
+      const sessionCount = row && row[0] ? parseInt(row[0].cnt, 10) : 0;
+      vacuumDue = sessionCount > 0 && sessionCount % compactInterval === 0;
     } catch (_e) {
       // If the count query fails, skip vacuum rather than block exit.
       vacuumDue = false;

--- a/src/memory-domain/sessions.js
+++ b/src/memory-domain/sessions.js
@@ -115,8 +115,12 @@ function sessionEnd(deps, args) {
   if (deps.runVacuum) {
     let vacuumDue = true;
     try {
+      const sessionRows = deps.sqlJson('SELECT project FROM session_log WHERE id = ?', [parseInt(id, 10)]);
+      const project = sessionRows[0]?.project;
       const compactInterval = getConfig().compact_every_n_sessions || 5;
-      const row = deps.sqlJson('SELECT COUNT(*) as cnt FROM session_log WHERE ended_at IS NOT NULL');
+      const row = project
+        ? deps.sqlJson('SELECT COUNT(*) as cnt FROM session_log WHERE project = ? AND ended_at IS NOT NULL', [project])
+        : deps.sqlJson('SELECT COUNT(*) as cnt FROM session_log WHERE ended_at IS NOT NULL');
       const ended = row && row[0] ? parseInt(row[0].cnt, 10) : 0;
       vacuumDue = ended > 0 && ended % compactInterval === 0;
     } catch (_e) {

--- a/src/platform/storage/repositories/aurex.js
+++ b/src/platform/storage/repositories/aurex.js
@@ -372,9 +372,19 @@ function createAurexRepository(deps) {
       const rows = filters.status
         ? sqlJson('SELECT * FROM todo_ledgers WHERE status = ? ORDER BY updated_at DESC', [filters.status]).map(mapLedgerRow)
         : sqlJson('SELECT * FROM todo_ledgers ORDER BY updated_at DESC').map(mapLedgerRow);
+      if (rows.length === 0) {
+        return [];
+      }
+      const missionIds = rows.map((ledger) => ledger.missionId);
+      const placeholders = missionIds.map(() => '?').join(',');
+      const todosByMission = groupTodosByMission(
+        sqlJson(`SELECT * FROM todo_items WHERE mission_id IN (${placeholders}) ORDER BY created_at`, missionIds).map(
+          mapTodoRow,
+        ),
+      );
       return rows.map((ledger) => ({
         ...ledger,
-        todos: this.listTodosByMission(ledger.missionId),
+        todos: todosByMission.get(ledger.missionId) || [],
       }));
     },
     updateMissionLedger(missionId, patch) {
@@ -605,7 +615,7 @@ function createAurexRepository(deps) {
                OR NOT EXISTS (
                  SELECT 1 FROM json_each(t.depends_on) dep
                  JOIN todo_items blocker ON blocker.id = dep.value
-                 WHERE blocker.status NOT IN ('passed', 'merged', 'cancelled')
+                 WHERE blocker.status NOT IN ('passed', 'merged', 'cancelled', 'implemented')
                )
              )
            ORDER BY t.priority DESC, t.created_at
@@ -722,6 +732,19 @@ const TODO_TYPES = new Set(['discovery', 'implementation', 'test', 'refactor', '
 const PRIORITIES = new Set(['low', 'medium', 'high']);
 const RISK_LEVELS = new Set(['low', 'medium', 'high']);
 const CONFIDENCE_LEVELS = new Set(['low', 'medium', 'high']);
+
+function groupTodosByMission(todos) {
+  const map = new Map();
+  for (const todo of todos) {
+    const existing = map.get(todo.missionId);
+    if (existing) {
+      existing.push(todo);
+    } else {
+      map.set(todo.missionId, [todo]);
+    }
+  }
+  return map;
+}
 
 function assertInSet(value, allowed, field) {
   if (!allowed.has(value)) {

--- a/src/platform/storage/repositories/aurex.js
+++ b/src/platform/storage/repositories/aurex.js
@@ -368,9 +368,14 @@ function createAurexRepository(deps) {
     listMissionLedgers(filters = {}) {
       if (filters.status) {
         assertInSet(filters.status, MISSION_LEDGER_STATUSES, 'status');
-        return sqlJson('SELECT * FROM todo_ledgers WHERE status = ? ORDER BY updated_at DESC', [filters.status]).map(mapLedgerRow);
       }
-      return sqlJson('SELECT * FROM todo_ledgers ORDER BY updated_at DESC').map(mapLedgerRow);
+      const rows = filters.status
+        ? sqlJson('SELECT * FROM todo_ledgers WHERE status = ? ORDER BY updated_at DESC', [filters.status]).map(mapLedgerRow)
+        : sqlJson('SELECT * FROM todo_ledgers ORDER BY updated_at DESC').map(mapLedgerRow);
+      return rows.map((ledger) => ({
+        ...ledger,
+        todos: this.listTodosByMission(ledger.missionId),
+      }));
     },
     updateMissionLedger(missionId, patch) {
       const existing = this.getMissionLedger(missionId);
@@ -593,9 +598,17 @@ function createAurexRepository(deps) {
              assigned_worker_id = ?,
              updated_at = datetime('now')
          WHERE id = (
-           SELECT id FROM todo_items
-           WHERE mission_id = ? AND status = 'ready'
-           ORDER BY priority DESC, created_at
+           SELECT t.id FROM todo_items t
+           WHERE t.mission_id = ? AND t.status = 'ready'
+             AND (
+               COALESCE(json_array_length(t.depends_on), 0) = 0
+               OR NOT EXISTS (
+                 SELECT 1 FROM json_each(t.depends_on) dep
+                 JOIN todo_items blocker ON blocker.id = dep.value
+                 WHERE blocker.status NOT IN ('passed', 'merged', 'cancelled')
+               )
+             )
+           ORDER BY t.priority DESC, t.created_at
            LIMIT 1
          )
          RETURNING *`,
@@ -849,7 +862,6 @@ function mapLedgerRow(row) {
     constraints: parseJson(row.constraints_json, []),
     assumptions: parseJson(row.assumptions, []),
     humanQuestions: parseJson(row.human_questions, []),
-    todos: [],
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/test/correctness-review-fixes.test.js
+++ b/test/correctness-review-fixes.test.js
@@ -1,0 +1,116 @@
+const dreamService = require('../services/dream');
+const sessionCmd = require('../commands/session');
+const { mapSearchRows } = require('../src/http/handlers/memory');
+const { search } = require('../src/memory-domain/search');
+const { createAurexRepository } = require('../src/platform/storage/repositories/aurex');
+const { logNegativeRecall } = require('../commands/observation');
+const dbModule = require('../db');
+
+describe('correctness review fixes', () => {
+  beforeAll(() => {
+    dbModule.ensureDb();
+  });
+
+  it('dream service exports runCompactCheap and runVacuum for session-end wiring', () => {
+    expect(typeof dreamService.runCompactCheap).toBe('function');
+    expect(typeof dreamService.runVacuum).toBe('function');
+  });
+
+  it('session-end command wires compaction helpers from dream service', () => {
+    const { sqlJson, sqlRun, ensureDb } = dbModule;
+    ensureDb();
+    sqlRun("INSERT INTO session_log (project, started_at) VALUES ('correctness-fix', datetime('now'))");
+    const id = sqlJson('SELECT id FROM session_log ORDER BY id DESC LIMIT 1')[0].id;
+    const result = sessionCmd.sessionEnd({ sqlJson, sqlRun }, { id: String(id), memories: '0' });
+    expect(result.compacted).toBeDefined();
+    expect(result.compacted.ok).toBe(true);
+  });
+
+  it('mapSearchRows maps memory search results for HTTP handlers', () => {
+    const rows = mapSearchRows([
+      { id: 1, title: 'T', snippet: 'body', type: 'decision', scope: 'project', topic_key: 'k' },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe('body');
+    expect(rows[0].topicKey).toBe('k');
+  });
+
+  it('memory search returns results object consumed by HTTP layer', () => {
+    const deps = {
+      sqlJson: dbModule.sqlJson,
+      sqlRun: dbModule.sqlRun,
+      jsonErrNoExit: (msg) => ({ error: msg }),
+    };
+    dbModule.sqlRun(
+      "INSERT INTO observations (session_id, type, title, content, project, scope) VALUES ('1','decision','HTTP fix token','unique-http-fix-token','p','project')",
+    );
+    const result = search(deps, { query: 'unique-http-fix-token', limit: '5' });
+    expect(result.results?.length).toBeGreaterThan(0);
+    expect(mapSearchRows(result.results)).toHaveLength(result.results.length);
+  });
+
+  it('listMissionLedgers includes todos for each ledger', () => {
+    const repo = createAurexRepository({ sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun });
+    const missionId = `mission-list-${Date.now()}`;
+    repo.createMissionLedger({ missionId, missionTitle: 'List test', status: 'planning' });
+    repo.createTodo(missionId, { title: 'Child todo', status: 'ready', goal: 'g' });
+    const list = repo.listMissionLedgers();
+    const entry = list.find((l) => l.missionId === missionId);
+    expect(entry?.todos?.length).toBe(1);
+  });
+
+  it('claimNextReadyTodo skips todos with incomplete dependencies', () => {
+    const repo = createAurexRepository({ sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun });
+    const missionId = `mission-claim-${Date.now()}`;
+    const blockerId = `blocker-${Date.now()}`;
+    const blockedId = `blocked-${Date.now()}`;
+    repo.createMissionLedger({ missionId, missionTitle: 'Claim test', status: 'planning' });
+    const blocker = repo.createTodo(missionId, { id: blockerId, title: 'Blocker', status: 'ready', goal: 'g' })[0];
+    repo.createTodo(missionId, {
+      id: blockedId,
+      title: 'Blocked',
+      status: 'ready',
+      goal: 'g',
+      dependsOn: [blocker.id],
+    });
+    const claimed = repo.claimNextReadyTodo(missionId, 'worker-a');
+    expect(claimed[0]?.id).toBe(blocker.id);
+    const blockedClaim = repo.claimNextReadyTodo(missionId, 'worker-b');
+    expect(blockedClaim).toEqual([]);
+  });
+
+  it('logNegativeRecall returns structured error for invalid JSON', () => {
+    const result = logNegativeRecall(
+      { sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun },
+      { entries: '{not-json' },
+    );
+    expect(result.error).toBe('Invalid --entries JSON');
+  });
+
+  it('file_scope_bindings has source_module column after migration', () => {
+    const cols = dbModule.sqlJson('PRAGMA table_info(file_scope_bindings)');
+    expect(cols.some((c) => c.name === 'source_module')).toBe(true);
+  });
+
+  it('resolveScopeBindings runs without missing-column SQL errors', () => {
+    const db = dbModule.getDb();
+    const repoPath = `/tmp/scope-fix-${Date.now()}`;
+    db.prepare('INSERT INTO code_repos (name, path, head_commit) VALUES (?, ?, NULL)').run('scope-fix', repoPath);
+    const repoId = db.prepare('SELECT id FROM code_repos WHERE name = ?').get('scope-fix').id;
+    db.prepare('INSERT INTO code_files (repo_id, path, content_hash, language, content) VALUES (?, ?, ?, ?, ?)').run(
+      repoId,
+      `${repoPath}/a.js`,
+      'abc',
+      'javascript',
+      'export const x = 1;',
+    );
+    const fileId = db.prepare('SELECT id FROM code_files WHERE repo_id = ?').get(repoId).id;
+    db.prepare(
+      `INSERT INTO file_scope_bindings (repo_id, file_id, name, kind, origin, source_file_id, source_name, source_module, line_start, line_end, scope_depth)
+       VALUES (?, ?, 'foo', 'named_import', 'external_file', NULL, 'foo', './utils', 1, 1, 0)`,
+    ).run(repoId, fileId);
+    const { resolveScopeBindings } = require('../src/code-index/scope-resolver');
+    expect(() => resolveScopeBindings(db, repoId)).not.toThrow();
+    db.prepare('DELETE FROM code_repos WHERE name = ?').run('scope-fix');
+  });
+});

--- a/test/correctness-review-fixes.test.js
+++ b/test/correctness-review-fixes.test.js
@@ -51,12 +51,37 @@ describe('correctness review fixes', () => {
 
   it('listMissionLedgers includes todos for each ledger', () => {
     const repo = createAurexRepository({ sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun });
-    const missionId = `mission-list-${Date.now()}`;
-    repo.createMissionLedger({ missionId, missionTitle: 'List test', status: 'planning' });
-    repo.createTodo(missionId, { title: 'Child todo', status: 'ready', goal: 'g' });
+    const missionA = `mission-list-a-${Date.now()}`;
+    const missionB = `mission-list-b-${Date.now()}`;
+    repo.createMissionLedger({ missionId: missionA, missionTitle: 'List A', status: 'planning' });
+    repo.createMissionLedger({ missionId: missionB, missionTitle: 'List B', status: 'planning' });
+    repo.createTodo(missionA, { title: 'Todo A', status: 'ready', goal: 'g' });
+    repo.createTodo(missionB, { title: 'Todo B', status: 'ready', goal: 'g' });
     const list = repo.listMissionLedgers();
-    const entry = list.find((l) => l.missionId === missionId);
-    expect(entry?.todos?.length).toBe(1);
+    expect(list.find((l) => l.missionId === missionA)?.todos?.length).toBe(1);
+    expect(list.find((l) => l.missionId === missionB)?.todos?.length).toBe(1);
+  });
+
+  it('listMissionLedgers loads todos in a single batch query', () => {
+    const repo = createAurexRepository({ sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun });
+    const missionA = `mission-batch-a-${Date.now()}`;
+    const missionB = `mission-batch-b-${Date.now()}`;
+    repo.createMissionLedger({ missionId: missionA, missionTitle: 'Batch A', status: 'planning' });
+    repo.createMissionLedger({ missionId: missionB, missionTitle: 'Batch B', status: 'planning' });
+    repo.createTodo(missionA, { title: 'Batch todo A', status: 'ready', goal: 'g' });
+    repo.createTodo(missionB, { title: 'Batch todo B', status: 'ready', goal: 'g' });
+
+    const originalSqlJson = dbModule.sqlJson;
+    const todoQueries = [];
+    const sqlJsonSpy = (query, params) => {
+      if (typeof query === 'string' && query.includes('FROM todo_items WHERE mission_id IN')) {
+        todoQueries.push(query);
+      }
+      return originalSqlJson(query, params);
+    };
+    const spiedRepo = createAurexRepository({ sqlJson: sqlJsonSpy, sqlRun: dbModule.sqlRun });
+    spiedRepo.listMissionLedgers();
+    expect(todoQueries).toHaveLength(1);
   });
 
   it('claimNextReadyTodo skips todos with incomplete dependencies', () => {
@@ -77,6 +102,27 @@ describe('correctness review fixes', () => {
     expect(claimed[0]?.id).toBe(blocker.id);
     const blockedClaim = repo.claimNextReadyTodo(missionId, 'worker-b');
     expect(blockedClaim).toEqual([]);
+  });
+
+  it('claimNextReadyTodo allows claim when dependency is implemented', () => {
+    const repo = createAurexRepository({ sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun });
+    const missionId = `mission-claim-impl-${Date.now()}`;
+    const blockerId = `blocker-impl-${Date.now()}`;
+    const blockedId = `blocked-impl-${Date.now()}`;
+    repo.createMissionLedger({ missionId, missionTitle: 'Implemented dep', status: 'planning' });
+    repo.createTodo(missionId, { id: blockerId, title: 'Blocker', status: 'ready', goal: 'g' });
+    repo.createTodo(missionId, {
+      id: blockedId,
+      title: 'Blocked',
+      status: 'ready',
+      goal: 'g',
+      dependsOn: [blockerId],
+    });
+    repo.claimNextReadyTodo(missionId, 'worker-a');
+    repo.addTodoEvidence(blockerId, { changedFiles: ['src/a.js'] });
+    repo.setTodoStatus(blockerId, 'implemented');
+    const claimed = repo.claimNextReadyTodo(missionId, 'worker-b');
+    expect(claimed[0]?.id).toBe(blockedId);
   });
 
   it('logNegativeRecall returns structured error for invalid JSON', () => {

--- a/test/http-server.test.js
+++ b/test/http-server.test.js
@@ -742,9 +742,22 @@ describe('Aurex HTTP Server', () => {
     });
 
     it('searches memory', async () => {
-      const res = await req('POST', '/memory/search', { query: 'test', limit: 5 });
+      const token = `http-e2e-search-${Date.now()}`;
+      sqlRun(
+        "INSERT INTO observations (session_id, type, title, content, project, scope) VALUES ('1', 'decision', 'HTTP search seed', ?, 'e2e', 'project')",
+        [token],
+      );
+      const res = await req('POST', '/memory/search', { query: token, limit: 5 });
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBeGreaterThan(0);
+      expect(res.body[0].title).toBe('HTTP search seed');
+    });
+
+    it('rejects memory search without query', async () => {
+      const res = await req('POST', '/memory/search', { limit: 5 });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('invalid_search');
     });
 
     it('GET /health still works after all operations', async () => {

--- a/test/review-fixes.test.js
+++ b/test/review-fixes.test.js
@@ -20,7 +20,7 @@ describe('review fixes', () => {
       dbModule.ensureDb();
     });
 
-    it('advances user_version from 22 to 23 and creates repo_index_locks', () => {
+    it('advances user_version from 22 through V23/V24 migrations', () => {
       tmpDb = path.join(os.tmpdir(), `lapis-v23-${Date.now()}.db`);
       dbModule.resetDb();
       dbModule.createDb({ db_path: tmpDb });
@@ -37,8 +37,13 @@ describe('review fixes', () => {
       const table = reopened
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='repo_index_locks'")
         .get();
-      expect(version).toBe(23);
+      const sourceModuleCol = reopened
+        .prepare('PRAGMA table_info(file_scope_bindings)')
+        .all()
+        .some((c) => c.name === 'source_module');
+      expect(version).toBe(24);
       expect(table).toBeTruthy();
+      expect(sourceModuleCol).toBe(true);
     });
   });
 

--- a/test/services-sessions.test.js
+++ b/test/services-sessions.test.js
@@ -163,12 +163,12 @@ describe('services/sessions', () => {
       const trustRecovery = vi.fn(() => ({ ok: true }));
       const runCompactCheap = vi.fn(() => ({ ok: true, startedAt: 't', steps: { expiredPurged: true } }));
       const runVacuum = vi.fn(() => ({ ok: true, steps: { vacuumed: true } }));
-      // Vacuum is gated by per-project ended session count.
+      // Vacuum is gated by per-project session count (same query as sessionStart).
       const sqlJson = vi.fn((query) => {
         if (/SELECT project FROM session_log WHERE id = \?/i.test(query)) {
           return [{ project: 'test-project' }];
         }
-        if (/COUNT\(\*\) as cnt FROM session_log WHERE project = \? AND ended_at IS NOT NULL/i.test(query)) {
+        if (/COUNT\(\*\) as cnt FROM session_log WHERE project = \?$/i.test(query)) {
           return [{ cnt: 10 }];
         }
         return [];
@@ -188,12 +188,12 @@ describe('services/sessions', () => {
       const trustRecovery = vi.fn(() => ({ ok: true }));
       const runCompactCheap = vi.fn(() => ({ ok: true, steps: { expiredPurged: true } }));
       const runVacuum = vi.fn(() => ({ ok: true }));
-      // 7 ended sessions → not divisible by 5 → vacuum NOT due.
+      // 7 sessions → not divisible by 5 → vacuum NOT due.
       const sqlJson = vi.fn((query) => {
         if (/SELECT project FROM session_log WHERE id = \?/i.test(query)) {
           return [{ project: 'test-project' }];
         }
-        if (/COUNT\(\*\) as cnt FROM session_log WHERE project = \? AND ended_at IS NOT NULL/i.test(query)) {
+        if (/COUNT\(\*\) as cnt FROM session_log WHERE project = \?$/i.test(query)) {
           return [{ cnt: 7 }];
         }
         return [];

--- a/test/services-sessions.test.js
+++ b/test/services-sessions.test.js
@@ -163,9 +163,12 @@ describe('services/sessions', () => {
       const trustRecovery = vi.fn(() => ({ ok: true }));
       const runCompactCheap = vi.fn(() => ({ ok: true, startedAt: 't', steps: { expiredPurged: true } }));
       const runVacuum = vi.fn(() => ({ ok: true, steps: { vacuumed: true } }));
-      // 10 ended sessions → divisible by default interval of 5 → vacuum due.
+      // Vacuum is gated by per-project ended session count.
       const sqlJson = vi.fn((query) => {
-        if (/COUNT\(\*\) as cnt FROM session_log WHERE ended_at IS NOT NULL/i.test(query)) {
+        if (/SELECT project FROM session_log WHERE id = \?/i.test(query)) {
+          return [{ project: 'test-project' }];
+        }
+        if (/COUNT\(\*\) as cnt FROM session_log WHERE project = \? AND ended_at IS NOT NULL/i.test(query)) {
           return [{ cnt: 10 }];
         }
         return [];
@@ -187,7 +190,10 @@ describe('services/sessions', () => {
       const runVacuum = vi.fn(() => ({ ok: true }));
       // 7 ended sessions → not divisible by 5 → vacuum NOT due.
       const sqlJson = vi.fn((query) => {
-        if (/COUNT\(\*\) as cnt FROM session_log WHERE ended_at IS NOT NULL/i.test(query)) {
+        if (/SELECT project FROM session_log WHERE id = \?/i.test(query)) {
+          return [{ project: 'test-project' }];
+        }
+        if (/COUNT\(\*\) as cnt FROM session_log WHERE project = \? AND ended_at IS NOT NULL/i.test(query)) {
           return [{ cnt: 7 }];
         }
         return [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes objectively broken behavior surfaced in the code correctness review: session-end compaction was silently skipped, HTTP search endpoints always returned empty results, scope resolution failed on a missing DB column, and several todo-ledger / indexing paths had incomplete wiring.

## Type of Change

- [x] Bug fix

## Changes

### Critical
- **Session-end compaction wiring** — `services/dream.js` exports `runCompactCheap` and `runVacuum`.

### High
- **Scope resolution** — Migration V24 + `source_module` persistence; module-aware import resolution.
- **HTTP memory search** — `POST /memory/search` and `GET /todos/:id/context` read `search().results`.

### Medium
- **`listMissionLedgers`** — Batch-loads todos in one query (no N+1).
- **`claimNextReadyTodo`** — Honors `depends_on`; satisfied statuses: `passed`, `merged`, `cancelled`, `implemented`.
- **Incremental reindex** — Null `head_commit` guard; derived-index error logging.
- **Vacuum cadence** — Per-project total session count (same query as `sessionStart`).
- **`log-negative-recall`** — Structured error for invalid JSON.

### Polish (3 commits)
- Vacuum cadence aligned with `sessionStart`; wildcard bindings inherit `source_module`.
- HTTP E2E tests for memory search; API docs for `claim-next` and memory search.
- V10 migration DDL includes `source_module`; `implemented` deps unblock claiming.

## How Has This Been Tested?

- `npm test` — **1870 tests pass**
- `test/correctness-review-fixes.test.js` — compaction, search, scope, ledger batch, dependency claim
- `test/http-server.test.js` — non-empty memory search + 400 on missing query
- `test/services-sessions.test.js` — vacuum gate expectations
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9d396bb-ee1a-4c6e-ba64-5543757ffc02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9d396bb-ee1a-4c6e-ba64-5543757ffc02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

