### PR TITLE
fix(guardrails): honor tool_guardrails.enabled config toggle

### DIFF
--- a/config.js
+++ b/config.js
@@ -33,6 +33,9 @@ const DEFAULTS = {
     min_chars: 2000, // Don't compress output shorter than this
     min_savings_percent: 30, // Don't replace if savings < this %
   },
+  tool_guardrails: {
+    enabled: true, // Master toggle — set false to disable raw grep/find + unread-file guardrails
+  },
 };
 
 function deepMerge(target, source) {

--- a/extensions/memory-layer/hooks/tool-guardrails.ts
+++ b/extensions/memory-layer/hooks/tool-guardrails.ts
@@ -11,6 +11,7 @@ import {
 } from './guardrail-utils';
 import { getKnownRepos, invalidateRepoCache } from '../host/project-detector';
 import { memStreaming } from '../host/memory-client';
+import { getConfig } from '../../config';
 import path from 'node:path';
 
 interface GuardrailsDeps {
@@ -58,6 +59,14 @@ function ensureIndexed(deps: GuardrailsDeps, resolvedCwd: string, projectName: s
 
 export function registerToolGuardrails(pi: ExtensionAPI, deps: GuardrailsDeps) {
   pi.on('tool_call', async (event, _ctx) => {
+    // Honor the `tool_guardrails.enabled: false` config toggle
+    // (see ~/.pi/memory/config.jsonc). When disabled, the raw grep/find
+    // and unread-file guardrails are skipped entirely so raw repository
+    // search and direct file reads work without the memory-code redirect.
+    if (getConfig().tool_guardrails?.enabled === false) {
+      return;
+    }
+
     const toolName = event.toolName;
     const input = event.input as Record<string, unknown>;
 

--- a/extensions/memory-layer/hooks/tool-guardrails.ts
+++ b/extensions/memory-layer/hooks/tool-guardrails.ts
@@ -11,7 +11,6 @@ import {
 } from './guardrail-utils';
 import { getKnownRepos, invalidateRepoCache } from '../host/project-detector';
 import { memStreaming } from '../host/memory-client';
-import { getConfig } from '../../config';
 import path from 'node:path';
 
 interface GuardrailsDeps {
@@ -20,6 +19,7 @@ interface GuardrailsDeps {
   isCodeFile: typeof isCodeFile;
   memStreaming: typeof memStreaming;
   invalidateRepoCache: typeof invalidateRepoCache;
+  getConfig: () => { tool_guardrails?: { enabled?: boolean } };
 }
 
 interface IndexResult {
@@ -63,7 +63,8 @@ export function registerToolGuardrails(pi: ExtensionAPI, deps: GuardrailsDeps) {
     // (see ~/.pi/memory/config.jsonc). When disabled, the raw grep/find
     // and unread-file guardrails are skipped entirely so raw repository
     // search and direct file reads work without the memory-code redirect.
-    if (getConfig().tool_guardrails?.enabled === false) {
+    // Tests and other callers that don't inject getConfig default to enabled.
+    if (deps.getConfig?.().tool_guardrails?.enabled === false) {
       return;
     }
 

--- a/extensions/memory-layer/index.ts
+++ b/extensions/memory-layer/index.ts
@@ -62,6 +62,7 @@ export default function memoryLayer(pi: ExtensionAPI) {
     formatCodeResult,
     formatDocResult,
     getSettings: () => ({ contextLimit: getConfig().context_limit }),
+    getConfig,
   };
 
   safeRegister(pi, deps, 'session-lifecycle hooks', registerSessionStart);

--- a/test/tool-guardrails.test.js
+++ b/test/tool-guardrails.test.js
@@ -102,6 +102,14 @@ describe('tool-guardrails: isTargetedSymbolLookup', () => {
   });
 });
 
+describe('tool-guardrails: config toggle', () => {
+  test('tool_guardrails.enabled default is true', () => {
+    const { DEFAULTS } = require('../config');
+    expect(DEFAULTS.tool_guardrails).toBeDefined();
+    expect(DEFAULTS.tool_guardrails.enabled).toBe(true);
+  });
+});
+
 describe('tool-guardrails: isPipedOutputFilter', () => {
   test('allows grep when filtering command output', () => {
     expect(isPipedOutputFilter('npx oxlint 2>&1 | grep -iE "(lowercase|Unused)" || true')).toBe(true);


### PR DESCRIPTION
## Problem

The `tool_guardrails.enabled: false` config setting (documented in `~/.pi/memory/config.jsonc`) was a **no-op**: the `registerToolGuardrails` hook in `extensions/memory-layer/hooks/tool-guardrails.ts` never read it. The "Code search detected in indexed repo — Use `memory-code` instead" block kept firing on raw `grep`/`find`/`rg` in `bash`, and the unread-file guardrail kept blocking direct `read` calls, even when the user had explicitly disabled the toggle.

This also created an inconsistency with the existing `code_index.enabled: false` toggle: a user who disabled code indexing but left the guardrails on would get redirected to `memory-code` for a subsystem they had turned off.

## Fix

Wire the config into the hook:

1. **`extensions/memory-layer/hooks/tool-guardrails.ts`** — read `getConfig().tool_guardrails?.enabled` at the top of every `tool_call` event and `return` early when it is `false`. This skips both the bash raw-search guardrail and the read unread-file guardrail.
2. **`config.js`** — add the matching `tool_guardrails: { enabled: true }` default to `DEFAULTS` so the key is always defined and the `?.enabled === false` check is safe.
3. **`test/tool-guardrails.test.js`** — add a test asserting the default is present and `true`.

## Behavior

- Default (`enabled: true`, or key absent): no change — guardrails fire as today.
- `enabled: false` in `~/.pi/memory/config.jsonc`: raw repository search (`grep`/`find`/`rg` in `bash`) and direct `read` of code files work without the `memory-code` redirect.

## Verification

- `npx vitest run test/tool-guardrails.test.js` → 22/22 passing (including the new config-toggle test).
- `npx oxlint` on the changed files → only pre-existing style warnings (`one-var`), no new errors or warnings from the added lines.
- Full suite has 39 pre-existing failures on `main` (unrelated: async indexing, agent-preflight, tool-safety); this PR introduces none.