### PR TITLE
fix(memory): self-heal stale cached project key from path-resolved repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Memory layer: self-heal stale cached project key from path-resolved repo**
+  - `before_agent_start` now uses anchored, deepest-path `resolveIndexedRepo` (matching `detectProject`) instead of first-match `startsWith` prefix resolution.
+  - When the path-resolved repo name differs from the session-start cached key, `state.currentProject` self-heals so memory saves and the context banner use the correct project bucket.
+  - `buildSourceLookupGuidance` uses the same repo resolution to avoid nested-repo and unanchored-prefix mismatches.
+  - Regression tests cover mid-session rename self-heal and nested-repo non-regression.
+
 - **Code correctness review fixes**
   - Export `runCompactCheap` / `runVacuum` from `services/dream.js` so `session-end` runs cheap compact and gated vacuum again.
   - Add `source_module` column to `file_scope_bindings` (migration V24); persist module paths in `insertScopeBindings`.

--- a/extensions/memory-layer/hooks/context-injection.ts
+++ b/extensions/memory-layer/hooks/context-injection.ts
@@ -24,6 +24,7 @@ import {
   isHistoricalMemoryPrompt,
   isPreflightWorthyPrompt,
 } from '../../../src/hooks-engine/prompt-classifiers.js';
+import { resolveIndexedRepo } from '../../../src/hooks-engine/project.js';
 
 // Re-exported for existing tests that import from this file.
 export { extractFilePaths } from '../../../src/hooks-engine/context-builder.js';
