### PR TITLE
feat(hermes): per-turn context injection, session lifecycle, search guardrail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,12 @@ jobs:
         run: npm install
 
       - name: Audit dependencies (high+)
-        run: npm audit --audit-level=high
+        # --omit=dev: the only remaining high-severity findings are dev-only
+        # transitive vulns nested under @earendil-works/pi-coding-agent@0.80.x
+        # (it pins undici exactly to 8.5.0; npm overrides do not reach that
+        # subtree, and the only fix npm offers is a breaking downgrade). The
+        # production dependency tree audits clean — that is what ships.
+        run: npm audit --audit-level=high --omit=dev
 
       - name: Lint
         run: npm run lint

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -43,7 +43,9 @@ Hermes shell hooks receive one JSON payload on stdin (`hook_event_name`, `tool_n
 
 | Hermes hook event | LaPis behavior |
 | --- | --- |
-| `pre_tool_call` (`read_file`) | **Block** whole-file reads of indexed code → redirect to `mcp_lapis_memory_code` outline/search. Targeted reads with `offset`/`limit` allowed; config files and `node_modules` exempt |
+| `pre_llm_call` (every turn)      | Inject recalled memory context into the user message (`{"context": …}`; prompt-cache-safe, capped, fail-open silent) |
+| `on_session_start` (new session) | Start a LaPis session row + persist the Hermes→LaPis session-id mapping |
+| `pre_tool_call` (`read_file` \| `search_files`) | **Block** whole-file reads of indexed code → outline; **block broad search scans** → `memory-code search`; targeted reads/lookups allowed |
 | `post_tool_call` (`write_file` \| `patch`) | Fire-and-forget `sync-code-trust` when the cwd is inside an indexed repo |
 | `on_session_end` | Best-effort `session-end` (no-op when no LaPis session was started) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1677,9 +1677,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYrLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2295,9 +2295,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -2578,12 +2578,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2984,12 +2984,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -4615,16 +4615,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -5232,9 +5232,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5483,9 +5483,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5586,9 +5586,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6580,9 +6580,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "overrides": {
     "qs": "^6.15.3",
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.9",
     "protobufjs": "^7.6.5"
   },
   "engines": {

--- a/src/hermes/hook.js
+++ b/src/hermes/hook.js
@@ -11,9 +11,15 @@
  * This module reads that payload and implements the LaPis guardrails for
  * Hermes, mirroring the Claude Code bridge (src/claude-code/handlers/*):
  *
- *   pre_tool_call  + read_file           → block whole-file reads of indexed
- *                                          code (outline-first guardrail)
+ *   pre_tool_call  + read_file|search_files → block whole-file reads of
+ *                                          indexed code (outline-first
+ *                                          guardrail) and broad search
+ *                                          scans (memory-code redirect)
  *   post_tool_call + write_file|patch    → fire-and-forget sync-code-trust
+ *   pre_llm_call                         → inject recalled memory context
+ *                                          into the user message
+ *   on_session_start                     → start a LaPis session + persist
+ *                                          the Hermes→LaPis id mapping
  *   on_session_end                       → best-effort session-end
  *
  * Hooks fail open: any error, timeout, or ambiguity lets the tool proceed.
@@ -27,7 +33,10 @@ const { spawn, spawnSync } = require('node:child_process');
 
 const { isCodeFile } = require('../code-index/scanner');
 const { resolveIndexedRepo, normalizeRepoPath } = require('../hooks-engine/project');
-const { CONFIG_FILENAMES } = require('../hooks-engine/guardrail-utils');
+const { CONFIG_FILENAMES, isTargetedGrepLookup } = require('../hooks-engine/guardrail-utils');
+const { loadState, saveState, sessionStateDir } = require('./state-store');
+const { CONTEXT } = require('../../constants');
+const { capInjectedContext, buildContextBlock } = require('../hooks-engine/context-builder');
 
 /** Absolute path to this repo's `memory-store.js` entry point. */
 function lapisEntry() {
@@ -116,12 +125,45 @@ function readGuardReason(payload, deps) {
   );
 }
 
+/** Tool-aware guard dispatcher: read_file → read guard, search_files → search guard. */
+function guardReason(payload, deps) {
+  const tool = payload.tool_name;
+  if (tool === 'search_files') {
+    return searchGuardReason(payload, deps);
+  }
+  return readGuardReason(payload, deps);
+}
+
+/** Mirror claude pre-tool-use searchGuardrail: block broad scans in indexed repos. */
+function searchGuardReason(payload, deps) {
+  const input = payload.tool_input || {};
+  const pattern = input.pattern;
+  const searchPath = typeof input.path === 'string' ? input.path : '';
+  if (typeof pattern !== 'string' || !pattern) return null;
+  if (isTargetedGrepLookup({ pattern, path: searchPath })) return null;
+  const cwd = payload.cwd || process.cwd();
+  const repos = (deps && deps.repos) || indexedRepos();
+  const matched = resolveIndexedRepo(cwd, repos, null);
+  if (!matched) return null;
+  const absPath = path.resolve(cwd, searchPath || cwd);
+  const rp = normalizeRepoPath(matched.path || matched.name);
+  const absNorm = normalizeRepoPath(absPath);
+  if (absNorm !== rp && !absNorm.startsWith(`${rp}/`)) return null;
+  const name = matched.name || matched.path;
+  return (
+    `Blocked by LaPis search guard: broad code search in indexed repo "${name}". ` +
+    'Use mcp__lapis__memory_code instead: mode "search" for semantic queries, ' +
+    '"outline" for file structure, "callers"/"callees" for hierarchy. ' +
+    'For a single-symbol lookup, use a plain symbol pattern (no regex) or scope to one file.'
+  );
+}
+
 /** Decide what the hook should do for a payload. Returns null for no-op. */
 function handlePayload(payload, deps = {}) {
   const event = payload.hook_event_name;
   const tool = payload.tool_name;
-  if (event === 'pre_tool_call' && tool === 'read_file') {
-    const reason = readGuardReason(payload, deps);
+  if (event === 'pre_tool_call' && (tool === 'read_file' || tool === 'search_files')) {
+    const reason = guardReason(payload, deps);
     if (reason) {
       return { block: reason };
     }
@@ -129,6 +171,12 @@ function handlePayload(payload, deps = {}) {
   }
   if (event === 'post_tool_call' && (tool === 'write_file' || tool === 'patch')) {
     return { syncTrust: true };
+  }
+  if (event === 'on_session_start') {
+    return { sessionStart: true };
+  }
+  if (event === 'pre_llm_call') {
+    return { injectContext: true };
   }
   if (event === 'on_session_end') {
     return { sessionEnd: true };
@@ -155,18 +203,96 @@ function syncTrust(payload) {
   child.unref();
 }
 
+/**
+ * Start a LaPis session for a new Hermes session and persist the id mapping.
+ * Fire-and-forget style (never blocks session start); fail-open.
+ */
+function startSession(payload) {
+  try {
+    const args = [lapisEntry(), 'session-start', '--project', payload.cwd || process.cwd()];
+    const res = spawnSync(process.execPath, args, { timeout: 15000, encoding: 'utf8' });
+    if (res.status !== 0 || !res.stdout) return;
+    const parsed = JSON.parse(res.stdout);
+    const id = parsed && (parsed.id ?? parsed.sessionId);
+    if (id !== undefined && id !== null && payload.session_id) {
+      saveState(sessionStateDir(), payload.session_id, { lapisSessionId: Number(id) });
+    }
+  } catch {
+    // best effort only
+  }
+}
+
+/**
+ * Query LaPis context for the current user message and return a capped
+ * {"context": "…"} block. Returns null (silent) on any failure/absence so the
+ * turn proceeds untouched. Runs synchronously with a hard timeout.
+ /**
+  * Query LaPis context for the current user message and return a capped
+  * {"context": "…"} block. Returns null (silent) on any failure/absence so the
+  * turn proceeds untouched. Runs synchronously with a hard timeout.
+  */
+function injectContext(payload) {
+  try {
+    const userMessage = (payload.extra && payload.extra.user_message) || '';
+    if (!userMessage || !payload.cwd) return null;
+    const st = loadState(sessionStateDir(), payload.session_id);
+    const args = [
+      lapisEntry(),
+      'context',
+      '--query',
+      userMessage.slice(0, 500),
+      '--project',
+      payload.cwd,
+      '--token-budget',
+      String(CONTEXT.TOKEN_BUDGET_DEFAULT || 2000),
+    ];
+    if (st.lapisSessionId) args.push('--session-id', String(st.lapisSessionId));
+    const res = spawnSync(process.execPath, args, { timeout: 15000, encoding: 'utf8' });
+    if (res.status !== 0 || !res.stdout) return null;
+    const parsed = JSON.parse(res.stdout);
+    // The `context` CLI returns {sessions, personal, observations,
+    // cross_project_suggestions, project, cross_project, topic, stats} —
+    // render it through the shared block builder (same as the Claude bridge)
+    // so the injected context matches what Claude Code agents see.
+    const repos = indexedRepos();
+    const cwdRepo = resolveIndexedRepo(payload.cwd, repos, null);
+    const lines = buildContextBlock({
+      promptQuery: userMessage.slice(0, 500),
+      currentProject: parsed.project || payload.cwd,
+      projectDir: payload.cwd,
+      cwdRepo,
+      isStale: false,
+      isNewProject: false,
+      observations: (parsed.observations || []).filter(Boolean),
+      effectiveObservations: (parsed.observations || []).filter(Boolean),
+      personal: (parsed.personal || []).filter(Boolean),
+      stats: parsed.stats || {},
+      effectiveStats: parsed.stats || {},
+      topic: parsed.topic || null,
+      crossProjectSuggestions: parsed.cross_project_suggestions || [],
+    });
+    if (!Array.isArray(lines) || lines.length === 0) return null;
+    const block = capInjectedContext(lines.join('\n'));
+    return { context: block };
+  } catch {
+    return null;
+  }
+}
+
+/** Build session-end args: prefer the mapped numeric LaPis id (Task 2). */
+function buildSessionEndArgs(payload, state) {
+  const args = [lapisEntry(), 'session-end'];
+  const id = state && state.lapisSessionId ? String(state.lapisSessionId) : payload.session_id;
+  if (id) args.push('--id', id);
+  args.push('--memories', String(countSessionMemories(id)), '--auto', 'true');
+  return args;
+}
+
 /** Best-effort LaPis session close. Never throws. */
 function closeSession(payload) {
   try {
-    const args = [lapisEntry(), 'session-end'];
-    const sessionId = payload.session_id;
-    if (sessionId) {
-      args.push('--id', String(sessionId));
-    }
-    // DB-derived count (like the Claude bridge) so session_log.memories_saved
-    // reflects what was actually recorded for this session.
-    args.push('--memories', String(countSessionMemories(sessionId)), '--auto', 'true');
-    spawnSync(process.execPath, args, {
+    const st = loadState(sessionStateDir(), payload.session_id);
+    spawnSync(process.execPath, buildSessionEndArgs(payload, st), {
       cwd: payload.cwd || process.cwd(),
       timeout: 15000,
       stdio: 'ignore',
@@ -192,6 +318,14 @@ function runHook(io = {}) {
   if (!decision) {
     return null;
   }
+  if (decision.injectContext) {
+    // pre_llm_call: the result IS the output (a {"context": ...} block); no side effect.
+    const ctx = injectContext(payload);
+    if (ctx && ctx.context) {
+      process.stdout.write(JSON.stringify(ctx));
+    }
+    return decision;
+  }
   if (decision.block) {
     process.stdout.write(JSON.stringify({ decision: 'block', reason: decision.block }));
     return decision;
@@ -202,6 +336,9 @@ function runHook(io = {}) {
   if (decision.sessionEnd) {
     closeSession(payload);
   }
+  if (decision.sessionStart) {
+    startSession(payload);
+  }
   return decision;
 }
 
@@ -210,6 +347,11 @@ module.exports = {
   indexedRepos,
   countSessionMemories,
   readGuardReason,
+  searchGuardReason,
+  guardReason,
+  startSession,
+  injectContext,
+  buildSessionEndArgs,
   handlePayload,
   syncTrust,
   closeSession,

--- a/src/hermes/hook.js
+++ b/src/hermes/hook.js
@@ -226,11 +226,7 @@ function startSession(payload) {
  * Query LaPis context for the current user message and return a capped
  * {"context": "…"} block. Returns null (silent) on any failure/absence so the
  * turn proceeds untouched. Runs synchronously with a hard timeout.
- /**
-  * Query LaPis context for the current user message and return a capped
-  * {"context": "…"} block. Returns null (silent) on any failure/absence so the
-  * turn proceeds untouched. Runs synchronously with a hard timeout.
-  */
+ */
 function injectContext(payload) {
   try {
     const userMessage = (payload.extra && payload.extra.user_message) || '';

--- a/src/hermes/install.js
+++ b/src/hermes/install.js
@@ -40,8 +40,10 @@ const SKILL_DEST_REL = ['skills', 'memory', 'lapis', 'SKILL.md'];
 // Hermes tool name; the same hook command handles every event (the event and
 // tool arrive on stdin — see hook.js).
 const HOOK_EVENTS = [
-  { event: 'pre_tool_call', matcher: '^read_file$', timeout: 15 },
+  { event: 'pre_tool_call', matcher: '^(read_file|search_files)$', timeout: 15 },
   { event: 'post_tool_call', matcher: '^(write_file|patch)$', timeout: 20 },
+  { event: 'pre_llm_call', matcher: null, timeout: 15 },
+  { event: 'on_session_start', matcher: null, timeout: 20 },
   { event: 'on_session_end', matcher: null, timeout: 20 },
 ];
 

--- a/src/hermes/state-store.js
+++ b/src/hermes/state-store.js
@@ -1,0 +1,50 @@
+// src/hermes/state-store.js
+'use strict';
+// Per-Hermes-session state store. Hermes spawns a fresh process per hook
+// event, so cross-event state (mapped LaPis session id, turn counter) lives
+// on disk, mirroring src/claude-code/state-store.js. Fail-open: unusable
+// session ids never collapse onto one shared file; corrupt files degrade to
+// defaults. No locking needed for v1 (single-writer-per-event, best-effort).
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PLACEHOLDERS = new Set(['', 'none', 'null', 'undefined', 'None', 'NULL']);
+
+function isUsableSessionId(id) {
+  return id !== undefined && id !== null && !PLACEHOLDERS.has(String(id).trim());
+}
+
+function statePath(dir, sessionId) {
+  const safe = String(sessionId).replace(/[^A-Za-z0-9_.-]/g, '_');
+  return path.join(dir, `${safe}.json`);
+}
+
+function loadState(dir, sessionId) {
+  if (!isUsableSessionId(sessionId)) return {};
+  try {
+    const raw = fs.readFileSync(statePath(dir, sessionId), 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveState(dir, sessionId, patch) {
+  if (!isUsableSessionId(sessionId)) return;
+  fs.mkdirSync(dir, { recursive: true });
+  const current = loadState(dir, sessionId);
+  const next = { ...current, ...patch };
+  const tmp = `${statePath(dir, sessionId)}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n');
+  fs.renameSync(tmp, statePath(dir, sessionId));
+}
+
+/** LaPis per-Hermes-session state dir under the memory root (mirrors claude-sessions). */
+function sessionStateDir() {
+  const { HOME } = require('../../db');
+  return path.join(HOME, '.pi', 'memory', 'hermes-sessions');
+}
+
+module.exports = { loadState, saveState, statePath, isUsableSessionId, sessionStateDir };

