### PR TITLE
fix(code-index): get-code-source accepts repo-relative paths

### DIFF
--- a/src/cli/commands/code-index.js
+++ b/src/cli/commands/code-index.js
@@ -9,7 +9,7 @@ const USAGE = {
   'health-code-repo': '--repo <repo-name>',
   'search-code': '--query <text> [--repo NAME] [--kind TYPE] [--max-results N]',
   'ranked-code-context': '--query <text> [--repo NAME] [--kind TYPE] [--token-budget N] [--max-results N]',
-  'get-code-source': '--repo NAME --file PATH --name SYMBOL',
+  'get-code-source': '--repo NAME --file PATH --name SYMBOL  (PATH may be absolute or repo-relative, e.g. lib/helper.js)',
   'list-code-repos': '',
   'remove-code-repo': '--repo <repo-name>',
 };

--- a/src/code-index/source-retrieval.js
+++ b/src/code-index/source-retrieval.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { ensureDb, sqlJson, sqlRaw } = require('../../db');
 const { estimateTokens } = require('../../utils');
 const { createCodeIndexRepository } = require('./repos');
@@ -10,9 +11,24 @@ function sourceSliceFromRow(row) {
 function getCodeSource(repoName, filePath, symbolName, repository = null) {
   ensureDb();
   const repo = repository || createCodeIndexRepository(require('../../db'));
-  const row = repo.findSymbolSource({ repoName, filePath, symbolName });
+
+  // The symbol index stores absolute file paths; resolve repo-relative inputs
+  // (e.g. lib/helper.js, ./x, ../y) against the indexed repo root.
+  let resolvedPath = filePath;
+  if (!path.isAbsolute(filePath)) {
+    const repoRow = repo.findRepoByName(repoName);
+    if (!repoRow || !repoRow.path) {
+      return { success: false, error: `Repo "${repoName}" not found; cannot resolve relative path "${filePath}"` };
+    }
+    resolvedPath = path.resolve(repoRow.path, filePath);
+  }
+
+  const row = repo.findSymbolSource({ repoName, filePath: resolvedPath, symbolName });
   if (!row) {
-    return { success: false, error: 'Symbol not found' };
+    return {
+      success: false,
+      error: `Symbol "${symbolName}" not found in ${resolvedPath} (repo-relative paths like lib/helper.js are resolved against the repo root)`,
+    };
   }
 
   return {

--- a/test/index-repo.test.js
+++ b/test/index-repo.test.js
@@ -82,6 +82,38 @@ describe('index-repo (WASM)', () => {
       expect(result.source).toContain('main');
     });
 
+    it('accepts repo-relative --file paths and reports resolved path on miss', () => {
+      const absFile = '/tmp/test-wasm-integ-repo/app.js';
+
+      const relOut = execSync(
+        `node "${STORE}" get-code-source --repo test-wasm-integ --file app.js --name main`,
+        { encoding: 'utf8', timeout: 10000 },
+      );
+      const relResult = JSON.parse(relOut);
+      expect(relResult.success).toBe(true);
+      expect(relResult.symbol).toBe('main');
+
+      const absOut = execSync(
+        `node "${STORE}" get-code-source --repo test-wasm-integ --file ${absFile} --name main`,
+        { encoding: 'utf8', timeout: 10000 },
+      );
+      const absResult = JSON.parse(absOut);
+      expect(absResult.success).toBe(true);
+      expect(absResult.symbol).toBe('main');
+
+      let missErr = '';
+      try {
+        execSync(
+          `node "${STORE}" get-code-source --repo test-wasm-integ --file app.js --name doesNotExist`,
+          { encoding: 'utf8', timeout: 10000 },
+        );
+      } catch (err) {
+        missErr = JSON.parse(err.stderr || '').error || '';
+      }
+      expect(missErr).toContain(absFile);
+      expect(missErr).toMatch(/resolved against the repo root/);
+    });
+
     it('should not mention Python in error messages', () => {
       let stderr = '';
       try {


### PR DESCRIPTION
get-code-source failed with a misleading "Symbol not found" when given a repo-relative --file path (the symbol index stores absolute paths and the lookup is exact-match). Now resolves relative paths against the indexed repo root before lookup, keeps absolute-path behavior identical, and reports the queried resolved path in the not-found error.

Verified: temp-repo repro before/after, full vitest suite green, lint green.