### PR TITLE
chore: wire grammar install checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,16 @@ test/                    # Vitest unit/integration tests and CLI smoke tests
 crosshash/               # Rust code-intelligence workspace
 ```
 
+### Tree-sitter grammar ownership
+
+The `grammars/` directory is populated by three different paths, and the split
+matters when adding a language or debugging a missing `.wasm` (see
+[`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) for the troubleshooting entry):
+
+- **HTML** — `postinstall.js` copies `tree-sitter-html.wasm` from the installed `tree-sitter-html` npm package into `grammars/` and verifies the destination (testable helper in `scripts/postinstall-helpers.js`).
+- **JavaScript, TypeScript, SQL** — `scripts/fetch-grammars.sh` fetches the dev grammar packages and builds/copies their WASM files.
+- **Go, Python, Rust, and other bundled grammars** — the WASM artifacts are committed under `grammars/` and shipped in the package.
+
 ## Dependency boundaries
 
 LaPis is a modular monolith: one package, many independently testable feature modules. The target dependency flow is:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,6 +2,16 @@
 
 This guide covers configuration for the LaPis memory layer extension.
 
+## Tree-sitter grammar ownership
+
+LaPis uses three grammar ownership paths:
+
+- **HTML**: `postinstall.js` copies `tree-sitter-html.wasm` from the installed `tree-sitter-html` package into `grammars/` and verifies the destination.
+- **JavaScript, TypeScript, and SQL**: `scripts/fetch-grammars.sh` fetches the development grammar packages and builds/copies their WASM files.
+- **Go, Python, Rust, and other bundled grammars**: the WASM artifacts are committed under `grammars/` and shipped in the package.
+
+If HTML parsing is unavailable after installation, rerun `npm install` and inspect the postinstall warning. For development grammar refreshes, run `bash scripts/fetch-grammars.sh`.
+
 ## Setup
 
 LaPis does not install npm dependencies during Pi startup or database access. Install dependencies explicitly when running from a local checkout:

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "tree-sitter-javascript": "^0.25.0",
         "tree-sitter-sql": "^0.1.0",
         "tree-sitter-typescript": "^0.23.2",
-        "typebox": "^1.1.37",
         "typescript": "^6.0.3",
         "vitest": "^4.1.6"
       },
@@ -7450,13 +7449,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/typebox": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
-      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/typed-inject": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "tree-sitter-javascript": "^0.25.0",
     "tree-sitter-sql": "^0.1.0",
     "tree-sitter-typescript": "^0.23.2",
-    "typebox": "^1.1.37",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"
   },

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,22 +1,25 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
+const { copyHtmlGrammar } = require('./scripts/postinstall-helpers');
 
 const root = __dirname;
 const nm = (...p) => path.join(root, 'node_modules', ...p);
 
 // Copy the bundled tree-sitter-html.wasm grammar into ./grammars.
