### PR TITLE
fix(db): honor LAPIS_HOME in config.js so the DB path actually follows it

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
-const HOME = process.env.HOME || process.env.USERPROFILE || os.homedir();
+const HOME = process.env.LAPIS_HOME || process.env.HOME || process.env.USERPROFILE || os.homedir();
 const CONFIG_DIR = path.join(HOME, '.pi', 'memory');
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.jsonc');
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -204,4 +204,36 @@ describe('config.js', () => {
       expect(cfg.ranking.recall).toBe(DEFAULTS.ranking.recall);
     });
   });
+
+  describe('LAPIS_HOME env override', () => {
+    const CONFIG_REAL = require.resolve('../config');
+    const ORIGINAL_LAPIS = process.env.LAPIS_HOME;
+    const ORIGINAL_HOME = process.env.HOME;
+
+    afterEach(() => {
+      if (ORIGINAL_LAPIS === undefined) delete process.env.LAPIS_HOME;
+      else process.env.LAPIS_HOME = ORIGINAL_LAPIS;
+      if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+      else process.env.HOME = ORIGINAL_HOME;
+      delete require.cache[CONFIG_REAL];
+      resetConfigCache();
+    });
+
+    it('resolves the memory dir from LAPIS_HOME before HOME (db_path follows)', () => {
+      process.env.LAPIS_HOME = '/opt/lapis-home';
+      process.env.HOME = '/tmp/other-home';
+      delete require.cache[CONFIG_REAL];
+      const fresh = require('../config');
+      expect(fresh.DEFAULTS.db_path).toBe(path.join('/opt/lapis-home', '.pi', 'memory', 'memory.db'));
+      expect(fresh.DEFAULTS.tier_config_path).toBe(path.join('/opt/lapis-home', '.pi', 'memory', 'tier.jsonc'));
+    });
+
+    it('falls back to HOME when LAPIS_HOME is unset', () => {
+      delete process.env.LAPIS_HOME;
+      process.env.HOME = '/tmp/plain-home';
+      delete require.cache[CONFIG_REAL];
+      const fresh = require('../config');
+      expect(fresh.DEFAULTS.db_path).toBe(path.join('/tmp/plain-home', '.pi', 'memory', 'memory.db'));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #256 (merged). The `LAPIS_HOME` override added to `db.js` in #256 was **dead code for the actual database path**: `db.DB_PATH` resolves through `config.js`, whose `HOME` resolution only read `process.env.HOME`. Any process launched with a different `HOME` — the exact scenario the Hermes installer pins `LAPIS_HOME` for — still silently split the database between the MCP server and the CLI.

## Fix

- `config.js` — `HOME` now resolves `LAPIS_HOME` → `HOME` → `USERPROFILE` → `os.homedir()`, matching `db.js`. `db_path` and `tier_config_path` now follow the installed `mcp_servers.lapis` `env.LAPIS_HOME` pin, so the MCP server and CLI share one SQLite DB regardless of the hosting process's `HOME`.

## Test plan

- `test/config.test.js` — 2 new regression tests: re-require `config.js` with `LAPIS_HOME` set (asserts `db_path`/`tier_config_path` follow it over `HOME`) and with it unset (falls back to `HOME`).
- Verified: `LAPIS_HOME=/opt/data HOME=/tmp/fakehome node -e "…db.DB_PATH…"` → resolves to `/opt/data/.pi/memory/memory.db` (previously `/tmp/fakehome/.pi/…`).
- Full suite: **1964 passing** (134 files) — run before this branch was cut from `main` (#256 + this commit).

## Discovery

Found during adoption on the author's machine: the real Hermes host runs with `HOME=/opt/data` while the CLI shell has `HOME=/opt/data/home` — the two paths were hardlinked to the same inode, masking the split (until a VACUUM/checkpoint recreates a file and the hardlink breaks).