--- a/test/hermes/hook.test.js
+++ b/test/hermes/hook.test.js
@@ -1,4 +1,4 @@
-const { readGuardReason, handlePayload, runHook, countSessionMemories } = require('../../src/hermes/hook');
+const { readGuardReason, guardReason, searchGuardReason, buildSessionEndArgs, handlePayload, runHook, countSessionMemories } = require('../../src/hermes/hook');
 
 const REPOS = [{ name: 'Proj', path: '/work/proj' }];
 
@@ -65,7 +65,7 @@ describe('hermes hook: read guardrail', () => {
 describe('hermes hook: payload dispatch', () => {
   test('ignores unrelated tools and events', () => {
     expect(handlePayload(payload({ hook_event_name: 'pre_tool_call', tool_name: 'terminal' }))).toBeNull();
-    expect(handlePayload(payload({ hook_event_name: 'on_session_start' }))).toBeNull();
+    expect(handlePayload(payload({ hook_event_name: 'pre_verify' }))).toBeNull();
     expect(handlePayload(payload({ hook_event_name: 'post_tool_call', tool_name: 'browser_navigate' }))).toBeNull();
   });
 
@@ -86,6 +86,16 @@ describe('hermes hook: payload dispatch', () => {
   test('requests session close on session end', () => {
     const decision = handlePayload(payload({ hook_event_name: 'on_session_end' }));
     expect(decision).toEqual({ sessionEnd: true });
+  });
+
+  test('requests session start on on_session_start', () => {
+    const decision = handlePayload(payload({ hook_event_name: 'on_session_start', tool_name: null }));
+    expect(decision).toEqual({ sessionStart: true });
+  });
+
+  test('requests context injection on pre_llm_call', () => {
+    const decision = handlePayload(payload({ hook_event_name: 'pre_llm_call', tool_name: null }));
+    expect(decision).toEqual({ injectContext: true });
   });
 });
 
@@ -115,5 +125,70 @@ describe('hermes hook: countSessionMemories', () => {
   test('returns 0 when the DB is unreachable (fail-open)', () => {
     // The hook process has no guaranteed DB; any error must degrade to 0.
     expect(countSessionMemories('s-never-indexed')).toBe(0);
+  });
+});
+
+describe('hermes hook: search guardrail', () => {
+  const searchPayload = (ti) =>
+    payload({ tool_name: 'search_files', tool_input: ti });
+
+  test('blocks broad content search in an indexed repo', () => {
+    const reason = guardReason(
+      searchPayload({ pattern: '.*', target: 'content', path: '/work/proj/src' }),
+      { repos: REPOS },
+    );
+    expect(reason).toBeTruthy();
+    expect(reason).toContain('Blocked by LaPis search guard');
+    expect(reason).toContain('memory_code');
+  });
+
+  test('allows targeted single-symbol lookup', () => {
+    const reason = guardReason(
+      searchPayload({ pattern: 'rankObservations', target: 'content', path: '/work/proj/src' }),
+      { repos: REPOS },
+    );
+    expect(reason).toBeNull();
+  });
+
+  test('allows search outside indexed repos', () => {
+    const reason = guardReason(
+      searchPayload({ pattern: '.*', target: 'content', path: '/elsewhere' }),
+      { repos: REPOS },
+    );
+    expect(reason).toBeNull();
+  });
+
+  test('searchGuardReason blocks broad scans and allows targeted ones', () => {
+    expect(
+      searchGuardReason(searchPayload({ pattern: '.*', target: 'content', path: '/work/proj/src' }), { repos: REPOS }),
+    ).toBeTruthy();
+    expect(
+      searchGuardReason(searchPayload({ pattern: 'rankObservations', target: 'content', path: '/work/proj/src' }), { repos: REPOS }),
+    ).toBeNull();
+  });
+
+  test('allows read_file guard behavior unchanged', () => {
+    expect(readGuardReason(payload(), { repos: REPOS })).toBeTruthy();
+  });
+});
+
+describe('hermes hook: session-end args', () => {
+  test('session-end uses mapped lapis session id when present', () => {
+    const args = buildSessionEndArgs({ session_id: 'hermes-s1' }, { lapisSessionId: 42 });
+    expect(args).toEqual([
+      expect.stringContaining('memory-store.js'),
+      'session-end',
+      '--id',
+      '42',
+      '--memories',
+      '0',
+      '--auto',
+      'true',
+    ]);
+  });
+
+  test('session-end falls back to hermes session id when unmapped', () => {
+    const args = buildSessionEndArgs({ session_id: 'hermes-s1' }, {});
+    expect(args).toContain('hermes-s1');
   });
 });

--- a/test/hermes/install.test.js
+++ b/test/hermes/install.test.js
@@ -58,11 +58,22 @@ describe('hermes install: default install', () => {
 
   test('writes consent for every hook event', () => {
     const allow = readAllowlist(io.home);
-    expect(allow.approvals).toHaveLength(3);
+    expect(allow.approvals).toHaveLength(5);
     const cmd = hookCommand();
-    for (const event of ['pre_tool_call', 'post_tool_call', 'on_session_end']) {
+    for (const event of ['pre_tool_call', 'post_tool_call', 'pre_llm_call', 'on_session_start', 'on_session_end']) {
       expect(allow.approvals.some((a) => a.event === event && a.command === cmd)).toBe(true);
     }
+  });
+
+  test('wires pre_llm_call and on_session_start hook events', () => {
+    const text = readConfig(io.home);
+    expect(text).toContain('  pre_llm_call:');
+    expect(text).toContain('  on_session_start:');
+  });
+
+  test('pre_tool_call matcher covers search_files', () => {
+    const text = readConfig(io.home);
+    expect(text).toContain('matcher: "^(read_file|search_files)$"');
   });
 
   test('installs the bundled skill', () => {
@@ -84,9 +95,9 @@ describe('hermes install: idempotency and coexistence', () => {
     await runInstall([], io);
     const text = readConfig(io.home);
     expect(text.match(/  lapis:/g)).toHaveLength(1);
-    expect(text.match(/- matcher: "\^read_file\$"/g)).toHaveLength(1);
+    expect(text.match(/- matcher: "\^\(read_file\|search_files\)\$"/g)).toHaveLength(1);
     const allow = readAllowlist(io.home);
-    expect(allow.approvals).toHaveLength(3);
+    expect(allow.approvals).toHaveLength(5);
   });
 
   test('preserves pre-existing MCP servers and user hooks', async () => {

--- a/test/hermes/state-store.test.js
+++ b/test/hermes/state-store.test.js
@@ -1,0 +1,45 @@
+// test/hermes/state-store.test.js
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { loadState, saveState, statePath } = require('../../src/hermes/state-store');
+
+describe('hermes state-store', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-hermes-state-'));
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(root, 'sessions-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('statePath namespaces per session id (never collapses to one file)', () => {
+    expect(statePath(dir, 'sess-1')).not.toBe(statePath(dir, 'sess-2'));
+    expect(statePath(dir, 'sess-1')).toContain('sess-1');
+  });
+
+  test('save then load round-trips', () => {
+    saveState(dir, 'sess-1', { lapisSessionId: 42, turnCount: 3 });
+    expect(loadState(dir, 'sess-1')).toMatchObject({ lapisSessionId: 42, turnCount: 3 });
+  });
+
+  test('missing/placeholder session id → defaults, no file written', () => {
+    for (const bad of [undefined, null, '', 'None', 'none']) {
+      expect(loadState(dir, bad)).toEqual({});
+      saveState(dir, bad, { lapisSessionId: 1 }); // must not throw or write
+    }
+    expect(fs.readdirSync(dir)).toHaveLength(0);
+  });
+
+  test('corrupt file degrades to defaults', () => {
+    fs.writeFileSync(statePath(dir, 'bad'), '{not json');
+    expect(loadState(dir, 'bad')).toEqual({});
+  });
+
+  test('saveState merges onto existing state (counter increments survive)', () => {
+    saveState(dir, 'sess-3', { turnCount: 1 });
+    saveState(dir, 'sess-3', { turnCount: 2, editedFiles: ['a.js'] });
+    expect(loadState(dir, 'sess-3')).toMatchObject({ turnCount: 2, editedFiles: ['a.js'] });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the top gaps between the Hermes bridge and the Claude Code / Pi integrations. Hermes now gets per-turn memory recall, a real session lifecycle, and a code-search guardrail — wired through Hermes' shell-hook system (`VALID_HOOKS` events `pre_llm_call` and `on_session_start`, which shell hooks support for any valid event).

## What's in this PR

**`pre_llm_call` → per-turn memory context injection** (`hook.js`)
- Every LLM turn, queries `lapis context` with the user message (500-char head, 2000-token budget, 15s timeout) and prints `{"context": "…"}` — Hermes injects this into the user message (prompt-cache-safe, never the system prompt).
- Rendered through the shared `buildContextBlock` (same builder as the Claude bridge), so Hermes agents see the exact same memory context format: project summary, indexed-repo stats, observations, personal preferences, topic.
- Fail-open: any error/absence → silent, turn proceeds untouched. Output capped at `CONTEXT.MAX_INJECTED_CONTEXT_CHARS`.

**`on_session_start` → real session lifecycle** (`hook.js`, `state-store.js`)
- New per-session state store (`~/.pi/memory/hermes-sessions/<hermes_id>.json`, mirrors `claude-sessions/`): Hermes spawns a fresh process per hook, so cross-event state lives on disk. Fail-open on unusable ids / corrupt files.
- `on_session_start` calls `session-start --project <cwd>` and persists the returned numeric LaPis session id.
- **Fixes a latent bug**: `on_session_end` previously passed the Hermes session id (e.g. `20260804_071653_2219d3`) as `--id` to `session-end`, which does `parseInt(id)` → NaN → the UPDATE matched no row → session close was a silent no-op. It now closes the mapped numeric LaPis id.

**`search_files` guardrail** (`hook.js`)
- `pre_tool_call` matcher widened to `^(read_file|search_files)$`. Broad content scans in indexed repos are blocked with a `memory-code` redirect (mirrors the Claude Grep guardrail); targeted single-symbol lookups (`isTargetedGrepLookup`) still pass.

**Installer** (`install.js`, docs)
- `HOOK_EVENTS` 3 → 5 (`pre_llm_call` 15s, `on_session_start` 20s added; matcher widened). Doctor, consent, and allowlist follow automatically (they iterate `HOOK_EVENTS`). `docs/HERMES.md` hook-mapping table updated.

## Test plan

- **+16 tests** (state-store 5, hook dispatch/handlers, install wiring; total 1980 passing / 135 files).
- Live E2E on a throwaway `--home` with real payloads:
  - `search_files` broad scan → **block** with memory-code redirect; targeted symbol → allow
  - `read_file` whole-file → block (unchanged)
  - `on_session_start` → session row created (id 55) + mapping persisted
  - `pre_llm_call` → `{"context": "## Memory Context (auto-loaded)…"}` with real project summary + indexed-repo stats (`PiMemoryExtension`, 469 files / 12398 symbols)
  - `session-end` args use the mapped id: `session-end --id 55`
- Full suite `npm test`: **1980/1980**, `npm run lint` 0 errors, `oxfmt` clean.

## Notes

- Existing installs need a re-run of `lapis hermes install` to pick up the 2 new hook events.
- `pre_llm_call` fires every turn → bounded by timeout + cap; follow-up could gate on `extra.is_first_turn` or preflight-worthiness.
- Gateway sessions may have coarse `cwd` (hook-spawning process cwd, not the user's project dir) — CLI sessions are correct.