@@ -125,13 +126,17 @@ export function registerBeforeAgentStart(pi: ExtensionAPI, deps: ContextDeps) {
 
     const stats = effectiveContext.stats as { total_memories: number; total_personal: number };
 
-    // Resolve repo staleness
+    // Resolve repo staleness (anchored, deepest path match — mirrors detectProject)
     const repos = await deps.getKnownRepos();
     const resolvedCwd = path.resolve(ctx.cwd);
-    const cwdRepo =
-      repos.find((r) => resolvedCwd.startsWith(path.resolve(r.path))) ||
-      repos.find((r) => r.name.toLowerCase() === deps.state.currentProject?.toLowerCase());
+    const cwdRepo = resolveIndexedRepo(resolvedCwd, repos, deps.state.currentProject);
     const isStale = cwdRepo ? deps.isRepoStale(cwdRepo) : false;
+
+    // Self-heal stale session-start project key when path-resolved repo name differs.
+    // Context for this turn was fetched with the stale key; counts catch up next turn.
+    if (cwdRepo && cwdRepo.name.toLowerCase() !== (deps.state.currentProject || '').toLowerCase()) {
+      deps.state.currentProject = cwdRepo.name;
+    }
 
     const isNewProject = crossProjectResult !== null && !projectContext;
     let effectiveObservations: any[] = [];

--- a/src/hooks-engine/context-builder.js
+++ b/src/hooks-engine/context-builder.js
@@ -12,6 +12,7 @@
  */
 
 const path = require('node:path');
+const { resolveIndexedRepo } = require('./project');
 const fs = require('node:fs');
 const { CONTEXT } = require('../../constants');
 const { isNavigationPrompt } = require('./prompt-classifiers');
@@ -108,9 +109,7 @@ function appendExtensionHint(lines, cwd) {
 
 function buildSourceLookupGuidance(repos, cwd, currentProject) {
   const resolvedCwd = path.resolve(cwd);
-  const cwdRepo =
-    repos.find((r) => resolvedCwd.startsWith(path.resolve(r.path))) ||
-    repos.find((r) => r.name.toLowerCase() === currentProject?.toLowerCase());
+  const cwdRepo = resolveIndexedRepo(resolvedCwd, repos, currentProject);
 
   if (!cwdRepo) {
     return null;

--- a/test/context-injection.test.js
+++ b/test/context-injection.test.js
@@ -266,9 +266,61 @@ describe('rich context injection', () => {
     const content = result.message.content;
 
     expect(content.length).toBeLessThanOrEqual(1800);
-    expect(content).toContain('Project: **TestProject**');
+    expect(content).toContain('Project: **TestRepo**');
     expect(content).toContain('[decision] Use SQLite FTS5');
     expect(content).toContain('What: Use FTS5');
+  });
+
+  test('self-heals stale currentProject when path-resolved repo name differs', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-self-heal-rename-'));
+    const deps = buildDeps({
+      state: { currentProject: 'work', hasInjectedContext: false, sessionId: 1 },
+      getKnownRepos: vi.fn().mockResolvedValue([
+        {
+          name: 'netcrawl',
+          path: tempDir,
+          file_count: 10,
+          symbol_count: 50,
+          indexed_at: '2026-05-29T00:00:00Z',
+        },
+      ]),
+    });
+    const handler = extractHandler(deps);
+
+    await handler({}, { cwd: tempDir });
+
+    expect(deps.state.currentProject).toBe('netcrawl');
+  });
+
+  test('does not self-heal to a parent repo when cwd is inside a nested child repo', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-self-heal-nested-'));
+    const parentDir = path.join(root, 'work');
+    const childDir = path.join(parentDir, 'netcrawl');
+    fs.mkdirSync(childDir, { recursive: true });
+    const deps = buildDeps({
+      state: { currentProject: 'netcrawl', hasInjectedContext: false, sessionId: 1 },
+      getKnownRepos: vi.fn().mockResolvedValue([
+        {
+          name: 'work',
+          path: parentDir,
+          file_count: 100,
+          symbol_count: 500,
+          indexed_at: '2026-05-29T00:00:00Z',
+        },
+        {
+          name: 'netcrawl',
+          path: childDir,
+          file_count: 20,
+          symbol_count: 80,
+          indexed_at: '2026-05-29T00:00:00Z',
+        },
+      ]),
+    });
+    const handler = extractHandler(deps);
+
+    await handler({}, { cwd: childDir });
+
+    expect(deps.state.currentProject).toBe('netcrawl');
   });
 
   test('navigation prompts can include two related memories but no more', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recreates [#204](https://github.com/GeneGulanesJr/LaPis/pull/204) with the review feedback from @GeneGulanesJr addressed.

## Problem

`state.currentProject` is set once at `session_start` and never refreshed. When a repo is renamed in `code_repos` mid-session, or `detectProject`'s basename-walk mis-resolves at startup, the context banner's `Code index:` line can show the correct name while `Project:` and downstream `memory-save` calls keep using the stale cached key — silently writing memories to the wrong project bucket.

## Fix

1. **Anchored, deepest-path repo resolution** — `before_agent_start` now uses `resolveIndexedRepo` from `hooks-engine/project` (same algorithm as `detectProject` and Claude Code bridge) instead of naive `startsWith` first-match. This avoids nested-repo and unanchored-prefix regressions flagged in the #204 review.

2. **Self-heal** — When the path-resolved repo name differs from the cached key, `state.currentProject` is updated before the banner is emitted so subsequent saves in the same turn use the correct bucket. Context/stats for the current turn were already fetched with the stale key; they self-correct on the next turn.

3. **`buildSourceLookupGuidance`** — Uses the same `resolveIndexedRepo` helper for consistency on the source-authoritative early-return path.

## Tests

- **Rename case** — stale `work` key self-heals to path-matched `netcrawl`
- **Nested-repo case** — cwd inside child `netcrawl` does **not** get overwritten by parent `work` (regression guard for the review concern)

## Supersedes

Closes the intent of #204. The original author's branch is no longer available; this PR incorporates their fix plus the requested anchored resolution and unit tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66fe2370-0527-4772-b5a1-ee16d6f7b167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66fe2370-0527-4772-b5a1-ee16d6f7b167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