-(function copyHtmlGrammar() {
-  const grammarDir = path.join(root, 'grammars');
-  const htmlSrc = nm('tree-sitter-html', 'tree-sitter-html.wasm');
-  if (fs.existsSync(htmlSrc) && fs.existsSync(grammarDir)) {
-    const dest = path.join(grammarDir, 'tree-sitter-html.wasm');
-    if (!fs.existsSync(dest)) {
-      try {
-        fs.copyFileSync(htmlSrc, dest);
-      } catch {}
-    }
-  }
+//
+// The copy is idempotent (an existing, non-trivial destination is preserved)
+// but never silent: a missing source, a missing grammars/ directory, a failed
+// copy, or a missing/truncated destination after copy each emit a clear
+// warning to stderr and are reflected in the returned result. See
+// scripts/postinstall-helpers.js for the testable implementation.
+//
+// Grammar ownership split (see docs/MODULE_MAP.md):
+//   - HTML   -> copied here from the tree-sitter-html npm package at install.
+//   - JS/TS/SQL -> fetched/renamed by scripts/fetch-grammars.sh (dev tooling).
+//   - Go/Python/Rust (and other) WASM grammars are committed to ./grammars.
+(function copyHtmlGrammarStep() {
+  copyHtmlGrammar({ root, warn: (m) => console.error(m) });
 })();
 
 // Patch transitive vulnerabilities that `overrides` cannot reach.

--- a/scripts/postinstall-helpers.js
+++ b/scripts/postinstall-helpers.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Testable helpers extracted from postinstall.js so the HTML grammar copy and
+// its verification logic can be unit-tested without spawning a child process.
+//
+// Design goals:
+//  - Pure w.r.t. the filesystem: every path is passed in, no magic globals.
+//  - Idempotent: never overwrites an existing, non-empty destination unless
+//    `force` is set. Re-running `npm install` is a no-op once the grammar is
+//    in place.
+//  - Never silent: missing source, missing destination directory, a failed
+//    copy, or a missing/empty file after copy all emit a clear warning to a
+//    caller-supplied `warn` sink (stderr in production) and are reported in
+//    the returned result object.
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_HTML_SRC_REL = path.join('tree-sitter-html', 'tree-sitter-html.wasm');
+const DEFAULT_HTML_DEST_NAME = 'tree-sitter-html.wasm';
+
+// Minimum size in bytes below which a .wasm file is treated as truncated/corrupt.
+// The real HTML grammar is ~18KB; anything tiny is a failed or partial copy.
+const MIN_GRAMMAR_BYTES = 1024;
+
+/**
+ * Copy a single bundled WASM grammar from a source path to a destination
+ * directory, verifying the destination afterwards. Never overwrites an existing
+ * non-empty destination unless `opts.force` is true.
+ *
+ * @param {object} opts
+ * @param {string} opts.grammarDir        Destination directory (must already exist; warned if not).
+ * @param {string} opts.src               Absolute path to the source .wasm file.
+ * @param {string} opts.destName          Filename to write under grammarDir.
+ * @param {(msg: string) => void} [opts.warn]  Warning sink (defaults to no-op).
+ * @param {boolean} [opts.force]          Overwrite an existing non-empty destination.
+ * @param {object} [opts.fs]              Inject fs for testing.
+ * @returns {{copied: boolean, skipped: boolean, ok: boolean, reason?: string}}
+ */
+function copyGrammar(opts) {
+  const fsys = opts.fs || fs;
+  const warn = typeof opts.warn === 'function' ? opts.warn : () => {};
+  const grammarDir = opts.grammarDir;
+  const src = opts.src;
+  const destName = opts.destName;
+  const dest = path.join(grammarDir, destName);
+
+  // 1. Destination directory must exist. If it does not, there is nowhere to
+  //    write — warn loudly rather than failing silently.
+  if (!fsys.existsSync(grammarDir)) {
+    warn(`postinstall: destination directory missing, skipping grammar copy: ${grammarDir}`);
+    return { copied: false, skipped: true, ok: false, reason: 'dest_dir_missing' };
+  }
+
+  // 2. Source must exist and be non-trivially sized. A missing/empty source
+  //    usually means the grammar npm package layout changed upstream.
+  if (!fsys.existsSync(src)) {
+    warn(`postinstall: grammar source not found, skipping copy: ${src}`);
+    return { copied: false, skipped: true, ok: false, reason: 'src_missing' };
+  }
+  let srcSize = 0;
+  try {
+    srcSize = fsys.statSync(src).size;
+  } catch (err) {
+    warn(`postinstall: could not stat grammar source ${src}: ${err && err.message}`);
+    return { copied: false, skipped: true, ok: false, reason: 'src_stat_failed' };
+  }
+  if (srcSize < MIN_GRAMMAR_BYTES) {
+    warn(`postinstall: grammar source looks empty/truncated (${srcSize} bytes), skipping copy: ${src}`);
+    return { copied: false, skipped: true, ok: false, reason: 'src_empty' };
+  }
+
+  // 3. Idempotency: do not clobber an existing non-empty destination. Only
+  //    overwrite when explicitly forced (e.g. a stale/failed copy we want to
+  //    repair). An existing-but-too-small destination is treated as stale and
+  //    repaired only when forced; otherwise warned.
+  if (fsys.existsSync(dest)) {
+    let destSize = 0;
+    try {
+      destSize = fsys.statSync(dest).size;
+    } catch (err) {
+      warn(`postinstall: could not stat existing grammar ${dest}: ${err && err.message}`);
+      destSize = -1;
+    }
+    if (destSize >= MIN_GRAMMAR_BYTES && !opts.force) {
+      return { copied: false, skipped: true, ok: true, reason: 'already_present' };
+    }
+    if (destSize < MIN_GRAMMAR_BYTES && !opts.force) {
+      warn(
+        `postinstall: existing grammar looks stale/truncated (${destSize} bytes), not overwriting without --force: ${dest}`,
+      );
+      return { copied: false, skipped: false, ok: false, reason: 'dest_stale' };
+    }
+    // fall through: force === true -> overwrite
+  }
+
+  // 4. Perform the copy.
+  try {
+    fsys.copyFileSync(src, dest);
+  } catch (err) {
+    warn(`postinstall: failed to copy grammar ${src} -> ${dest}: ${err && err.message}`);
+    return { copied: false, skipped: false, ok: false, reason: 'copy_failed' };
+  }
+
+  // 5. Verify the destination actually exists and is non-trivially sized.
+  //    This catches failed copies that did not throw (rare, but possible on
+  //    some FS / permission edge cases) and partial writes.
+  if (!fsys.existsSync(dest)) {
+    warn(`postinstall: grammar copy reported success but destination is missing: ${dest}`);
+    return { copied: true, skipped: false, ok: false, reason: 'dest_missing_after_copy' };
+  }
+  let destSize = 0;
+  try {
+    destSize = fsys.statSync(dest).size;
+  } catch (err) {
+    warn(`postinstall: grammar copied but could not stat destination ${dest}: ${err && err.message}`);
+    return { copied: true, skipped: false, ok: false, reason: 'dest_stat_failed' };
+  }
+  if (destSize < MIN_GRAMMAR_BYTES) {
+    warn(`postinstall: grammar copy produced a truncated file (${destSize} bytes): ${dest}`);
+    return { copied: true, skipped: false, ok: false, reason: 'dest_truncated' };
+  }
+
+  return { copied: true, skipped: false, ok: true, reason: 'copied' };
+}
+
+/**
+ * Convenience wrapper for the HTML grammar copy used by postinstall.js.
+ *
+ * @param {object} opts
+ * @param {string} opts.root            Repo root (where node_modules/ and grammars/ live).
+ * @param {(msg: string) => void} [opts.warn]
+ * @param {object} [opts.fs]
+ * @param {boolean} [opts.force]
+ * @returns {{copied: boolean, skipped: boolean, ok: boolean, reason?: string}}
+ */
+function copyHtmlGrammar(opts) {
+  const fsys = opts.fs || fs;
+  const grammarDir = path.join(opts.root, 'grammars');
+  const src = path.join(opts.root, 'node_modules', DEFAULT_HTML_SRC_REL);
+  return copyGrammar({
+    grammarDir,
+    src,
+    destName: DEFAULT_HTML_DEST_NAME,
+    warn: opts.warn,
+    force: opts.force,
+    fs: fsys,
+  });
+}
+
+module.exports = {
+  copyGrammar,
+  copyHtmlGrammar,
+  DEFAULT_HTML_SRC_REL,
+  DEFAULT_HTML_DEST_NAME,
+  MIN_GRAMMAR_BYTES,
+};

--- a/test/postinstall-helpers.test.js
+++ b/test/postinstall-helpers.test.js
@@ -1,0 +1,185 @@
+// Tests for the postinstall grammar copy + verification helper.
+//
+// The repo runs vitest with `globals: true` (see vitest.config.mjs), so
+// describe/it/expect are available without importing — matching every other
+// test file under test/. Do not `require('vitest')`; that throws under CJS.
+const { copyGrammar, copyHtmlGrammar, MIN_GRAMMAR_BYTES } = require('../scripts/postinstall-helpers');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Payload well above MIN_GRAMMAR_BYTES so size guards fire only on purpose.
+const VALID_WASM = Buffer.alloc(MIN_GRAMMAR_BYTES + 4096, 0x00);
+
+function makeFixture({ srcBytes = VALID_WASM, destBytes = null } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-postinstall-'));
+  const grammarDir = path.join(root, 'grammars');
+  fs.mkdirSync(grammarDir, { recursive: true });
+  const src = path.join(root, 'source', 'tree-sitter-html.wasm');
+  fs.mkdirSync(path.dirname(src), { recursive: true });
+  fs.writeFileSync(src, srcBytes);
+  const dest = path.join(grammarDir, 'tree-sitter-html.wasm');
+  if (destBytes !== null) fs.writeFileSync(dest, destBytes);
+  return { root, grammarDir, src, destName: 'tree-sitter-html.wasm', dest };
+}
+
+describe('postinstall grammar copy + verification', () => {
+  let warns;
+
+  beforeEach(() => {
+    warns = [];
+  });
+
+  it('copies the grammar and verifies the destination afterwards', () => {
+    const f = makeFixture();
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m) });
+    expect(res.copied).toBe(true);
+    expect(res.skipped).toBe(false);
+    expect(res.ok).toBe(true);
+    expect(res.reason).toBe('copied');
+    expect(fs.existsSync(f.dest)).toBe(true);
+    expect(fs.statSync(f.dest).size).toBe(VALID_WASM.length);
+    expect(warns).toHaveLength(0);
+  });
+
+  it('is idempotent: preserves an existing non-empty destination (no overwrite)', () => {
+    const existing = Buffer.alloc(MIN_GRAMMAR_BYTES + 123, 0xab);
+    const f = makeFixture({ destBytes: existing });
+    const mtimeBefore = fs.statSync(f.dest).mtimeMs;
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m) });
+    expect(res.copied).toBe(false);
+    expect(res.skipped).toBe(true);
+    expect(res.ok).toBe(true);
+    expect(res.reason).toBe('already_present');
+    // Untouched: same bytes, same mtime.
+    expect(fs.readFileSync(f.dest)).toEqual(existing);
+    expect(fs.statSync(f.dest).mtimeMs).toBe(mtimeBefore);
+    expect(warns).toHaveLength(0);
+  });
+
+  it('warns and skips when the source grammar is missing', () => {
+    const f = makeFixture();
+    fs.rmSync(f.src);
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m) });
+    expect(res.copied).toBe(false);
+    expect(res.skipped).toBe(true);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('src_missing');
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatch(/source not found/i);
+  });
+
+  it('warns and skips when the destination directory is missing', () => {
+    const f = makeFixture();
+    fs.rmSync(f.grammarDir, { recursive: true, force: true });
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m) });
+    expect(res.copied).toBe(false);
+    expect(res.skipped).toBe(true);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('dest_dir_missing');
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatch(/destination directory missing/i);
+  });
+
+  it('warns on a truncated/empty source and does not copy', () => {
+    const f = makeFixture({ srcBytes: Buffer.alloc(16, 0x00) });
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m) });
+    expect(res.copied).toBe(false);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('src_empty');
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatch(/empty\/truncated/i);
+  });
+
+  it('warns about a stale/truncated destination and does NOT overwrite without force', () => {
+    const stale = Buffer.alloc(8, 0x00);
+    const f = makeFixture({ destBytes: stale });
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m) });
+    expect(res.copied).toBe(false);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('dest_stale');
+    // The stale file is left in place (no silent repair without force).
+    expect(fs.readFileSync(f.dest)).toEqual(stale);
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatch(/stale\/truncated/i);
+  });
+
+  it('repairs a stale destination when force=true', () => {
+    const stale = Buffer.alloc(8, 0x00);
+    const f = makeFixture({ destBytes: stale });
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m), force: true });
+    expect(res.copied).toBe(true);
+    expect(res.ok).toBe(true);
+    expect(fs.readFileSync(f.dest)).toEqual(VALID_WASM);
+    expect(warns).toHaveLength(0);
+  });
+
+  it('detects a copy that silently failed to produce the destination', () => {
+    const f = makeFixture();
+    // Fake fs: source + grammarDir exist; copyFileSync is a no-op; the
+    // destination never appears, so post-copy verification must catch it.
+    const fakeFs = {
+      existsSync: (p) => p === f.src || p === f.grammarDir,
+      statSync: () => ({ size: VALID_WASM.length }),
+      copyFileSync: () => {
+        /* swallow: simulate silent failure */
+      },
+    };
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m), fs: fakeFs, force: true });
+    expect(res.copied).toBe(true);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('dest_missing_after_copy');
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatch(/reported success but destination is missing/i);
+  });
+
+  it('detects a copy that produced a truncated destination', () => {
+    const f = makeFixture();
+    // Seed a real stale destination so the helper takes the copy path; then
+    // make post-copy stat report a truncated size to exercise verification.
+    fs.writeFileSync(f.dest, Buffer.alloc(8, 0x00));
+    let copied = false;
+    const fakeFs = {
+      existsSync: (p) => fs.existsSync(p),
+      statSync: (p) => {
+        // Source is valid; before copy the dest is stale; after copy it reads
+        // back as truncated (4 bytes).
+        if (p === f.src) return { size: VALID_WASM.length };
+        return { size: copied ? 4 : 8 };
+      },
+      copyFileSync: () => {
+        copied = true;
+      },
+    };
+    const res = copyGrammar({ ...f, warn: (m) => warns.push(m), fs: fakeFs, force: true });
+    expect(res.copied).toBe(true);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('dest_truncated');
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatch(/truncated file/i);
+  });
+
+  it('copyHtmlGrammar wires root -> node_modules/tree-sitter-html -> grammars/', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-pi-html-'));
+    fs.mkdirSync(path.join(root, 'grammars'), { recursive: true });
+    const src = path.join(root, 'node_modules', 'tree-sitter-html', 'tree-sitter-html.wasm');
+    fs.mkdirSync(path.dirname(src), { recursive: true });
+    fs.writeFileSync(src, VALID_WASM);
+    const dest = path.join(root, 'grammars', 'tree-sitter-html.wasm');
+
+    const res = copyHtmlGrammar({ root, warn: (m) => warns.push(m) });
+    expect(res.ok).toBe(true);
+    expect(res.copied).toBe(true);
+    expect(fs.existsSync(dest)).toBe(true);
+    expect(fs.statSync(dest).size).toBe(VALID_WASM.length);
+  });
+
+  it('copyHtmlGrammar warns when node_modules/tree-sitter-html is absent', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-pi-html-'));
+    fs.mkdirSync(path.join(root, 'grammars'), { recursive: true });
+    const res = copyHtmlGrammar({ root, warn: (m) => warns.push(m) });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('src_missing');
+    expect(warns).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

This PR addresses the dependency-wiring review after #263.

- Removes the unused direct `typebox` devDependency and updates the lockfile.
- Makes HTML grammar installation observable and testable instead of silently ignoring failures.
- Preserves idempotency: valid existing grammar files are not overwritten.
- Warns for missing source/destination directories, truncated inputs, copy failures, and post-copy verification failures.
- Documents grammar ownership: HTML via `postinstall.js`; JavaScript/TypeScript/SQL via `scripts/fetch-grammars.sh`; other bundled grammars committed under `grammars/`.
- Leaves the `protobufjs` security workaround unchanged for a separate follow-up.

## Validation

- Targeted postinstall tests: 11 passed.
- Formatting check: passed.
- `git diff --check`: passed.

The branch is based on the merged `main` from #263.