### PR TITLE
fix: code-audit medium findings — scope resolution, winnow sort, html tags

### DIFF
--- a/src/code-analysis/import-graph-impl.js
+++ b/src/code-analysis/import-graph-impl.js
@@ -658,31 +658,40 @@ function winnow(db, repoId, opts = {}) {
     activeAxes.push('min_callers');
   }
 
+  // Ensure the JOIN needed for the chosen sort axis exists (even without a min*
+  // filter) and expose the column the comparator sorts on. Without these columns
+  // in the SELECT, the sort comparators read `undefined` and become no-ops.
+  const selectCols = ['s.id', 's.name', 's.kind', 's.file_path', 's.signature', 's.start_line', 's.end_line'];
+
+  if (sortBy === 'complexity') {
+    if (!joins.some((j) => j.includes('symbol_complexity'))) {
+      joins.push('LEFT JOIN symbol_complexity sc ON sc.symbol_id = s.id');
+    }
+    selectCols.push('sc.cyclomatic');
+  } else if (sortBy === 'churn') {
+    if (!joins.some((j) => j.includes('churn_metrics'))) {
+      joins.push('LEFT JOIN churn_metrics cm ON cm.file_path = s.file_path AND cm.repo_id = s.repo_id');
+    }
+    selectCols.push('cm.commits');
+  } else if (sortBy === 'callers') {
+    if (!joins.some((j) => j.includes('cc_cnt'))) {
+      joins.push(`LEFT JOIN (
+        SELECT callee_symbol_id, COUNT(DISTINCT caller_symbol_id) as caller_count
+        FROM code_calls WHERE repo_id = ? AND callee_symbol_id IS NOT NULL
+        GROUP BY callee_symbol_id
+      ) cc_cnt ON cc_cnt.callee_symbol_id = s.id`);
+      params.unshift(repoId);
+    }
+    selectCols.push('cc_cnt.caller_count');
+  }
+
   // Build the SQL
