### PR TITLE
fix: correctness review F14-F22 — nine silent/inconsistent bugs

### DIFF
--- a/db.js
+++ b/db.js
@@ -445,6 +445,35 @@ function _createTableIndexes(name, db) {
 
 /* ── migrations ───────────────────────────────────────────── */
 
+const MIGRATIONS = [
+  { to: 2, run: runMigrationV2 },
+  { to: 3, run: runMigrationV3 },
+  { to: 4, run: runMigrationV4 },
+  { to: 5, run: runMigrationV5 },
+  { to: 6, run: runMigrationV6 },
+  { to: 7, run: runMigrationV7 },
+  { to: 8, run: runMigrationV8 },
+  { to: 9, run: runMigrationV9 },
+  { to: 10, run: runMigrationV10 },
+  { to: 11, run: runMigrationV11 },
+  { to: 12, run: runMigrationV12 },
+  { to: 13, run: runMigrationV13 },
+  { to: 14, run: runMigrationV14 },
+  { to: 15, run: runMigrationV15 },
+  { to: 16, run: runMigrationV16 },
+  { to: 17, run: runMigrationV17 },
+  { to: 18, run: runMigrationV18 },
+  { to: 19, run: runMigrationV19 },
+  { to: 20, run: runMigrationV20 },
+  { to: 21, run: runMigrationV21 },
+  { to: 22, run: runMigrationV22 },
+  { to: 23, run: runMigrationV23 },
+  { to: 24, run: runMigrationV24 },
+  { to: 25, run: runMigrationV25 },
+];
+
+const LATEST_MIGRATION_VERSION = MIGRATIONS.reduce((max, m) => Math.max(max, m.to), 0);
+
 function runMigrations() {
   let version = 0;
   try {
@@ -454,39 +483,12 @@ function runMigrations() {
     console.error('[db] Failed to read user_version:', e.message);
   }
 
-  if (version >= 24) {
+  if (version >= LATEST_MIGRATION_VERSION) {
     return { migrated: false, version };
   }
 
-  const migrations = [
-    { to: 2, run: runMigrationV2 },
-    { to: 3, run: runMigrationV3 },
-    { to: 4, run: runMigrationV4 },
-    { to: 5, run: runMigrationV5 },
-    { to: 6, run: runMigrationV6 },
-    { to: 7, run: runMigrationV7 },
-    { to: 8, run: runMigrationV8 },
-    { to: 9, run: runMigrationV9 },
-    { to: 10, run: runMigrationV10 },
-    { to: 11, run: runMigrationV11 },
-    { to: 12, run: runMigrationV12 },
-    { to: 13, run: runMigrationV13 },
-    { to: 14, run: runMigrationV14 },
-    { to: 15, run: runMigrationV15 },
-    { to: 16, run: runMigrationV16 },
-    { to: 17, run: runMigrationV17 },
-    { to: 18, run: runMigrationV18 },
-    { to: 19, run: runMigrationV19 },
-    { to: 20, run: runMigrationV20 },
-    { to: 21, run: runMigrationV21 },
-    { to: 22, run: runMigrationV22 },
-    { to: 23, run: runMigrationV23 },
-    { to: 24, run: runMigrationV24 },
-    { to: 25, run: runMigrationV25 },
-  ];
-
   const fromVersion = version;
-  const pending = migrations.filter((m) => version < m.to);
+  const pending = MIGRATIONS.filter((m) => version < m.to);
   for (const migration of pending) {
     const errors = migration.run();
     if (errors.length > 0) {

--- a/src/agent-intel/blast.js
+++ b/src/agent-intel/blast.js
@@ -4,29 +4,34 @@
 
 function blastRadius(db, repoId, symbolName, options = {}) {
   const { includeRuntime = true } = options;
-  
+
   // Find the symbol
-  const symbolRow = db.prepare(`
+  const symbolRow = db
+    .prepare(`
     SELECT id, name, qualified_name, kind, file_path
     FROM code_symbols
     WHERE repo_id = ? AND (name = ? OR qualified_name = ?)
     LIMIT 1
-  `).get(repoId, symbolName, symbolName);
+  `)
+    .get(repoId, symbolName, symbolName);
 
   if (!symbolRow) {
     return { error: `Symbol not found: ${symbolName}` };
   }
 
   // Direct callers
-  const directCallers = db.prepare(`
+  const directCallers = db
+    .prepare(`
     SELECT DISTINCT cs.id, cs.name, cs.qualified_name, cs.kind, cs.file_path
     FROM code_calls cc
     JOIN code_symbols cs ON cs.id = cc.caller_symbol_id
     WHERE cc.repo_id = ? AND cc.callee_symbol_id = ?
-  `).all(repoId, symbolRow.id);
+  `)
+    .all(repoId, symbolRow.id);
 
   // Transitive callers (2 hops)
-  const transitiveCallers = db.prepare(`
+  const transitiveCallers = db
+    .prepare(`
     SELECT DISTINCT cs2.id, cs2.name, cs2.qualified_name, cs2.kind, cs2.file_path
     FROM code_calls cc1
     JOIN code_symbols cs1 ON cs1.id = cc1.caller_symbol_id
@@ -34,29 +39,58 @@ function blastRadius(db, repoId, symbolName, options = {}) {
     JOIN code_symbols cs2 ON cs2.id = cc2.caller_symbol_id
     WHERE cc1.repo_id = ? AND cc1.callee_symbol_id = ?
       AND cs2.id != ?
-  `).all(repoId, symbolRow.id, symbolRow.id);
+  `)
+    .all(repoId, symbolRow.id, symbolRow.id);
 
-  // Tests that likely call this symbol
-  const likelyTests = db.prepare(`
-    SELECT DISTINCT cf.path
-    FROM code_files cf
-    WHERE cf.repo_id = ?
-      AND (LOWER(cf.path) LIKE '%test%' OR LOWER(cf.path) LIKE '%spec%')
-      AND cf.path LIKE ?
-    LIMIT 20
-  `).all(repoId, `%${symbolRow.name}%`);
+  // Tests that likely call this symbol.
+  // Previous implementation matched test files whose path string contained the
+  // symbol's name — that's a heuristic on the file path, not on call-graph
+  // evidence. It systematically excluded tests like `test/api.test.js` that
+  // import and exercise the symbol, and only matched tests whose file path
+  // happened to embed the symbol name. Use the call graph instead: find any
+  // file that contains a symbol whose caller chain reaches the target.
+  let likelyTests = [];
+  try {
+    likelyTests = db
+      .prepare(
+        `
+        SELECT DISTINCT cf.path
+        FROM code_calls cc
+        JOIN code_symbols caller ON caller.id = cc.caller_symbol_id
+        JOIN code_files cf ON cf.id = caller.file_id
+        WHERE cc.repo_id = ?
+          AND cc.callee_symbol_id = ?
+          AND (LOWER(cf.path) LIKE '%test%' OR LOWER(cf.path) LIKE '%spec%')
+        UNION
+        SELECT DISTINCT cf.path
+        FROM code_imports ci
+        JOIN code_symbols sym ON sym.file_id = ci.source_file_id
+        JOIN code_calls cc ON cc.caller_symbol_id = sym.id
+        JOIN code_files cf ON cf.id = ci.source_file_id
+        WHERE ci.repo_id = ?
+          AND cc.callee_symbol_id = ?
+          AND (LOWER(cf.path) LIKE '%test%' OR LOWER(cf.path) LIKE '%spec%')
+        LIMIT 20
+      `,
+      )
+      .all(repoId, symbolRow.id, repoId, symbolRow.id);
+  } catch {
+    likelyTests = [];
+  }
 
   // Docs that reference this symbol
   let docsAffected = [];
   try {
-    const docsWithSymbol = db.prepare(`
+    const docsWithSymbol = db
+      .prepare(`
       SELECT ds.title, df.path as file_path
       FROM doc_sections ds
       JOIN doc_files df ON df.id = ds.file_id
       WHERE ds.repo_id = ? AND ds.content LIKE ?
       LIMIT 10
-    `).all(repoId, `%${symbolRow.name}%`);
-    docsAffected = docsWithSymbol.map(d => d.file_path);
+    `)
+      .all(repoId, `%${symbolRow.name}%`);
+    docsAffected = docsWithSymbol.map((d) => d.file_path);
   } catch {
     // doc_sections may not have required structure - graceful degradation
   }
@@ -66,19 +100,23 @@ function blastRadius(db, repoId, symbolName, options = {}) {
   if (includeRuntime) {
     try {
       // Try to match by symbol_id first, then by function_name and file_path
-      let runtimeData = db.prepare(`
+      let runtimeData = db
+        .prepare(`
         SELECT hit_count, traffic, last_seen
         FROM runtime_symbols
         WHERE repo_id = ? AND symbol_id = ?
-      `).get(repoId, symbolRow.id);
+      `)
+        .get(repoId, symbolRow.id);
 
       // If not found by symbol_id, try matching by function_name
       if (!runtimeData) {
-        runtimeData = db.prepare(`
+        runtimeData = db
+          .prepare(`
           SELECT hit_count, traffic, last_seen
           FROM runtime_symbols
           WHERE repo_id = ? AND function_name = ? AND file_path LIKE ?
-        `).get(repoId, symbolRow.name, `%${symbolRow.file_path}`);
+        `)
+          .get(repoId, symbolRow.name, `%${symbolRow.file_path}`);
       }
 
       if (runtimeData) {
@@ -115,9 +153,10 @@ function blastRadius(db, repoId, symbolName, options = {}) {
     riskScore = Math.min(100, riskScore + 20);
   }
 
-  const reason = runtime && runtime.traffic === 'hot'
-    ? `Hot runtime path with ${totalCallers} total callers.`
-    : `${totalCallers} total callers (${directCallers.length} direct, ${transitiveCallers.length} transitive).`;
+  const reason =
+    runtime && runtime.traffic === 'hot'
+      ? `Hot runtime path with ${totalCallers} total callers.`
+      : `${totalCallers} total callers (${directCallers.length} direct, ${transitiveCallers.length} transitive).`;
 
   return {
     symbol: symbolRow.name,
@@ -128,7 +167,7 @@ function blastRadius(db, repoId, symbolName, options = {}) {
     transitive_callers: transitiveCallers.length,
     total_callers: totalCallers,
     routes_affected: likelyTests.length > 0 ? ['(inferred from test files)'] : [],
-    tests_likely_affected: likelyTests.map(t => t.path),
+    tests_likely_affected: likelyTests.map((t) => t.path),
     docs_affected: docsAffected,
     runtime,
     risk,

--- a/src/agent-intel/preflight.js
+++ b/src/agent-intel/preflight.js
@@ -232,18 +232,18 @@ function getDocMatches(db, task, repoName, limit) {
 function duplicateWarnings(task, codeItems) {
   const terms = taskTerms(task);
   const warnings = [];
-  const normalizedTask = terms.join(' ');
+  if (terms.length === 0) {
+    return warnings;
+  }
+  const overlapThreshold = Math.min(2, Math.max(1, terms.length));
   for (const item of codeItems.slice(0, 6)) {
     const normalizedSymbol = normalizeName(`${item.symbol} ${item.qualified_name || ''} ${item.signature || ''}`);
     const overlap = terms.filter((term) => normalizedSymbol.includes(term));
-    if (
-      overlap.length >= Math.min(2, Math.max(1, terms.length)) ||
-      (normalizedTask && normalizedSymbol.includes(normalizedTask))
-    ) {
+    if (overlap.length >= overlapThreshold) {
       warnings.push({
         symbol: item.symbol,
         file: item.file,
-        reason: `Existing symbol overlaps task intent (${overlap.slice(0, 4).join(', ') || normalizedTask}).`,
+        reason: `Existing symbol overlaps task intent (${overlap.slice(0, 4).join(', ')}).`,
       });
     }
   }
@@ -367,15 +367,17 @@ function preflight(deps, args) {
   try {
     const runtimeIngest = require('./runtime-ingest');
     const hotSymbols = runtimeIngest.getHotSymbols(db, repo.id, 50);
-    
+
     // Check if any of the top code items are hot paths
-    const topFiles = codeItems.slice(0, 3).map(item => item.file);
-    const hotMatches = hotSymbols.filter(s => s.file_path && topFiles.some(f => s.file_path.includes(f) || f.includes(s.file_path)));
-    
+    const topFiles = codeItems.slice(0, 3).map((item) => item.file);
+    const hotMatches = hotSymbols.filter(
+      (s) => s.file_path && topFiles.some((f) => s.file_path.includes(f) || f.includes(s.file_path)),
+    );
+
     if (hotMatches.length > 0) {
       runtimeHotness = {
         is_hot_path: true,
-        hot_matches: hotMatches.slice(0, 3).map(s => ({
+        hot_matches: hotMatches.slice(0, 3).map((s) => ({
           symbol: s.function_name,
           file: s.file_path,
           traffic: s.traffic,
@@ -388,9 +390,14 @@ function preflight(deps, args) {
   }
 
   // Recalculate risk with runtime consideration
-  const effectiveRisk = runtimeHotness && runtimeHotness.is_hot_path
-    ? (risk === 'low' ? 'medium' : risk === 'medium' ? 'high' : risk)
-    : risk;
+  const effectiveRisk =
+    runtimeHotness && runtimeHotness.is_hot_path
+      ? risk === 'low'
+        ? 'medium'
+        : risk === 'medium'
+          ? 'high'
+          : risk
+      : risk;
 
   return {
     task_summary: task,

--- a/src/agent-intel/runtime-ingest.js
+++ b/src/agent-intel/runtime-ingest.js
@@ -19,9 +19,9 @@ const fs = require('fs');
  */
 
 const TRAFFIC_THRESHOLDS = {
-  hot: 1000,    // >= 1000 hits in coverage period
-  warm: 100,    // >= 100 hits
-  cold: 0,      // < 100 hits
+  hot: 1000, // >= 1000 hits in coverage period
+  warm: 100, // >= 100 hits
+  cold: 0, // < 100 hits
 };
 
 function classifyTraffic(hitCount) {
@@ -39,10 +39,10 @@ function extractFunctionHits(coverageData) {
   const results = [];
   for (const [filePath, data] of Object.entries(coverageData)) {
     if (!data || !data.fnMap || !data.f) continue;
-    
+
     const fnMap = data.fnMap;
     const hitCounts = data.f;
-    
+
     for (const [idx, fn] of Object.entries(fnMap)) {
       const hitCount = hitCounts[idx] || 0;
       results.push({
@@ -68,11 +68,13 @@ function ingestCoverage(db, repoId, coveragePath, sourceFile = '') {
   // Pre-fetch symbol_id mapping for this repo to link runtime data to code symbols
   const symbolLookup = new Map();
   try {
-    const symbols = db.prepare(`
+    const symbols = db
+      .prepare(`
       SELECT id, name, qualified_name, file_path
       FROM code_symbols
       WHERE repo_id = ?
-    `).all(repoId);
+    `)
+      .all(repoId);
     for (const sym of symbols) {
       const key = `${sym.file_path}:${sym.name}`;
       symbolLookup.set(key, sym.id);
@@ -112,40 +114,66 @@ function ingestCoverage(db, repoId, coveragePath, sourceFile = '') {
 
   const result = upsert(functions);
 
+  // Aggregate traffic_breakdown from the PERSISTED state, not the just-ingested
+  // file. `INSERT OR REPLACE` overwrites the rows for functions in this file
+  // on every call but does not delete orphans from previously ingested files
+  // (or earlier versions of the same coverage report). Counting only
+  // `functions` would under-count hot/warm symbols after the second ingest
+  // and produce misleading dashboards that show a single-file snapshot.
+  let breakdown = { hot: 0, warm: 0, cold: 0 };
+  try {
+    const breakdownRows = db
+      .prepare('SELECT traffic, COUNT(*) as cnt FROM runtime_symbols WHERE repo_id = ? GROUP BY traffic')
+      .all(repoId);
+    for (const row of breakdownRows) {
+      if (row.traffic === 'hot') breakdown.hot = row.cnt;
+      else if (row.traffic === 'warm') breakdown.warm = row.cnt;
+      else if (row.traffic === 'cold') breakdown.cold = row.cnt;
+    }
+  } catch {
+    // runtime_symbols table may not exist yet — keep the function-level counts
+    // as a best-effort fallback so the return value is still defined.
+    breakdown = {
+      hot: functions.filter((f) => f.traffic === 'hot').length,
+      warm: functions.filter((f) => f.traffic === 'warm').length,
+      cold: functions.filter((f) => f.traffic === 'cold').length,
+    };
+  }
+
   return {
     functions_ingested: result.inserted,
     symbols_linked: result.linked,
-    traffic_breakdown: {
-      hot: functions.filter(f => f.traffic === 'hot').length,
-      warm: functions.filter(f => f.traffic === 'warm').length,
-      cold: functions.filter(f => f.traffic === 'cold').length,
-    },
+    traffic_breakdown: breakdown,
     source_file: coveragePath,
   };
 }
 
 function getHotSymbols(db, repoId, limit = 20) {
-  const rows = db.prepare(`
+  const rows = db
+    .prepare(`
     SELECT rs.*, cs.qualified_name, cs.kind
     FROM runtime_symbols rs
     LEFT JOIN code_symbols cs ON cs.id = rs.symbol_id
     WHERE rs.repo_id = ? AND rs.traffic IN ('hot', 'warm')
     ORDER BY rs.hit_count DESC
     LIMIT ?
-  `).all(repoId, limit);
+  `)
+    .all(repoId, limit);
 
   return rows;
 }
 
 function getColdSymbols(db, repoId, limit = 20) {
-  const rows = db.prepare(`
+  const rows = db
+    .prepare(`
     SELECT rs.*, cs.qualified_name, cs.kind
     FROM runtime_symbols rs
     LEFT JOIN code_symbols cs ON cs.id = rs.symbol_id
     WHERE rs.repo_id = ? AND rs.traffic = 'cold'
     ORDER BY rs.hit_count ASC
     LIMIT ?
-  `).all(repoId, limit);
+  `)
+    .all(repoId, limit);
 
   return rows;
 }

--- a/src/claude-code/context-inject.js
+++ b/src/claude-code/context-inject.js
@@ -112,7 +112,12 @@ async function assembleContextLines({ dispatch, getKnownRepos, project, cwd, que
 
 /** Capped convenience wrapper returning the final markdown string (or null). */
 async function buildInjectedContext(opts) {
-  const assembled = await assembleContextLines(opts).catch(() => null);
+  const assembled = await assembleContextLines(opts).catch((err) => {
+    // Log instead of silently swallowing — a null return value is
+    // indistinguishable from "no relevant memories" without a log line.
+    console.error(`[claude-code] assembleContextLines failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  });
   if (!assembled) {
     return null;
   }

--- a/src/claude-code/handlers/user-prompt-submit.js
+++ b/src/claude-code/handlers/user-prompt-submit.js
@@ -73,11 +73,7 @@ async function appendPreflight({ lines, dispatch, cwdRepo, prompt }) {
 
 async function run({ payload, dispatch, getKnownRepos, getKnownProjects, stateStore, isCancelled }) {
   const prompt = payload.prompt || '';
-  const { resolvedCwd, repos, project } = resolveProjectForCwd(
-    payload.cwd,
-    getKnownRepos,
-    getKnownProjects,
-  );
+  const { resolvedCwd, repos, project } = resolveProjectForCwd(payload.cwd, getKnownRepos, getKnownProjects);
   const claudeSessionId = payload.session_id;
 
   const state = stateStore.loadState(claudeSessionId);
@@ -90,7 +86,18 @@ async function run({ payload, dispatch, getKnownRepos, getKnownProjects, stateSt
     cwd: payload.cwd,
     query: prompt,
     sessionId,
-  }).catch(() => null);
+  }).catch((err) => {
+    // Log but do not throw — prompt must still go through with whatever
+    // non-memory context we can compute locally. Without logging, dispatch
+    // failures (engine unreachable, schema mismatch) are invisible to the
+    // user and indistinguishable from "no relevant memories found".
+    console.error(
+      `[claude-code] assembleContextLines failed for session ${claudeSessionId || 'unknown'}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return null;
+  });
 
   if (isCancelled?.()) {
     return null;

--- a/src/code-analysis/dead-code-impl.js
+++ b/src/code-analysis/dead-code-impl.js
@@ -118,15 +118,23 @@ function getDeadCode(db, repoId, opts) {
     .all(repoId, repoId);
 
   // ── Symbols that are re-exported (barrel exports) ──
-  const reExportedNames = new Set();
-  const reExports = db
-    .prepare(
-      "SELECT fi.path, ci.target_module FROM code_imports ci JOIN code_files fi ON fi.id = ci.source_file_id WHERE ci.import_type = 're-export' AND ci.repo_id = ?",
-    )
-    .all(repoId);
-  for (const re of reExports) {
-    reExportedNames.add(re.target_module);
-  }
+  // Populate the name set from `file_scope_bindings` where kind='re_export'.
+  // `code_imports` only stores the target module path (e.g. './utils') — it
+  // does NOT record the exported identifier name — so we cannot derive the
+  // exported symbol name set from that table alone. Scope bindings, however,
+  // capture the binding name (`export { foo } from './bar'` → name='foo').
+  // Falling back to scope bindings is the correct fix; the previous
+  // implementation compared module paths against symbol names and matched
+  // essentially never, so the RE_EXPORTED_PENALTY was dead and the
+  // NO_CALLERS_WEIGHT was always added even for barrel-re-exported symbols.
+  const reExportedNames = new Set(
+    db
+      .prepare(
+        "SELECT name FROM file_scope_bindings WHERE repo_id = ? AND kind = 're_export' AND name IS NOT NULL AND name != ''",
+      )
+      .all(repoId)
+      .map((row) => row.name),
+  );
 
   // PERF: Batch-retrieved re-export target file IDs (replaces per-symbol SQL query).
   // Do NOT replace with per-element queries — see issue #138.

--- a/src/code-analysis/risk-impl.js
+++ b/src/code-analysis/risk-impl.js
@@ -22,9 +22,7 @@ function gitDiffOutput(repoPath, base, branch, stat = false) {
     return '';
   }
   const range = `${base}...${branch}`;
-  const args = stat
-    ? ['-C', repoPath, 'diff', '--stat', range]
-    : ['-C', repoPath, 'diff', '--name-only', range];
+  const args = stat ? ['-C', repoPath, 'diff', '--stat', range] : ['-C', repoPath, 'diff', '--name-only', range];
   return execFileSync('git', args, {
     encoding: 'utf-8',
     timeout: 10000,
@@ -240,11 +238,17 @@ function getPrRiskProfile(db, repoId, opts = {}) {
       const maxCallers = Math.max(...rows.map((r) => r.affected_callers), 1);
       blastRadiusScore = Math.min(1.0, maxCallers / PR_RISK.BLAST_RADIUS_NORMALIZER);
     } else {
-      // Per-symbol blast radius for small PRs
+      // Per-symbol blast radius for small PRs. Pass depth=5 to match the
+      // batch CTE's `ct.depth < 5` boundary above; otherwise the per-symbol
+      // path would use getBlastRadius's default depth=3 and produce a
+      // systematically smaller affected-callers count than the batch branch,
+      // causing risk scores to jump discontinuously when the changed-symbol
+      // count crosses the >20 threshold.
       let maxCallers = 0;
       for (const sid of changedSymbolIds) {
         const br = getBlastRadius(db, repoId, {
           symbol: db.prepare('SELECT name FROM code_symbols WHERE id = ?').get(sid)?.name,
+          depth: 5,
         });
         const edgeCount = (br.callers || []).length;
         if (edgeCount > maxCallers) {

--- a/src/memory-domain/compaction.js
+++ b/src/memory-domain/compaction.js
@@ -428,10 +428,18 @@ function dream(deps, args = {}) {
         10,
       );
       deps.sqlRun("INSERT OR REPLACE INTO settings (key, value) VALUES ('dream_last_run', ?)", [report.completedAt]);
-      deps.sqlRun("INSERT OR REPLACE INTO settings (key, value) VALUES ('dream_total_cleaned', ?)", [String(currentTotal + totalCleaned)]);
-      deps.sqlRun("INSERT OR REPLACE INTO settings (key, value) VALUES ('dream_run_count', ?)", [String(currentCount + 1)]);
-    } catch (_e) {
-      // Non-critical — dashboard will show "no data" if this fails
+      deps.sqlRun("INSERT OR REPLACE INTO settings (key, value) VALUES ('dream_total_cleaned', ?)", [
+        String(currentTotal + totalCleaned),
+      ]);
+      deps.sqlRun("INSERT OR REPLACE INTO settings (key, value) VALUES ('dream_run_count', ?)", [
+        String(currentCount + 1),
+      ]);
+    } catch (e) {
+      // Log instead of swallowing silently — the report still advertises
+      // totalCleaned > 0 to the caller, so users would see inconsistent
+      // dashboard stats (in-memory says cleaned, settings says no data) with
+      // no way to reconcile without a log line.
+      console.error(`[dream] failed to persist dream-cycle stats: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/src/memory-domain/workspaces.js
+++ b/src/memory-domain/workspaces.js
@@ -1,5 +1,9 @@
 function listWorkspaces(deps) {
   const { sqlJson } = deps;
+  // Sort un-archived workspaces first, then most-recently-active first.
+  // `w.archived_at IS NULL` evaluates to 0/1; sorting it DESC puts NULLs
+  // (un-archived) before non-NULL (archived) without relying on the
+  // SQLite-3.30+ `NULLS FIRST` clause — works on any SQLite engine.
   const workspaces = sqlJson(`
     SELECT w.id, w.name, w.created_at, w.archived_at,
            COUNT(CASE WHEN o.deleted_at IS NULL AND o.type != 'skill' THEN 1 END) as memory_count,
@@ -7,7 +11,7 @@ function listWorkspaces(deps) {
     FROM workspaces w
     LEFT JOIN observations o ON o.project = w.name
     GROUP BY w.id
-    ORDER BY w.archived_at NULLS FIRST, last_active DESC
+    ORDER BY (w.archived_at IS NULL) DESC, w.archived_at ASC, last_active DESC
   `);
   return { workspaces, total: workspaces.length };
 }

--- a/test/correctness-review-fixes-2.test.js
+++ b/test/correctness-review-fixes-2.test.js
@@ -1,0 +1,431 @@
+// Regression tests for correctness review findings F14-F22
+// (separate from the earlier correctness-review-fixes.test.js F1-F13 set).
+// Each sub-describe covers one verified bug fix with a focused test.
+//
+// F14: src/code-analysis/dead-code-impl.js — re-export detection used the
+//      wrong namespace (module paths vs symbol names) so re-exported
+//      symbols were always treated as dead.
+// F15: src/agent-intel/runtime-ingest.js — traffic_breakdown only counted
+//      the just-ingested file, not the persisted runtime_symbols state.
+// F16: src/memory-domain/workspaces.js — used SQLite-only `NULLS FIRST`
+//      which fails on older SQLite engines.
+// F17: src/agent-intel/blast.js — tests_likely_affected filtered by symbol
+//      name in file path instead of by call-graph evidence.
+// F18: src/code-analysis/risk-impl.js — per-symbol blast-radius used depth=3
+//      while the batch branch used depth=5, so risk scores jumped at the
+//      >20 changed-symbol threshold.
+// F19: src/agent-intel/preflight.js — duplicateWarnings had a dead
+//      secondary check (`normalizedSymbol.includes(normalizedTask)`) that
+//      could never trigger independently of the primary overlap check.
+// F20: src/claude-code/handlers/user-prompt-submit.js — silent
+//      .catch(() => null) on assembleContextLines.
+// F21: src/claude-code/context-inject.js — silent
+//      .catch(() => null) on assembleContextLines in buildInjectedContext.
+// F22: src/memory-domain/compaction.js — dream stats persist failure was
+//      silently swallowed.
+
+const dbModule = require('../db');
+const { getDeadCode } = require('../src/code-analysis/dead-code-impl');
+const { ingestCoverage, classifyTraffic } = require('../src/agent-intel/runtime-ingest');
+const { listWorkspaces, createWorkspace, archiveWorkspace } = require('../src/memory-domain/workspaces');
+const { blastRadius } = require('../src/agent-intel/blast');
+const { getPrRiskProfile } = require('../src/code-analysis/risk-impl');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function uniqueRepoName(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// SQLite-backed tests are skipped when better-sqlite3 isn't installed.
+function sqliteReady() {
+  try {
+    dbModule.ensureDb();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('correctness review fixes (round 2) — source-level', () => {
+  // These checks are pure source inspection — they do not require the
+  // SQLite native binding and serve as guardrails against future
+  // regressions even when integration tests cannot run.
+
+  // ── F14: re-export detection uses correct namespace (file_scope_bindings) ──
+  it('F14: dead-code-impl reads file_scope_bindings.kind=re_export for names', () => {
+    const src = fs.readFileSync(require.resolve('../src/code-analysis/dead-code-impl'), 'utf8');
+    expect(src).toContain("kind = 're_export'");
+    // The pre-fix bug populated a set from code_imports.target_module and
+    // compared it against symbol names — the fix must use file_scope_bindings.
+    expect(src).not.toMatch(/reExportedNames\.add\(re\.target_module\)/);
+  });
+
+  // ── F15: traffic_breakdown reflects persisted runtime_symbols state ──
+  it('F15: runtime-ingest aggregates traffic_breakdown from runtime_symbols table', () => {
+    const src = fs.readFileSync(require.resolve('../src/agent-intel/runtime-ingest'), 'utf8');
+    expect(src).toContain('FROM runtime_symbols');
+    expect(src).toContain('GROUP BY traffic');
+    // The primary return value must derive from the persisted table,
+    // not from `functions.filter(...)` over the just-ingested file.
+    // Implementation uses dot-assignment to populate the breakdown object
+    // from the query result rows.
+    expect(src).toMatch(/breakdown\.(hot|warm|cold)\s*=\s*row\.cnt/);
+  });
+
+  // ── F16: listWorkspaces uses portable SQL (no NULLS FIRST) ──
+  it('F16: workspaces.js does not use SQLite-only NULLS FIRST in SQL', () => {
+    const src = fs.readFileSync(require.resolve('../src/memory-domain/workspaces'), 'utf8');
+    // Strip comments and check the remaining SQL strings.
+    const stripped = src
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*'))
+      .join('\n');
+    expect(stripped).not.toMatch(/NULLS\s+FIRST/i);
+  });
+
+  // ── F17: blastRadius tests_likely_affected uses call-graph evidence ──
+  it('F17: blast.js uses call graph (code_calls) to find tests, not symbol-name path LIKE', () => {
+    const src = fs.readFileSync(require.resolve('../src/agent-intel/blast'), 'utf8');
+    // The query must reference code_calls to find callers.
+    expect(src).toContain('FROM code_calls cc');
+    // Pre-fix bug matched test files whose path string contained the symbol name.
+    expect(src).not.toMatch(/cf\.path LIKE \?\s*\)\.all\(repoId, `%\$\{symbolRow\.name\}%`\)/);
+  });
+
+  // ── F18: risk-impl blast-radius branch consistency ──
+  it('F18: risk-impl.js per-symbol blast-radius branch passes depth=5', () => {
+    const src = fs.readFileSync(require.resolve('../src/code-analysis/risk-impl'), 'utf8');
+    expect(src).toMatch(/depth:\s*5/);
+    expect(src).not.toMatch(/\.edges\b/);
+  });
+
+  // ── F19: preflight duplicateWarnings removes dead secondary check ──
+  it('F19: duplicateWarnings no longer contains the unreachable normalizedSymbol.includes(normalizedTask) branch', () => {
+    const src = fs.readFileSync(require.resolve('../src/agent-intel/preflight'), 'utf8');
+    expect(src).not.toMatch(/normalizedSymbol\.includes\(normalizedTask\)/);
+    expect(src).toMatch(/overlap\.slice\(0,\s*4\)\.join/);
+  });
+
+  // ── F20: user-prompt-submit logs errors on assembleContextLines failure ──
+  it('F20: user-prompt-submit logs via console.error for assembleContextLines failures', () => {
+    const src = fs.readFileSync(require.resolve('../src/claude-code/handlers/user-prompt-submit'), 'utf8');
+    expect(src).toContain('console.error');
+    expect(src).toContain('assembleContextLines failed');
+    // The specific catch on the assembleContextLines(...) call must NOT be a
+    // silent `() => null` swallow — it must take the error and log it.
+    const assembleIdx = src.indexOf('assembleContextLines({');
+    if (assembleIdx === -1) {
+      throw new Error('could not locate assembleContextLines({ call');
+    }
+    // Find the closing `)` of the .catch chained onto that call.
+    const snippet = src.slice(assembleIdx, assembleIdx + 800);
+    expect(snippet).toMatch(/\.catch\(\s*\(err\)\s*=>/);
+  });
+
+  // ── F21: context-inject logs errors on assembleContextLines failure ──
+  it('F21: buildInjectedContext logs via console.error instead of .catch(() => null)', () => {
+    const src = fs.readFileSync(require.resolve('../src/claude-code/context-inject'), 'utf8');
+    expect(src).toContain('console.error');
+    expect(src).toContain('assembleContextLines failed');
+    expect(src).not.toMatch(/\.catch\(\(\)\s*=>\s*null\s*\)/);
+  });
+
+  // ── F22: dream stats persist failure is logged ──
+  it('F22: compaction.js dream stats persist failure logs via console.error', () => {
+    const src = fs.readFileSync(require.resolve('../src/memory-domain/compaction'), 'utf8');
+    expect(src).toContain('failed to persist dream-cycle stats');
+    // The previous silent swallow used a `_e` catch binding with the
+    // "Non-critical" comment — verify both are gone.
+    expect(src).not.toMatch(/catch\s*\(\s*_e\s*\)\s*{\s*\/\/\s*Non-critical/);
+  });
+});
+
+// Integration tests below require better-sqlite3 native binding. They are
+// skipped (not failed) when the binding is unavailable in the runtime.
+const describeIfSqlite = sqliteReady() ? describe : describe.skip;
+
+describeIfSqlite('correctness review fixes (round 2) — integration', () => {
+  beforeAll(() => {
+    dbModule.ensureDb();
+  });
+
+  // ── F14 integration: re-export detection ──
+
+  describe('F14: dead-code re-export detection', () => {
+    const repoName = uniqueRepoName('f14-reexport');
+    const repoId = 990001;
+
+    afterAll(() => {
+      try {
+        dbModule.sqlRun('DELETE FROM file_scope_bindings WHERE repo_id = ?', [repoId]);
+        dbModule.sqlRun('DELETE FROM code_files WHERE repo_id = ?', [repoId]);
+        dbModule.sqlRun('DELETE FROM code_symbols WHERE repo_id = ?', [repoId]);
+        dbModule.sqlRun('DELETE FROM code_repos WHERE id = ?', [repoId]);
+        dbModule.sqlRun('DELETE FROM code_repos WHERE name = ?', [repoName]);
+      } catch {}
+    });
+
+    it('detects symbols that are re-exported via file_scope_bindings (kind=re_export)', () => {
+      dbModule.sqlRun('INSERT INTO code_repos (id, name, path, head_commit) VALUES (?, ?, ?, NULL)', [
+        repoId,
+        repoName,
+        `/tmp/${repoName}`,
+      ]);
+      dbModule.sqlRun(
+        `INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count)
+         VALUES (?, ?, 'javascript', 'export function validateUser() {}', 'h1', 1000, 100, 1)`,
+        [repoId, `/tmp/${repoName}/internal.js`],
+      );
+      const fileId = dbModule.sqlJson('SELECT id FROM code_files WHERE repo_id = ? ORDER BY id DESC LIMIT 1', [
+        repoId,
+      ])[0].id;
+
+      dbModule.sqlRun(
+        `INSERT INTO code_symbols (repo_id, file_id, file_path, name, kind, signature, qualified_name,
+          start_line, end_line, start_byte, end_byte, docstring, body_preview, language, parent_name,
+          stable_symbol_id, content_hash, summary, decorators_json, keywords_json, call_references_json, ecosystem_context)
+         VALUES (?, ?, ?, 'validateUser', 'function', '() => void', 'validateUser',
+          1, 1, 0, 50, '', '', 'javascript', '', '', 'h1', '', '[]', '[]', '[]', '')`,
+        [repoId, fileId, `/tmp/${repoName}/internal.js`],
+      );
+
+      dbModule.sqlRun(
+        `INSERT INTO file_scope_bindings (repo_id, file_id, name, kind, origin, source_file_id,
+          source_name, source_module, line_start, line_end, scope_depth)
+         VALUES (?, ?, 'validateUser', 're_export', 'external_file', ?, 'validateUser',
+          './internal', 1, 1, 0)`,
+        [repoId, fileId, fileId],
+      );
+
+      const result = getDeadCode(dbModule.getDb(), repoId, { includeTests: true });
+      expect(result).toBeDefined();
+      expect(Array.isArray(result.dead_symbols)).toBe(true);
+      const sym = result.dead_symbols.find((s) => s.name === 'validateUser');
+      if (sym) {
+        // When the symbol IS re-exported, the dead-code detector must
+        // either omit it entirely (confidence < threshold) or include the
+        // 're_exported' signal with reduced confidence.
+        expect(
+          sym.signals.includes('re_exported') || sym.confidence < 0.5,
+          're-exported symbol should not be flagged as confidently dead',
+        ).toBe(true);
+      }
+    });
+
+    it('still flags truly uncalled, non-reexported symbols', () => {
+      const fileId = dbModule.sqlJson(
+        'SELECT id FROM code_files WHERE repo_id = ? ORDER BY id ASC LIMIT 1',
+        [990001],
+      )[0]?.id;
+      if (!fileId) return;
+      dbModule.sqlRun(
+        `INSERT INTO code_symbols (repo_id, file_id, file_path, name, kind, signature, qualified_name,
+          start_line, end_line, start_byte, end_byte, docstring, body_preview, language, parent_name,
+          stable_symbol_id, content_hash, summary, decorators_json, keywords_json, call_references_json, ecosystem_context)
+         VALUES (?, ?, ?, 'orphanSymbol', 'function', '() => void', 'orphanSymbol',
+          2, 2, 51, 100, '', '', 'javascript', '', '', 'h1', '', '[]', '[]', '[]', '')`,
+        [990001, fileId, `/tmp/${uniqueRepoName('f14')}/internal.js`],
+      );
+      const result = getDeadCode(dbModule.getDb(), 990001, { includeTests: true });
+      const orphan = result.dead_symbols.find((s) => s.name === 'orphanSymbol');
+      expect(orphan).toBeDefined();
+      expect(orphan.signals).toContain('no_callers');
+    });
+  });
+
+  // ── F15 integration: traffic_breakdown from persisted state ──
+
+  describe('F15: runtime-ingest traffic_breakdown reflects persisted state', () => {
+    const repoName = uniqueRepoName('f15-traffic');
+
+    afterAll(() => {
+      try {
+        dbModule.sqlRun('DELETE FROM runtime_symbols WHERE repo_id IN (SELECT id FROM code_repos WHERE name = ?)', [
+          repoName,
+        ]);
+        dbModule.sqlRun('DELETE FROM code_repos WHERE name = ?', [repoName]);
+      } catch {}
+    });
+
+    it('counts persisted hot/warm/cold across multiple ingest calls', () => {
+      const repoId = dbModule.sqlJson('INSERT INTO code_repos (name, path) VALUES (?, ?) RETURNING id', [
+        repoName,
+        `/tmp/${repoName}`,
+      ])[0].id;
+
+      const coverage = {
+        '/src/first.js': {
+          fnMap: {
+            0: { name: 'hotFn', line: 1, loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } } },
+            1: { name: 'coldFn', line: 2, loc: { start: { line: 2, column: 0 }, end: { line: 2, column: 1 } } },
+          },
+          f: { 0: 5000, 1: 0 },
+        },
+        '/src/second.js': {
+          fnMap: {
+            0: { name: 'warmFn', line: 1, loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } } },
+          },
+          f: { 0: 500 },
+        },
+      };
+
+      const tmpPath = path.join(os.tmpdir(), `${repoName}.json`);
+      fs.writeFileSync(tmpPath, JSON.stringify(coverage), 'utf8');
+      try {
+        ingestCoverage(dbModule.getDb(), repoId, tmpPath);
+        ingestCoverage(dbModule.getDb(), repoId, tmpPath);
+
+        const result = ingestCoverage(dbModule.getDb(), repoId, tmpPath);
+        const expected = { hot: 1, warm: 1, cold: 1 };
+        expect(result.traffic_breakdown).toEqual(expected);
+
+        const dbRows = dbModule.sqlJson(
+          'SELECT traffic, COUNT(*) as cnt FROM runtime_symbols WHERE repo_id = ? GROUP BY traffic',
+          [repoId],
+        );
+        const persisted = { hot: 0, warm: 0, cold: 0 };
+        for (const row of dbRows) {
+          persisted[row.traffic] = row.cnt;
+        }
+        expect(persisted).toEqual(expected);
+      } finally {
+        try {
+          fs.unlinkSync(tmpPath);
+        } catch {}
+      }
+    });
+
+    it('classifyTraffic boundary values are stable', () => {
+      expect(classifyTraffic(999)).toBe('cold');
+      expect(classifyTraffic(1000)).toBe('hot');
+      expect(classifyTraffic(100)).toBe('warm');
+    });
+  });
+
+  // ── F16 integration: listWorkspaces sorting ──
+
+  describe('F16: listWorkspaces SQL portability', () => {
+    it('listWorkspaces sorts un-archived workspaces before archived ones', () => {
+      const w1 = uniqueRepoName('f16-active');
+      const w2 = uniqueRepoName('f16-archived');
+      createWorkspace(dbModule, w1);
+      createWorkspace(dbModule, w2);
+      archiveWorkspace(dbModule, w2);
+
+      const result = listWorkspaces(dbModule);
+      const active = result.workspaces.find((w) => w.name === w1);
+      const archived = result.workspaces.find((w) => w.name === w2);
+      expect(active).toBeDefined();
+      expect(archived).toBeDefined();
+      expect(active.archived_at).toBeNull();
+      expect(archived.archived_at).not.toBeNull();
+
+      const activeIdx = result.workspaces.findIndex((w) => w.name === w1);
+      const archivedIdx = result.workspaces.findIndex((w) => w.name === w2);
+      expect(activeIdx).toBeLessThan(archivedIdx);
+    });
+  });
+
+  // ── F17 integration: blastRadius tests_likely_affected ──
+
+  describe('F17: blastRadius tests_likely_affected', () => {
+    const repoName = uniqueRepoName('f17-blast');
+
+    afterAll(() => {
+      try {
+        dbModule.sqlRun('DELETE FROM code_calls WHERE repo_id IN (SELECT id FROM code_repos WHERE name = ?)', [
+          repoName,
+        ]);
+        dbModule.sqlRun('DELETE FROM code_symbols WHERE repo_id IN (SELECT id FROM code_repos WHERE name = ?)', [
+          repoName,
+        ]);
+        dbModule.sqlRun('DELETE FROM code_files WHERE repo_id IN (SELECT id FROM code_repos WHERE name = ?)', [
+          repoName,
+        ]);
+        dbModule.sqlRun('DELETE FROM code_repos WHERE name = ?', [repoName]);
+      } catch {}
+    });
+
+    it('finds tests via call-graph even when their file path does not contain the symbol name', () => {
+      const repoId = dbModule.sqlJson('INSERT INTO code_repos (name, path) VALUES (?, ?) RETURNING id', [
+        repoName,
+        `/tmp/${repoName}`,
+      ])[0].id;
+
+      dbModule.sqlRun(
+        `INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count)
+         VALUES (?, ?, 'javascript',
+          'export function criticalFunction() { return 1; }',
+          'core-h', 1000, 100, 1)`,
+        [repoId, `/tmp/${repoName}/src/core.js`],
+      );
+      const coreFileId = dbModule.sqlJson('SELECT id FROM code_files WHERE repo_id = ? ORDER BY id DESC LIMIT 1', [
+        repoId,
+      ])[0].id;
+
+      dbModule.sqlRun(
+        `INSERT INTO code_symbols (repo_id, file_id, file_path, name, kind, signature, qualified_name,
+          start_line, end_line, start_byte, end_byte, docstring, body_preview, language, parent_name,
+          stable_symbol_id, content_hash, summary, decorators_json, keywords_json, call_references_json, ecosystem_context)
+         VALUES (?, ?, ?, 'criticalFunction', 'function', '() => 1', 'criticalFunction',
+          1, 1, 0, 60, '', '', 'javascript', '', '', 'h-core', '', '[]', '[]', '[]', '')`,
+        [repoId, coreFileId, `/tmp/${repoName}/src/core.js`],
+      );
+      const targetSym = dbModule.sqlJson('SELECT id FROM code_symbols WHERE repo_id = ? AND name = ?', [
+        repoId,
+        'criticalFunction',
+      ])[0].id;
+
+      dbModule.sqlRun(
+        `INSERT INTO code_files (repo_id, path, language, content, content_hash, mtime, size_bytes, line_count)
+         VALUES (?, ?, 'javascript',
+          'test("critical", () => { criticalFunction(); });',
+          'api-h', 1000, 100, 1)`,
+        [repoId, `/tmp/${repoName}/test/api.test.js`],
+      );
+      const testFileId = dbModule.sqlJson('SELECT id FROM code_files WHERE repo_id = ? ORDER BY id DESC LIMIT 1', [
+        repoId,
+      ])[0].id;
+
+      dbModule.sqlRun(
+        `INSERT INTO code_symbols (repo_id, file_id, file_path, name, kind, signature, qualified_name,
+          start_line, end_line, start_byte, end_byte, docstring, body_preview, language, parent_name,
+          stable_symbol_id, content_hash, summary, decorators_json, keywords_json, call_references_json, ecosystem_context)
+         VALUES (?, ?, ?, 'runApiTest', 'function', '() => void', 'runApiTest',
+          1, 1, 0, 60, '', '', 'javascript', '', '', 'h-test', '', '[]', '[]', '[]', '')`,
+        [repoId, testFileId, `/tmp/${repoName}/test/api.test.js`],
+      );
+      const testCaller = dbModule.sqlJson('SELECT id FROM code_symbols WHERE repo_id = ? AND name = ?', [
+        repoId,
+        'runApiTest',
+      ])[0].id;
+
+      dbModule.sqlRun(
+        `INSERT INTO code_calls (repo_id, caller_symbol_id, callee_name, callee_symbol_id, confidence, line_number)
+         VALUES (?, ?, 'criticalFunction', ?, 1.0, 1)`,
+        [repoId, testCaller, targetSym],
+      );
+
+      const result = blastRadius(dbModule.getDb(), repoId, 'criticalFunction');
+      expect(result.error).toBeUndefined();
+      expect(result.tests_likely_affected).toBeDefined();
+      expect(result.tests_likely_affected.length).toBe(1);
+      expect(result.tests_likely_affected[0]).toMatch(/api\.test\.js$/);
+    });
+  });
+
+  // ── F18 integration: getPrRiskProfile blast-radius branch ──
+
+  describe('F18: getPrRiskProfile blast-radius branch consistency', () => {
+    it('getPrRiskProfile returns consistent blast_radius in [0, 1]', () => {
+      const result = getPrRiskProfile(dbModule.getDb(), 999999, { branch: 'HEAD', base: 'main' });
+      expect(result).toBeDefined();
+      if (result.signals) {
+        expect(result.signals.blast_radius).toBeGreaterThanOrEqual(0);
+        expect(result.signals.blast_radius).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+});

--- a/test/correctness-review-fixes-2.test.js
+++ b/test/correctness-review-fixes-2.test.js
@@ -298,9 +298,13 @@ describeIfSqlite('correctness review fixes (round 2) — integration', () => {
     });
 
     it('classifyTraffic boundary values are stable', () => {
-      expect(classifyTraffic(999)).toBe('cold');
+      // Thresholds: hot >= 1000, warm >= 100, cold < 100.
+      // Just below hot → warm; just at hot → hot; just at warm → warm;
+      // well below warm → cold.
+      expect(classifyTraffic(999)).toBe('warm');
       expect(classifyTraffic(1000)).toBe('hot');
       expect(classifyTraffic(100)).toBe('warm');
+      expect(classifyTraffic(50)).toBe('cold');
     });
   });
 

--- a/test/review-fixes.test.js
+++ b/test/review-fixes.test.js
@@ -20,7 +20,7 @@ describe('review fixes', () => {
       dbModule.ensureDb();
     });
 
-    it('advances user_version from 22 through V23/V24 migrations', () => {
+    it('advances user_version from 22 through all pending migrations', () => {
       tmpDb = path.join(os.tmpdir(), `lapis-v23-${Date.now()}.db`);
       dbModule.resetDb();
       dbModule.createDb({ db_path: tmpDb });
@@ -41,9 +41,14 @@ describe('review fixes', () => {
         .prepare('PRAGMA table_info(file_scope_bindings)')
         .all()
         .some((c) => c.name === 'source_module');
-      expect(version).toBe(24);
+      const churnCols = reopened.prepare('PRAGMA table_info(churn_metrics)').all();
+      const hasTotalFilesChanged = churnCols.some((c) => c.name === 'total_files_changed');
+      const hasTopFilesJson = churnCols.some((c) => c.name === 'top_files_json');
+      expect(version).toBe(25);
       expect(table).toBeTruthy();
       expect(sourceModuleCol).toBe(true);
+      expect(hasTotalFilesChanged).toBe(true);
+      expect(hasTopFilesJson).toBe(true);
     });
   });
 
@@ -65,21 +70,21 @@ describe('review fixes', () => {
         [sessionId],
       );
       memoryId = obs[0].id;
-      dbModule.sqlRun(
-        'INSERT INTO recall_log (memory_id, session_id, query, was_useful) VALUES (?, ?, ?, 1)',
-        [memoryId, sessionId, 'test-query'],
-      );
-      dbModule.sqlRun(
-        'INSERT INTO symbol_links (memory_id, symbol_id, repo, trust_score) VALUES (?, ?, ?, ?)',
-        [String(memoryId), '__unlinked__', 'review-fixes-trust', 0.5],
-      );
+      dbModule.sqlRun('INSERT INTO recall_log (memory_id, session_id, query, was_useful) VALUES (?, ?, ?, 1)', [
+        memoryId,
+        sessionId,
+        'test-query',
+      ]);
+      dbModule.sqlRun('INSERT INTO symbol_links (memory_id, symbol_id, repo, trust_score) VALUES (?, ?, ?, ?)', [
+        String(memoryId),
+        '__unlinked__',
+        'review-fixes-trust',
+        0.5,
+      ]);
     });
 
     it('getRecalledMemoryIds includes recall_log entries', () => {
-      const rows = getRecalledMemoryIds(
-        { sqlJson: dbModule.sqlJson },
-        sessionId,
-      );
+      const rows = getRecalledMemoryIds({ sqlJson: dbModule.sqlJson }, sessionId);
       expect(rows.some((r) => String(r.memory_id) === String(memoryId))).toBe(true);
     });
 
@@ -102,14 +107,17 @@ describe('review fixes', () => {
         [negativeSessionId],
       );
       const ignoredMemoryId = obs[0].id;
-      dbModule.sqlRun(
-        'INSERT INTO recall_log (memory_id, session_id, query, was_useful) VALUES (?, ?, ?, 0)',
-        [ignoredMemoryId, negativeSessionId, 'ignored-search'],
-      );
-      dbModule.sqlRun(
-        'INSERT INTO symbol_links (memory_id, symbol_id, repo, trust_score) VALUES (?, ?, ?, ?)',
-        [String(ignoredMemoryId), '__unlinked__', 'review-fixes-trust-negative', 0.5],
-      );
+      dbModule.sqlRun('INSERT INTO recall_log (memory_id, session_id, query, was_useful) VALUES (?, ?, ?, 0)', [
+        ignoredMemoryId,
+        negativeSessionId,
+        'ignored-search',
+      ]);
+      dbModule.sqlRun('INSERT INTO symbol_links (memory_id, symbol_id, repo, trust_score) VALUES (?, ?, ?, ?)', [
+        String(ignoredMemoryId),
+        '__unlinked__',
+        'review-fixes-trust-negative',
+        0.5,
+      ]);
 
       const recalled = getRecalledMemoryIds({ sqlJson: dbModule.sqlJson }, negativeSessionId);
       expect(recalled.some((r) => String(r.memory_id) === String(ignoredMemoryId))).toBe(false);
@@ -130,10 +138,10 @@ describe('review fixes', () => {
         repoId = existing[0].id;
         return;
       }
-      const inserted = dbModule.sqlJson(
-        'INSERT INTO code_repos (name, path) VALUES (?, ?) RETURNING id',
-        ['review-fixes-pr-risk', process.cwd()],
-      );
+      const inserted = dbModule.sqlJson('INSERT INTO code_repos (name, path) VALUES (?, ?) RETURNING id', [
+        'review-fixes-pr-risk',
+        process.cwd(),
+      ]);
       repoId = inserted[0].id;
     });
 


### PR DESCRIPTION
## Summary

Addresses nine bugs identified in the correctness review pass that are still present in main:

| # | File | Bug |
|---|------|-----|
| F14 | `src/code-analysis/dead-code-impl.js` | Re-export detection populated `reExportedNames` from `code_imports.target_module` (module paths) but checked it against symbol names — RE_EXPORTED_PENALTY was always silent and barrel-re-exported symbols were always flagged dead. |
| F15 | `src/agent-intel/runtime-ingest.js` | `traffic_breakdown` only counted the just-ingested `functions` array, not the persisted `runtime_symbols` state. Re-ingesting undercounted hot/warm symbols on the dashboard. |
| F16 | `src/memory-domain/workspaces.js` | `ORDER BY ... NULLS FIRST` is SQLite-3.30+-only and breaks portability. |
| F17 | `src/agent-intel/blast.js` | `tests_likely_affected` filtered test files by checking if their path contained the symbol name — generic tests like `test/api.test.js` were systematically excluded. |
| F18 | `src/code-analysis/risk-impl.js` | Per-symbol blast-radius branch used depth=3; batch branch used depth=5 — risk scores jumped at the >20 changed-symbol threshold. |
| F19 | `src/agent-intel/preflight.js` | `duplicateWarnings` had a dead secondary check that could never trigger independently of the primary overlap check. |
| F20 | `src/claude-code/handlers/user-prompt-submit.js` | `.catch(() => null)` silently swallowed dispatch failures. |
| F21 | `src/claude-code/context-inject.js` | Same silent-swallow pattern on `assembleContextLines`. |
| F22 | `src/memory-domain/compaction.js` | Dream stats persistence failure was silently swallowed while `report.totalCleaned` still advertised success. |

## Additional commits in this PR

- `e35655c` cherry-picks the upstream V25 migration fix (#252) so that `test/review-fixes.test.js` (which expects `user_version` to advance to the latest migration) passes. The upstream fix already added V25 to `db.js` but the test fix was not part of the original PR.
- `52d796a` corrects the F15 `classifyTraffic` boundary test — the original assertion `classifyTraffic(999) === 'cold'` was wrong because `999 >= 100` puts it in the warm bucket. Updated to `=== 'warm'` and added a true-cold case (`50`) for completeness.

## Test plan

- New `test/correctness-review-fixes-2.test.js` with regression tests for all nine findings.
- Source-level checks run without the SQLite native binding.
- Integration tests are gated on `sqliteReady()` and skipped when `better-sqlite3` is unavailable.
- All existing tests still pass (`test/code-audit-fixes.test.js`, `test/code-audit-medium-fixes.test.js`, `test/data-access-workspaces.test.js`, `test/review-fixes.test.js` — green).
- `oxlint` reports 0 errors on the workspace.

🤖 Generated with [Kilo Code](https://kilocode.ai)