### PR TITLE
fix(security): address CodeQL alerts #1-#5 (workflow perms + shell injection)

### DIFF
--- a/.github/workflows/crosshash-ci.yml
+++ b/.github/workflows/crosshash-ci.yml
@@ -10,9 +10,14 @@ on:
       - 'crosshash/**'
       - '.github/workflows/crosshash-ci.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build-test-clippy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: crosshash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
   # ── Gate: lint + test must pass before publish ──
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/bench/bench-helper.js
+++ b/bench/bench-helper.js
@@ -4,7 +4,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 // ══════════════════════════════════════════════════════════
 // LAPIS ROOT DETECTION
@@ -85,9 +85,12 @@ function pad(str, width) {
 
 function runCli(repo, subcommand, extraFlags = '') {
   const msPath = path.join(LAPIS_ROOT, 'memory-store.js');
-  const cmd = `node "${msPath}" ${subcommand} --repo ${repo} ${extraFlags}`;
+  const extraArgs = extraFlags
+    ? extraFlags.split(/\s+/).filter(Boolean)
+    : [];
+  const args = [msPath, subcommand, '--repo', repo, ...extraArgs];
   try {
-    const stdout = execSync(cmd, {
+    const stdout = execFileSync('node', args, {
       cwd: LAPIS_ROOT,
       encoding: 'utf-8',
       timeout: 30000,
@@ -102,7 +105,7 @@ function runCli(repo, subcommand, extraFlags = '') {
 function isRepoIndexed(repo) {
   try {
     const msPath = path.join(LAPIS_ROOT, 'memory-store.js');
-    const stdout = execSync(`node "${msPath}" list-code-repos`, {
+    const stdout = execFileSync('node', [msPath, 'list-code-repos'], {
       cwd: LAPIS_ROOT,
       encoding: 'utf-8',
       timeout: 5000,
@@ -128,7 +131,7 @@ function findSymbolWithCallers(repo) {
 
 function _pickHotFile(repo) {
   const msPath = path.join(LAPIS_ROOT, 'memory-store.js');
-  const stdout = execSync(`node "${msPath}" hotspots --repo ${repo} --top 1`, {
+  const stdout = execFileSync('node', [msPath, 'hotspots', '--repo', repo, '--top', '1'], {
     cwd: LAPIS_ROOT,
     encoding: 'utf-8',
     timeout: 10000,
@@ -144,7 +147,7 @@ function _pickHotFile(repo) {
 
 function _pickCallSymbolFromOutline(repo, hotFile) {
   const msPath = path.join(LAPIS_ROOT, 'memory-store.js');
-  const outlineOut = execSync(`node "${msPath}" outline --repo ${repo} --file "${hotFile}"`, {
+  const outlineOut = execFileSync('node', [msPath, 'outline', '--repo', repo, '--file', hotFile], {
     cwd: LAPIS_ROOT,
     encoding: 'utf-8',
     timeout: 10000,


### PR DESCRIPTION
Fixes the first 5 open CodeQL code-scanning alerts.

## Alerts addressed

| # | Rule | Location | Fix |
|---|------|----------|-----|
| 1 | `actions/missing-workflow-permissions` | `.github/workflows/test.yml` | Added explicit `permissions: contents: read` (workflow + job scope) |
| 2 | `actions/missing-workflow-permissions` | `.github/workflows/publish.yml` (`test` job) | Added `permissions: contents: read` to the `test` job (the `publish` job already had its own perms) |
| 3 | `actions/missing-workflow-permissions` | `.github/workflows/crosshash-ci.yml` | Added explicit `permissions: contents: read` (workflow + job scope) |
| 4 | `js/shell-command-injection-from-environment` | `bench/bench-helper.js:90` (`runCli`) | Replaced `execSync` with `execFileSync`, passing args as an array so no shell is invoked |
| 5 | `js/shell-command-injection-from-environment` | `bench/bench-helper.js:131` (`_pickHotFile`) | Same — `execFileSync` with explicit arg array |

## Why `execFileSync` for the bench-helper

CodeQL flags the old `execSync(`node "${msPath}" ${subcommand} --repo ${repo} ${extraFlags}`)` pattern because the untrusted-ish CLI args (`repo`, `subcommand`, `extraFlags`, `hotFile`) flow straight into a string that is parsed by `/bin/sh`. Special characters (spaces, quotes, `;`, `$`, backticks) in those values could change the meaning of the command.

Switching to `execFileSync('node', [msPath, ...args])` invokes `node` directly with the argument vector — no shell, no metacharacter interpretation — which is the recommendation in both the CodeQL help and the OWASP Command Injection guidance.

The other two `execSync` call sites in the same file (`isRepoIndexed`, `_pickCallSymbolFromOutline`) are migrated for consistency, even though they didn't have their own alerts yet — they're the same pattern and would trip the same query once any of their inputs become attacker-influenced.

## Verification

- `npx oxlint bench/bench-helper.js` → clean
- `node --check bench/bench-helper.js` → ok