-  let sql = `
-    SELECT s.id, s.name, s.kind, s.file_path, s.signature, s.start_line, s.end_line
+  const sql = `
+    SELECT ${selectCols.join(', ')}
     FROM code_symbols s
     ${joins.join('\n    ')}
     WHERE ${conditions.join(' AND ')}
   `;
-
-  if (sortBy === 'complexity' && minComplexity == null) {
-    if (!joins.some((j) => j.includes('symbol_complexity'))) {
-      sql = sql.replace(
-        'FROM code_symbols s',
-        'FROM code_symbols s\n    LEFT JOIN symbol_complexity sc ON sc.symbol_id = s.id',
-      );
-    }
-  }
-
-  if (sortBy === 'churn' && minChurn == null) {
-    if (!joins.some((j) => j.includes('churn_metrics'))) {
-      sql = sql.replace(
-        'FROM code_symbols s',
-        'FROM code_symbols s\n    LEFT JOIN churn_metrics cm ON cm.file_path = s.file_path AND cm.repo_id = s.repo_id',
-      );
-    }
-  }
 
   // Apply name regex filter in SQL if possible, otherwise filter in JS
   const rows = db.prepare(sql).all(...params);

--- a/src/code-index/scope-resolver.js
+++ b/src/code-index/scope-resolver.js
@@ -36,9 +36,7 @@ function resolveTargetFileId(db, binding) {
     }
   }
   const fallback = db
-    .prepare(
-      `SELECT target_file_id FROM code_imports WHERE source_file_id = ? AND target_file_id IS NOT NULL LIMIT 1`,
-    )
+    .prepare(`SELECT target_file_id FROM code_imports WHERE source_file_id = ? AND target_file_id IS NOT NULL LIMIT 1`)
     .get(binding.file_id);
   return fallback?.target_file_id || null;
 }
@@ -434,8 +432,13 @@ function getBindingLineRange(db, bindingId) {
  * @param {number} repoId - repo ID
  * @param {number[]} changedFileIds - IDs of changed files
  * @param {number[]} deletedFileIds - IDs of deleted files
+ * @returns {{ resolved: number, unresolved: number, passes: number, warnings: string[] }}
  */
 function resolveScopeBindingsForFiles(db, repoId, changedFileIds, deletedFileIds) {
+  const warnings = [];
+  let resolved = 0;
+  let unresolved = 0;
+
   // For incremental: clean and re-resolve for changed files + their direct importers
   const runInTx =
     typeof db.transaction === 'function'
@@ -491,17 +494,32 @@ function resolveScopeBindingsForFiles(db, repoId, changedFileIds, deletedFileIds
         .all(repoId, fileId);
 
       for (const binding of bindings) {
-        resolveBindingDirect(db, binding, 2);
+        const status = resolveBindingDirect(db, binding, 2);
+        if (status && status.startsWith('resolved')) {
+          resolved++;
+        } else {
+          unresolved++;
+        }
       }
     }
 
     // Run re-export resolution for all affected files
-    runReexportResolution(db, repoId, 3);
+    const reexportResult = runReexportResolution(db, repoId, 3);
+    resolved += reexportResult.resolved || 0;
+    warnings.push(...reexportResult.warnings);
   });
+
+  return {
+    resolved,
+    unresolved,
+    passes: 3,
+    warnings,
+  };
 }
 
 /**
  * Resolve a single binding directly (used by incremental resolution).
+ * @returns {string} the status inserted for this binding ('resolved_*' | 'unresolved')
  */
 function resolveBindingDirect(db, binding, passNum) {
   const insertResolution = db.prepare(
@@ -510,8 +528,10 @@ function resolveBindingDirect(db, binding, passNum) {
 
   if (binding.origin === 'external_package') {
     insertResolution.run(binding.id, null, null, 'resolved_external', passNum, 1.0);
+    return 'resolved_external';
   } else if (binding.origin === 'unresolved') {
     insertResolution.run(binding.id, null, null, 'unresolved', passNum, 0.0);
+    return 'unresolved';
   } else if (binding.origin === 'external_file') {
     let targetFileId = binding.source_file_id;
     if (!targetFileId) {
@@ -524,11 +544,14 @@ function resolveBindingDirect(db, binding, passNum) {
         .get(targetFileId, sourceName);
       if (symbolRow) {
         insertResolution.run(binding.id, symbolRow.id, targetFileId, 'resolved_internal', passNum, 1.0);
+        return 'resolved_internal';
       } else {
         insertResolution.run(binding.id, null, targetFileId, 'unresolved', passNum, 0.5);
+        return 'unresolved';
       }
     } else {
       insertResolution.run(binding.id, null, null, 'unresolved', passNum, 0.3);
+      return 'unresolved';
     }
   } else if (binding.origin === 'local') {
     const symbolRow = db
@@ -541,15 +564,20 @@ function resolveBindingDirect(db, binding, passNum) {
       .get(binding.file_id, binding.name, binding.line_end, binding.line_start);
     if (symbolRow) {
       insertResolution.run(binding.id, symbolRow.id, null, 'resolved_internal', passNum, 1.0);
+      return 'resolved_internal';
     } else {
       insertResolution.run(binding.id, null, null, 'unresolved', passNum, 0.2);
+      return 'unresolved';
     }
   } else if (binding.origin === 'internal_package' || binding.origin === 'internal_module') {
     insertResolution.run(binding.id, null, null, 'resolved_external', passNum, 0.8);
+    return 'resolved_external';
   } else if (binding.origin === 'external') {
     insertResolution.run(binding.id, null, null, 'resolved_external', passNum, 0.7);
+    return 'resolved_external';
   } else {
     insertResolution.run(binding.id, null, null, 'unresolved', passNum, 0.0);
+    return 'unresolved';
   }
 }
 

--- a/src/doc-index/html-parser.js
+++ b/src/doc-index/html-parser.js
@@ -82,7 +82,7 @@ function extractHtmlSections(content, filePath) {
         byte_start: 0,
         byte_end: headingRanges[0].start,
         role: classifyHtmlRole(title, textContent, ''),
-        tags: extractHtmlTags(textContent),
+        tags: extractHtmlTags(preamble),
         content_hash: hashContent(textContent),
       });
     }
@@ -100,7 +100,7 @@ function extractHtmlSections(content, filePath) {
       byte_start: heading.start,
       byte_end: nextStart,
       role: classifyHtmlRole(heading.text, textContent, ''),
-      tags: extractHtmlTags(textContent),
+      tags: extractHtmlTags(sectionContent),
       content_hash: hashContent(textContent),
     });
   }

--- a/test/code-audit-medium-fixes.test.js
+++ b/test/code-audit-medium-fixes.test.js
@@ -1,0 +1,247 @@
+// Regression tests for code-audit MEDIUM findings (#7, #8, #9).
+// Each sub-describe covers one verified bug fix.
+// Run via: npm test -- code-audit-medium-fixes
+
+const { resolveScopeBindingsForFiles } = require('../src/code-index/scope-resolver');
+const { winnow } = require('../src/code-analysis/import-graph-impl');
+const { extractHtmlSections } = require('../src/doc-index/html-parser');
+
+// ── #7: resolveScopeBindingsForFiles must return { resolved, ... } (not undefined) ──
+
+describe('code-audit #7: incremental scope resolution return value', () => {
+  // A native-style mock db: accepts all writes, returns the given binding for the
+  // direct-resolution SELECT and empty results everywhere else. This isolates the
+  // return-value contract from the SQLite backend.
+  function makeScopeResolverDb(binding) {
+    const writes = [];
+    const db = {
+      transaction: (fn) => () => fn(),
+      exec() {},
+      prepare(sql) {
+        const n = sql.replace(/\s+/g, ' ').trim();
+        return {
+          run(...params) {
+            writes.push({ sql: n, params });
+            return { changes: 0, lastInsertRowid: 0 };
+          },
+          get() {
+            return undefined;
+          },
+          all() {
+            // Direct-resolution bindings for affected files
+            if (n.includes('FROM file_scope_bindings fsb') && n.includes('fsb.file_id = ?')) {
+              return binding ? [binding] : [];
+            }
+            return [];
+          },
+        };
+      },
+    };
+    return { db, writes };
+  }
+
+  it('returns an object with numeric resolved count (caller can read sr.resolved)', () => {
+    const binding = {
+      id: 42,
+      file_id: 10,
+      name: 'lodash',
+      kind: 'named_import',
+      origin: 'external_package',
+      source_file_id: null,
+      source_name: 'lodash',
+      line_start: 1,
+      line_end: 1,
+    };
+    const { db, writes } = makeScopeResolverDb(binding);
+
+    let result;
+    // Before the fix the function returned undefined, so `result.resolved` threw
+    // a TypeError that the caller swallowed (logging a misleading error and
+    // always reporting scopeResolved = 0).
+    expect(() => {
+      result = resolveScopeBindingsForFiles(db, 1, [10], []);
+    }).not.toThrow();
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('object');
+    expect(typeof result.resolved).toBe('number');
+    // external_package bindings resolve immediately → counted as resolved.
+    expect(result.resolved).toBe(1);
+    expect(typeof result.unresolved).toBe('number');
+    expect(Array.isArray(result.warnings)).toBe(true);
+    // A scope_resolution row was actually inserted for the binding.
+    expect(writes.some((w) => w.sql.startsWith('INSERT INTO scope_resolution'))).toBe(true);
+  });
+});
+
+// ── #8: winnow must SELECT the column each sort axis sorts on ──
+
+describe('code-audit #8: winnow sort axis selects its sort column', () => {
+  // A mock native-style db that:
+  //  - answers the two PageRank queries (calls + symbols)
+  //  - captures the main winnow SELECT and projects returned rows to ONLY the
+  //    columns present in the SELECT. This faithfully reproduces the bug: when a
+  //    sort column is missing from SELECT, the projected rows lack it and the
+  //    comparator sees `undefined` (a no-op sort).
+  function makeWinnowDb(repoId, symbols, fullRows) {
+    const captured = { sql: null, params: null };
+    const db = {
+      prepare(sql) {
+        const n = sql.replace(/\s+/g, ' ').trim();
+        return {
+          all(...params) {
+            // PageRank call edges query → none for this test
+            if (n.includes('FROM code_calls cc JOIN code_symbols cs')) {
+              return [];
+            }
+            // PageRank symbols query
+            if (n.startsWith('SELECT id, name, kind, file_path FROM code_symbols WHERE repo_id = ?')) {
+              return symbols;
+            }
+            // Main winnow query
+            captured.sql = n;
+            captured.params = params;
+            const selectMatch = n.match(/SELECT\s+(.*?)\s+FROM\s+code_symbols\s+s/i);
+            const colNames = selectMatch
+              ? selectMatch[1]
+                  .split(',')
+                  .map((c) => c.trim())
+                  .map((c) => c.split('.').pop())
+              : [];
+            // Project to only the selected columns, preserving query order.
+            return fullRows.map((fr) => {
+              const row = {};
+              for (const cn of colNames) {
+                row[cn] = fr[cn];
+              }
+              return row;
+            });
+          },
+        };
+      },
+    };
+    return { db, getCaptured: () => captured };
+  }
+
+  const symbols = [
+    { id: 1, name: 'low', kind: 'function', file_path: '/r/a.js' },
+    { id: 2, name: 'high', kind: 'function', file_path: '/r/a.js' },
+  ];
+
+  it('sorts by complexity (SELECTs + uses sc.cyclomatic)', () => {
+    // Insert order intentionally "wrong" so a no-op sort would leave `low` first.
+    const fullRows = [
+      {
+        id: 1,
+        name: 'low',
+        kind: 'function',
+        file_path: '/r/a.js',
+        signature: null,
+        start_line: 1,
+        end_line: 2,
+        cyclomatic: 1,
+      },
+      {
+        id: 2,
+        name: 'high',
+        kind: 'function',
+        file_path: '/r/a.js',
+        signature: null,
+        start_line: 3,
+        end_line: 4,
+        cyclomatic: 9,
+      },
+    ];
+    const { db, getCaptured } = makeWinnowDb(9001, symbols, fullRows);
+    const res = winnow(db, 9001, { sortBy: 'complexity', top: 10 });
+    expect(res.results.length).toBe(2);
+    // Higher complexity must come first — fails if cyclomatic was not selected.
+    expect(res.results[0].cyclomatic).toBe(9);
+    expect(getCaptured().sql).toContain('sc.cyclomatic');
+  });
+
+  it('sorts by churn (SELECTs + uses cm.commits)', () => {
+    const fullRows = [
+      {
+        id: 1,
+        name: 'low',
+        kind: 'function',
+        file_path: '/r/a.js',
+        signature: null,
+        start_line: 1,
+        end_line: 2,
+        commits: 2,
+      },
+      {
+        id: 2,
+        name: 'high',
+        kind: 'function',
+        file_path: '/r/a.js',
+        signature: null,
+        start_line: 3,
+        end_line: 4,
+        commits: 7,
+      },
+    ];
+    const { db, getCaptured } = makeWinnowDb(9002, symbols, fullRows);
+    const res = winnow(db, 9002, { sortBy: 'churn', top: 10 });
+    expect(res.results[0].commits).toBe(7);
+    expect(getCaptured().sql).toContain('cm.commits');
+  });
+
+  it('sorts by callers (SELECTs + uses cc_cnt.caller_count)', () => {
+    const fullRows = [
+      {
+        id: 1,
+        name: 'low',
+        kind: 'function',
+        file_path: '/r/a.js',
+        signature: null,
+        start_line: 1,
+        end_line: 2,
+        caller_count: 0,
+      },
+      {
+        id: 2,
+        name: 'high',
+        kind: 'function',
+        file_path: '/r/a.js',
+        signature: null,
+        start_line: 3,
+        end_line: 4,
+        caller_count: 5,
+      },
+    ];
+    const { db, getCaptured } = makeWinnowDb(9003, symbols, fullRows);
+    const res = winnow(db, 9003, { sortBy: 'callers', top: 10 });
+    expect(res.results[0].caller_count).toBe(5);
+    expect(getCaptured().sql).toContain('cc_cnt.caller_count');
+  });
+});
+
+// ── #9: extractHtmlSections must feed raw HTML to extractHtmlTags ──
+
+describe('code-audit #9: html section tags extracted from raw HTML', () => {
+  it('populates tags for the preamble and heading-loop branches', () => {
+    const html = [
+      '<html><body>',
+      '<p class="intro">Welcome</p>',
+      '<h1>Docs</h1>',
+      '<div class="api-reference">body</div>',
+      '</body></html>',
+    ].join('\n');
+
+    const sections = extractHtmlSections(html, 'page.html');
+    // A doc with <h1> takes the preamble + heading-loop path (the previously
+    // broken branches). Tags used to be '' for every such section.
+    const allTags = sections.map((s) => s.tags).join(',');
+    expect(allTags).toContain('intro');
+    expect(allTags).toContain('api-reference');
+  });
+
+  it('still extracts tags for the no-headings branch (unchanged)', () => {
+    const html = '<html><body><div class="landing">no headings here</div></body></html>';
+    const sections = extractHtmlSections(html, 'flat.html');
+    expect(sections[0].tags).toContain('landing');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three MEDIUM code-audit findings (broken functionality / incorrect logic). Each fix is covered by a regression test in `test/code-audit-medium-fixes.test.js`.

### Finding 7 — Broken functionality: incremental scope resolution return value
**File:** `src/code-index/scope-resolver.js` → `resolveScopeBindingsForFiles`

`resolveScopeBindingsForFiles` ran its work inside `runInTx(...)` but never returned a value, so it fell off the end and returned `undefined`. The sibling full-repo function `resolveScopeBindings` returns `{ resolved, unresolved, passes, warnings }`. The incremental caller (`incremental-indexer.js:468`) does:

```js
const sr = resolveScopeBindingsForFiles(...);
scopeResolved = sr.resolved || 0;   // sr === undefined → TypeError
```

**Impact:** On every incremental reindex, `sr.resolved` threw a `TypeError` that the surrounding `catch` swallowed, `scopeResolved` was always reported as `0`, and a misleading `scope-resolution-incremental` error was logged — even though the resolution actually executed.

**Fix:** The function now accumulates `resolved`/`unresolved`/`warnings` (direct resolution via `resolveBindingDirect`, which now returns its status; plus the re-export pass result) and returns `{ resolved, unresolved, passes: 3, warnings }`, matching the sibling contract.

### Finding 8 — Incorrect logic: winnow sort axis never receives its sort values
**File:** `src/code-analysis/import-graph-impl.js` → `winnow`

The `sortBy` branches only added JOINs (and only for `complexity`/`churn`) — they never added the sort columns to the `SELECT`, and the `callers` axis added no JOIN at all. The comparators read `row.cyclomatic` / `row.commits` / `row.caller_count`, all `undefined`, so each evaluated to `0 - 0`.

**Impact:** Sorting by complexity, churn, or callers was a silent no-op (results returned in arbitrary SQL order); only the default PageRank axis actually sorted.

**Fix:** The SELECT column list is now built dynamically and includes the column the comparator sorts on (`sc.cyclomatic` / `cm.commits` / `cc_cnt.caller_count`), and the relevant JOIN (including the `callers` `cc_cnt` subquery) is ensured before the SQL is built. Param ordering for the `cc_cnt` subquery is preserved.

### Finding 9 — Broken functionality: HTML tag extractor fed stripped text
**File:** `src/doc-index/html-parser.js` → `extractHtmlSections`

`extractHtmlTags` scans raw HTML for `class="..."` attributes and `<meta name="keywords">`, but the preamble and heading-loop branches passed it the already-stripped `textContent` (which contains no tags). The no-headings branch did it correctly (`extractHtmlTags(content)`).

**Impact:** Every HTML doc containing `<h1>`–`<h6>` (the normal case) got `tags: ''` for all sections, so tag-based search/filtering of HTML docs never worked.

**Fix:** The preamble and heading-loop branches now pass the raw HTML slices (`preamble` and `sectionContent`) to `extractHtmlTags`.

## Test plan
- [x] Added `test/code-audit-medium-fixes.test.js` (6 tests) — all pass with the fixes.
- [x] Verified the tests are faithful: temporarily reverting the source fixes makes **5 of 6** tests fail (the 6th is the already-correct no-headings baseline), then they pass again once restored.
- [x] `oxlint` and `oxfmt --check` pass on all touched files.
- [x] Ran related suites (`correctness-review-fixes`, `code-audit-fixes`, `incremental-derived`, `code-analysis-modules`, `doc-index-modules`, `doc-parser`); no new failures introduced. The pre-existing failures in `html-extractor.test.js` / `code-analysis.test.js` are identical on `main` and stem from the sandbox lacking the `better-sqlite3` / tree-sitter native backends, not from these changes.