### PR TITLE
fix(packaging): ship scripts/, hermes/, prompts/ so the npm package boots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Test suite
         run: npm test
 
+      - name: Pack smoke test (tarball must ship required files)
+        run: |
+          npm pack --dry-run --json > /tmp/pack.json
+          node -e "const p=require('/tmp/pack.json')[0].files.map(f=>f.path); for (const need of ['scripts/cleanup-sessions.js','hermes/SKILL.md','prompts/memory-layer-protocols.md']) { if (!p.includes(need)) { console.error('MISSING FROM TARBALL: '+need); process.exit(1); } } console.log('pack smoke test OK')"
+
       - name: Smoke CLI tests
         run: node test/smoke-cli.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **npm packaging: ship `scripts/`, `hermes/`, `prompts/` so the published package boots**
+  - `package.json` `files` whitelist omitted `scripts/`, so the published package crashed on every subcommand (`MODULE_NOT_FOUND` for `scripts/cleanup-sessions`, eager-loaded by the CLI gateway). `scripts/`, `hermes/`, and `prompts/` are now shipped — the bundled Hermes skill and Pi prompts install correctly from npm installs.
+  - `test/config.test.js` tilde-expansion tests are now hermetic (`vi.resetModules` + `vi.stubEnv('LAPIS_HOME')`), passing whether or not `LAPIS_HOME` is set in the ambient environment.
+  - `docs/HERMES.md`: corrected stale "three hook entries" wording to five.
+
 - **Memory layer: self-heal stale cached project key from path-resolved repo**
   - `before_agent_start` now uses anchored, deepest-path `resolveIndexedRepo` (matching `detectProject`) instead of first-match `startsWith` prefix resolution.
   - When the path-resolved repo name differs from the session-start cached key, `state.currentProject` self-heals so memory saves and the context banner use the correct project bucket.

--- a/docs/HERMES.md
+++ b/docs/HERMES.md
@@ -19,7 +19,7 @@ From any directory:
 npx -y @genegulanesjr/lapis hermes install
 ```
 
-This writes the MCP server entry, the three hook entries, first-use consent, and the skill. The MCP server entry pins `LAPIS_HOME` to your home directory so the server and CLI always share one SQLite database.
+This writes the MCP server entry, the five hook entries, first-use consent, and the skill. The MCP server entry pins `LAPIS_HOME` to your home directory so the server and CLI always share one SQLite database.
 
 Then **restart Hermes** (or run `/reload-mcp` in a session) so the MCP tools load. Hooks register at process start; `hooks_auto_accept: true` is set so no consent prompts appear on non-TTY starts.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genegulanesjr/lapis",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "💎 LaPis — Persistent memory for the Pi coding agent. One SQLite DB, zero cloud, zero API keys.",
   "keywords": [
     "pi-package"
@@ -48,7 +48,10 @@
     "extensions/",
     "skills/",
     "grammars/",
-    "docs/"
+    "docs/",
+    "scripts/",
+    "hermes/",
+    "prompts/"
   ],
   "type": "commonjs",
   "main": "./memory-store.js",

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 const {
   stripJsoncComments,
   expandTilde,
@@ -64,14 +63,30 @@ describe('config.js', () => {
   });
 
   describe('expandTilde', () => {
-    it('expands ~/ to HOME', () => {
-      const result = expandTilde('~/foo/bar');
-      expect(result).toBe(path.join(os.homedir(), 'foo', 'bar'));
+    it('expands ~/ to HOME', async () => {
+      vi.resetModules();
+      vi.stubEnv('LAPIS_HOME', '/tmp/lapis-tilde-test');
+      try {
+        const { expandTilde: expand } = await import('../config');
+        const result = expand('~/foo/bar');
+        expect(result).toBe(path.join('/tmp/lapis-tilde-test', 'foo', 'bar'));
+      } finally {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+      }
     });
 
-    it('expands bare ~ to HOME', () => {
-      const result = expandTilde('~');
-      expect(result).toBe(os.homedir());
+    it('expands bare ~ to HOME', async () => {
+      vi.resetModules();
+      vi.stubEnv('LAPIS_HOME', '/tmp/lapis-tilde-test');
+      try {
+        const { expandTilde: expand } = await import('../config');
+        const result = expand('~');
+        expect(result).toBe('/tmp/lapis-tilde-test');
+      } finally {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+      }
     });
 
     it('leaves absolute paths unchanged', () => {
@@ -153,11 +168,23 @@ describe('config.js', () => {
       expect(cfg.db_path).toBe('/tmp/cleaned.db');
     });
 
-    it('expands tilde in db_path and tier_config_path', () => {
-      fs.readFileSync = () => '{"db_path": "~/my/db.db", "tier_config_path": "~/my/tier.jsonc"}';
-      const cfg = loadConfig();
-      expect(cfg.db_path).toBe(path.join(os.homedir(), 'my', 'db.db'));
-      expect(cfg.tier_config_path).toBe(path.join(os.homedir(), 'my', 'tier.jsonc'));
+    it('expands tilde in db_path and tier_config_path', async () => {
+      // config.js captures HOME from process.env at import time, so these
+      // Tests must reload the module under a controlled LAPIS_HOME (hermetic
+      // Against an ambient LAPIS_HOME export in the shell running the suite).
+      vi.resetModules();
+      vi.stubEnv('LAPIS_HOME', '/tmp/lapis-tilde-test');
+      try {
+        const { loadConfig: load, resetConfigCache: reset } = await import('../config');
+        reset();
+        fs.readFileSync = () => '{"db_path": "~/my/db.db", "tier_config_path": "~/my/tier.jsonc"}';
+        const cfg = load();
+        expect(cfg.db_path).toBe(path.join('/tmp/lapis-tilde-test', 'my', 'db.db'));
+        expect(cfg.tier_config_path).toBe(path.join('/tmp/lapis-tilde-test', 'my', 'tier.jsonc'));
+      } finally {
+        vi.unstubAllEnvs();
+        vi.resetModules();
+      }
     });
 
     it('returns defaults on invalid JSON (with console.error)', () => {


### PR DESCRIPTION
Fixes from code review:
- package.json files whitelist omitted scripts/, hermes/, prompts/ — published 1.1.3 crashed on every subcommand (MODULE_NOT_FOUND for scripts/cleanup-sessions). All three are now shipped.
- lapis hermes install now installs the bundled skill from npm installs (hermes/SKILL.md) instead of silently skipping it; hermes doctor skill check passes.
- docs/HERMES.md: corrected stale "three hook entries" to five.
- test/config.test.js tilde tests are hermetic (pass with or without LAPIS_HOME set).
- CI: pack smoke test asserts the tarball ships scripts/cleanup-sessions.js, hermes/SKILL.md, prompts/memory-layer-protocols.md.
- version bumped 1.1.3 → 1.1.4 for republish.

Verified: full vitest suite green, lint green, tarball boot test (cleanup-sessions, hermes install/doctor, search) pass from the extracted package.