### PR TITLE
fix: correctness review F10-F13 (lockfile counts, todo priority, compaction, --remember)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -237,7 +237,10 @@ if (isHelpRequest) {
             'project',
           ],
         );
-      } catch {}
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`${JSON.stringify({ error: `--remember failed: ${reason}` })}\n`);
+      }
     }
 
     if (text) {

--- a/extensions/memory-layer/hooks/session-lifecycle.ts
+++ b/extensions/memory-layer/hooks/session-lifecycle.ts
@@ -61,8 +61,11 @@ export function registerSessionCompact(pi: ExtensionAPI, deps: SessionDeps) {
       ...(deps.state.sessionId ? { 'session-id': String(deps.state.sessionId) } : {}),
     });
 
+    const contextObservations = (contextResult?.observations as any[]) || [];
+    const hasProjectContext = Boolean(contextResult) && contextObservations.length > 0;
+
     let crossProjectResult: MemResult | null = null;
-    if (!contextResult || !((contextResult.observations as any[]) || []).length) {
+    if (!hasProjectContext) {
       crossProjectResult = await deps.mem('context', {
         'all-projects': 'true',
         limit: '10',
@@ -84,10 +87,10 @@ export function registerSessionCompact(pi: ExtensionAPI, deps: SessionDeps) {
 
     const effectiveContext = contextResult || crossProjectResult;
 
-    const isNewProject = crossProjectResult !== null && !contextResult;
+    const isNewProject = !hasProjectContext && crossProjectResult !== null;
     const effectiveObservations = isNewProject
       ? (crossProjectResult!.observations as any[]) || []
-      : (effectiveContext.observations as any[]) || [];
+      : contextObservations;
     const stats = effectiveContext.stats as any;
     const personal = (effectiveContext.personal as any[]) || [];
 

--- a/src/platform/storage/repositories/aurex.js
+++ b/src/platform/storage/repositories/aurex.js
@@ -618,7 +618,14 @@ function createAurexRepository(deps) {
                  WHERE blocker.status NOT IN ('passed', 'merged', 'cancelled', 'implemented')
                )
              )
-           ORDER BY t.priority DESC, t.created_at
+           ORDER BY
+             CASE t.priority
+               WHEN 'high' THEN 3
+               WHEN 'medium' THEN 2
+               WHEN 'low' THEN 1
+               ELSE 2
+             END DESC,
+             t.created_at
            LIMIT 1
          )
          RETURNING *`,

--- a/src/token-saver/rules/git-diff.js
+++ b/src/token-saver/rules/git-diff.js
@@ -22,7 +22,6 @@ function compressGitDiff({ stdout, stderr }) {
   const files = [];
   let currentFile = null;
   const lockfileDiffs = [];
-  let lockfileLines = 0;
   let contextLines = 0;
   let inLockfile = false;
 
@@ -39,6 +38,7 @@ function compressGitDiff({ stdout, stderr }) {
           additions: 0,
           deletions: 0,
           hunks: [],
+          lockfileLines: 0,
         };
         files.push(currentFile);
         for (const lp of LOCKFILE_PATTERNS) {
@@ -48,8 +48,8 @@ function compressGitDiff({ stdout, stderr }) {
           }
         }
       }
-    } else if (inLockfile) {
-      lockfileLines++;
+    } else if (inLockfile && currentFile) {
+      currentFile.lockfileLines++;
     } else if (line.startsWith('@@')) {
       if (currentFile) {
         currentFile.hunks.push(line);
@@ -71,7 +71,7 @@ function compressGitDiff({ stdout, stderr }) {
   for (const file of files) {
     const isLockfile = lockfileDiffs.includes(file);
     if (isLockfile) {
-      output += `- ${file.path}: lockfile diff hidden (${lockfileLines} lines)\n`;
+      output += `- ${file.path}: lockfile diff hidden (${file.lockfileLines} lines)\n`;
     } else {
       output += `- ${file.path}: modified, +${file.additions} -${file.deletions}\n`;
     }
@@ -88,6 +88,7 @@ function compressGitDiff({ stdout, stderr }) {
     }
   }
 
+  const lockfileLines = lockfileDiffs.reduce((sum, f) => sum + f.lockfileLines, 0);
   const omitted = contextLines + lockfileLines;
   let summary = `${files.length} file(s) changed.`;
   if (lockfileDiffs.length > 0) {

--- a/test/aurex-todo-priority.test.js
+++ b/test/aurex-todo-priority.test.js
@@ -1,0 +1,49 @@
+const { createDb, sqlJson, sqlRun } = require('../db');
+const { createAurexRepository } = require('../src/platform/storage/repositories');
+
+// Wires an isolated in-memory DB (with full schema) onto the global sqlJson/sqlRun.
+// The aurex repository accepts that same { sqlJson, sqlRun } shape.
+const deps = { sqlJson, sqlRun };
+
+let initialized = false;
+beforeAll(() => {
+  if (!initialized) {
+    createDb({ db_path: ':memory:' });
+    initialized = true;
+  }
+});
+
+function setupMissionWithTodos(repo, todos) {
+  repo.createMissionLedger({ missionId: 'm1', missionTitle: 'priority mission', status: 'in_progress' });
+  for (const t of todos) {
+    repo.createTodo('m1', { status: 'ready', ...t });
+  }
+  return repo;
+}
+
+describe('claimNextReadyTodo priority ordering', () => {
+  it('claims high before medium before low (not lexicographic order)', () => {
+    const repo = createAurexRepository(deps);
+    // Insert out of priority order so a naive lexicographic DESC sort
+    // (medium > low > high) would surface the wrong todo first.
+    setupMissionWithTodos(repo, [
+      { id: 'td-low', priority: 'low', title: 'low todo' },
+      { id: 'td-med', priority: 'medium', title: 'medium todo' },
+      { id: 'td-high', priority: 'high', title: 'high todo' },
+    ]);
+
+    const first = repo.claimNextReadyTodo('m1', 'w1')[0];
+    const second = repo.claimNextReadyTodo('m1', 'w1')[0];
+    const third = repo.claimNextReadyTodo('m1', 'w1')[0];
+
+    expect(first.id).toBe('td-high');
+    expect(second.id).toBe('td-med');
+    expect(third.id).toBe('td-low');
+  });
+
+  it('returns empty when no ready todos remain', () => {
+    const repo = createAurexRepository(deps);
+    repo.createMissionLedger({ missionId: 'm2', missionTitle: 'empty', status: 'in_progress' });
+    expect(repo.claimNextReadyTodo('m2', 'w1')).toEqual([]);
+  });
+});

--- a/test/session-lifecycle-compact.test.js
+++ b/test/session-lifecycle-compact.test.js
@@ -1,0 +1,85 @@
+import { registerSessionCompact } from '../extensions/memory-layer/hooks/session-lifecycle.ts';
+
+function extractHandler(deps) {
+  let handler;
+  const pi = {
+    on: vi.fn((_eventName, callback) => {
+      handler = callback;
+    }),
+  };
+  registerSessionCompact(pi, deps);
+  return handler;
+}
+
+function buildDeps(memImpl) {
+  return {
+    state: { currentProject: 'TestProject', sessionId: 1 },
+    mem: vi.fn(memImpl),
+  };
+}
+
+describe('session_compact re-injection', () => {
+  test('uses cross-project memories when project context is non-null but empty', async () => {
+    const deps = buildDeps(async (_cmd, args) => {
+      if (args && args['all-projects'] === 'true') {
+        return {
+          observations: [{ type: 'decision', title: 'Cross-project decision' }],
+          personal: [],
+          stats: {},
+        };
+      }
+      // Project context call returns a non-null result with ZERO observations.
+      return { observations: [], personal: [], stats: { total_memories: 0 } };
+    });
+    const handler = extractHandler(deps);
+
+    const result = await handler({}, {});
+    const content = result.message.content;
+
+    // Pre-fix bug: fetched cross-project memories were discarded, showing "0 memories".
+    expect(content).toContain('Cross-project decision');
+    expect(content).not.toContain('0 memories');
+  });
+
+  test('uses project observations when present and does not fetch cross-project', async () => {
+    const mem = vi.fn(async () => ({
+      observations: [{ type: 'pattern', title: 'Project pattern', trust_score: 0.9 }],
+      personal: [],
+      stats: { total_memories: 5 },
+    }));
+    const deps = {
+      state: { currentProject: 'TestProject', sessionId: 1 },
+      mem,
+    };
+    const handler = extractHandler(deps);
+
+    const result = await handler({}, {});
+    const content = result.message.content;
+
+    expect(content).toContain('Project pattern');
+    expect(content).toContain('5 memories');
+    // Only the project context call should have been made.
+    expect(mem).toHaveBeenCalledTimes(1);
+    expect((mem.mock.calls[0][1] || {})['all-projects']).toBeUndefined();
+  });
+
+  test('handles truly new project (null project context)', async () => {
+    const deps = buildDeps(async (_cmd, args) => {
+      if (args && args['all-projects'] === 'true') {
+        return {
+          observations: [{ type: 'bugfix', title: 'Related from elsewhere' }],
+          personal: [],
+          stats: {},
+        };
+      }
+      return null;
+    });
+    const handler = extractHandler(deps);
+
+    const result = await handler({}, {});
+    const content = result.message.content;
+
+    expect(content).toContain('🆕 new project');
+    expect(content).toContain('Related from elsewhere');
+  });
+});

--- a/test/token-saver-git-diff.test.js
+++ b/test/token-saver-git-diff.test.js
@@ -50,4 +50,33 @@ describe('compress-git-diff', () => {
     expect(result.summary).toContain('lockfile');
     expect(result.importantOutput).toContain('lockfile diff hidden');
   });
+
+  it('reports each lockfile with its own line count across multiple lockfiles', () => {
+    const lockA = [
+      'diff --git a/package-lock.json b/package-lock.json',
+      'index abc..def 100644',
+      '--- a/package-lock.json',
+      '+++ b/package-lock.json',
+      '@@ -1,3 +1,3 @@',
+      ' lock-content-a',
+    ].join('\n');
+    const lockB = [
+      'diff --git a/yarn.lock b/yarn.lock',
+      'index abc..def 100644',
+      '--- a/yarn.lock',
+      '+++ b/yarn.lock',
+      '@@ -1,3 +1,3 @@',
+      ' lock-content-b-1',
+      ' lock-content-b-2',
+      ' lock-content-b-3',
+    ].join('\n');
+
+    const result = compressGitDiff({ stdout: `${lockA}\n${lockB}`, stderr: '', exitCode: 0 });
+
+    // Expected per-file counts: package-lock.json = 5 lines, yarn.lock = 7 lines.
+    // Pre-fix bug: both lockfiles printed the combined total (12 lines).
+    expect(result.importantOutput).toContain('package-lock.json: lockfile diff hidden (5 lines)');
+    expect(result.importantOutput).toContain('yarn.lock: lockfile diff hidden (7 lines)');
+    expect(result.importantOutput).not.toContain('(12 lines)');
+  });
 });


### PR DESCRIPTION
Fixes four correctness-review findings.

## F10 — Per-file lockfile line counts (`src/token-saver/rules/git-diff.js`)
`compressGitDiff` used a single global `lockfileLines` counter but printed it per-file, so when a diff touched two or more lockfiles each was reported with the **combined** line count of all lockfiles instead of its own. The counter is now tracked per-file on the file object, and the omitted total is derived from the per-file counts.

## F11 — Todo priority ordering (`src/platform/storage/repositories/aurex.js`)
`claimNextReadyTodo` used `ORDER BY t.priority DESC`, but `priority` is `TEXT`. SQLite therefore sorted the strings lexicographically (`medium` > `low` > `high`), so a medium-priority todo was claimed **before** any high-priority todo — the opposite of intent. Replaced with a numeric `CASE` (`high=3, medium=2, low=1`) ordered `DESC`, mirroring the existing `type_priority` CASE in `src/memory-domain/search.js`.

Verified with an isolated SQLite check:
- Old (`ORDER BY t.priority DESC`): `med -> low -> high` ❌
- New (numeric `CASE DESC`): `high -> med -> low` ✅

## F12 — Compaction cross-project re-injection (`extensions/memory-layer/hooks/session-lifecycle.ts`)
The fetch condition fetched cross-project memories when project context was `null` **or** had empty observations, but the consume condition (`isNewProject`) only used them when project context was `null`. So when a project's context call returned a non-null result with empty observations, the fetched cross-project memories were discarded and the post-compaction re-injection showed "0 memories". Aligned the consume condition with the fetch condition via a shared `hasProjectContext` flag (the same approach the sibling `context-injection.ts` uses for its consistent fetch/consume).

## F13 — Silent `--remember` failure (`cli.js`)
The `run --remember` handler wrapped the observations `INSERT` in `try { ... } catch {}`, swallowing any failure with no log while the command still exited 0. The failure is now reported to stderr as JSON (`{ "error": "--remember failed: ..." }`), matching the existing error-reporting convention in `cli.js`. The command's own exit code is preserved (the run command itself succeeded; only the persistence side-effect failed).

## Tests
- `test/token-saver-git-diff.test.js`: regression test for multiple lockfiles each reporting its own line count.
- `test/aurex-todo-priority.test.js`: `claimNextReadyTodo` claims high → medium → low (follows the repo's existing in-memory-DB test pattern).
- `test/session-lifecycle-compact.test.js`: post-compaction re-injection uses cross-project memories when project context is non-null but empty; also covers the normal and truly-new-project cases.

## Notes
- `oxlint` passes (exit 0) on all changed files.
- The DB-backed test requires `better-sqlite3`, which can't be compiled in this sandbox; it follows the established `job-store.test.js` pattern and runs in CI.
- `oxfmt` is not a CI gate (`test.yml` runs `npm test` + smoke CLI), and committed files aren't `oxfmt`-clean, so changes intentionally match the surrounding committed style without incidental reformatting.