### PR TITLE
fix(db): unblock V25 migration and correct migration short-circuit guard

### DIFF
--- a/db.js
+++ b/db.js
@@ -445,6 +445,35 @@ function _createTableIndexes(name, db) {
 
 /* ── migrations ───────────────────────────────────────────── */
 
+const MIGRATIONS = [
+  { to: 2, run: runMigrationV2 },
+  { to: 3, run: runMigrationV3 },
+  { to: 4, run: runMigrationV4 },
+  { to: 5, run: runMigrationV5 },
+  { to: 6, run: runMigrationV6 },
+  { to: 7, run: runMigrationV7 },
+  { to: 8, run: runMigrationV8 },
+  { to: 9, run: runMigrationV9 },
+  { to: 10, run: runMigrationV10 },
+  { to: 11, run: runMigrationV11 },
+  { to: 12, run: runMigrationV12 },
+  { to: 13, run: runMigrationV13 },
+  { to: 14, run: runMigrationV14 },
+  { to: 15, run: runMigrationV15 },
+  { to: 16, run: runMigrationV16 },
+  { to: 17, run: runMigrationV17 },
+  { to: 18, run: runMigrationV18 },
+  { to: 19, run: runMigrationV19 },
+  { to: 20, run: runMigrationV20 },
+  { to: 21, run: runMigrationV21 },
+  { to: 22, run: runMigrationV22 },
+  { to: 23, run: runMigrationV23 },
+  { to: 24, run: runMigrationV24 },
+  { to: 25, run: runMigrationV25 },
+];
+
+const LATEST_MIGRATION_VERSION = MIGRATIONS.reduce((max, m) => Math.max(max, m.to), 0);
+
 function runMigrations() {
   let version = 0;
   try {
@@ -454,39 +483,12 @@ function runMigrations() {
     console.error('[db] Failed to read user_version:', e.message);
   }
 
-  if (version >= 24) {
+  if (version >= LATEST_MIGRATION_VERSION) {
     return { migrated: false, version };
   }
 
-  const migrations = [
-    { to: 2, run: runMigrationV2 },
-    { to: 3, run: runMigrationV3 },
-    { to: 4, run: runMigrationV4 },
-    { to: 5, run: runMigrationV5 },
-    { to: 6, run: runMigrationV6 },
-    { to: 7, run: runMigrationV7 },
-    { to: 8, run: runMigrationV8 },
-    { to: 9, run: runMigrationV9 },
-    { to: 10, run: runMigrationV10 },
-    { to: 11, run: runMigrationV11 },
-    { to: 12, run: runMigrationV12 },
-    { to: 13, run: runMigrationV13 },
-    { to: 14, run: runMigrationV14 },
-    { to: 15, run: runMigrationV15 },
-    { to: 16, run: runMigrationV16 },
-    { to: 17, run: runMigrationV17 },
-    { to: 18, run: runMigrationV18 },
-    { to: 19, run: runMigrationV19 },
-    { to: 20, run: runMigrationV20 },
-    { to: 21, run: runMigrationV21 },
-    { to: 22, run: runMigrationV22 },
-    { to: 23, run: runMigrationV23 },
-    { to: 24, run: runMigrationV24 },
-    { to: 25, run: runMigrationV25 },
-  ];
-
   const fromVersion = version;
-  const pending = migrations.filter((m) => version < m.to);
+  const pending = MIGRATIONS.filter((m) => version < m.to);
   for (const migration of pending) {
     const errors = migration.run();
     if (errors.length > 0) {

--- a/test/review-fixes.test.js
+++ b/test/review-fixes.test.js
@@ -20,7 +20,7 @@ describe('review fixes', () => {
       dbModule.ensureDb();
     });
 
-    it('advances user_version from 22 through V23/V24 migrations', () => {
+    it('advances user_version from 22 through all pending migrations', () => {
       tmpDb = path.join(os.tmpdir(), `lapis-v23-${Date.now()}.db`);
       dbModule.resetDb();
       dbModule.createDb({ db_path: tmpDb });
@@ -41,9 +41,14 @@ describe('review fixes', () => {
         .prepare('PRAGMA table_info(file_scope_bindings)')
         .all()
         .some((c) => c.name === 'source_module');
-      expect(version).toBe(24);
+      const churnCols = reopened.prepare('PRAGMA table_info(churn_metrics)').all();
+      const hasTotalFilesChanged = churnCols.some((c) => c.name === 'total_files_changed');
+      const hasTopFilesJson = churnCols.some((c) => c.name === 'top_files_json');
+      expect(version).toBe(25);
       expect(table).toBeTruthy();
       expect(sourceModuleCol).toBe(true);
+      expect(hasTotalFilesChanged).toBe(true);
+      expect(hasTopFilesJson).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Problem

The migration suite in \`test/review-fixes.test.js\` failed:

\`\`\`
FAIL  test/review-fixes.test.js > review fixes > migration V23
      > advances user_version from 22 through V23/V24 migrations
AssertionError: expected 25 to be 24
\`\`\`

## Root cause

Migration V25 (\`churn_metrics\` \`total_files_changed\` / \`top_files_json\` columns) was added in \`db.js\`, but two things were not updated with it:

1. **Silent data-migration bug** — the \`runMigrations()\` short-circuit guard was still pinned at \`version >= 24\`. Any database already at \`user_version = 24\` returned early and **never received V25**, so the new columns would be missing on existing installs.
2. **Stale test** — the test still asserted \`user_version === 24\` and only checked the V23/V24 schema changes.

## Fix

- Extract the migration list to a module-level \`MIGRATIONS\` constant and derive \`LATEST_MIGRATION_VERSION\` from it (max \`to\` value). The early-return guard now uses \`version >= LATEST_MIGRATION_VERSION\`, so it automatically tracks the newest migration and can't fall out of sync again when V26+ is added.
- Update the \`review-fixes\` migration test to expect \`user_version === 25\` and assert the V24 (\`file_scope_bindings.source_module\`) and V25 (\`churn_metrics\` columns) schema effects.

## Testing

\`\`\`
node --check db.js            # OK
node --check test/review-fixes.test.js   # OK
\`\`\`

> Note: the full \`vitest\` suite could not be executed in this sandbox because native modules (\`better-sqlite3\`, \`tree-sitter-sql\`) require a build toolchain (\`make\`/\`g++\`) that is unavailable here. CI will run the suite. The failing assertion logic (24 → 25) and the guard threshold are addressed directly; the existing 1888 passing tests are unaffected by the refactor since \`MIGRATIONS\` is behaviorally identical to the previous inline array.