### PR TITLE
Update README to emphasize LaPis as local AI memory for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ Memory-on achieved perfect accuracy with 92.6% fewer active tokens overall. Memo
 
 The paired benchmark also reports behavior counters. In the latest run, memory-on used 6 total tools, 4 code-oriented tools, 4 memory tools, 12 assistant turns, and 0 failed tools. These counters help distinguish real memory regressions from normal provider cache and latency variance. The negative-control tasks are current-source questions; they should avoid memory facts and route quickly through `memory-code search` plus targeted reads when code verification is needed.
 
+## Website
+
+The LaPis landing page is included in [`website/`](website/). It is a build-free static site configured for Cloudflare Workers Static Assets and Cloudflare Pages; see the [deployment instructions](website/README.md).
+
 ## Documentation
 
 - [`docs/INDEX.md`](docs/INDEX.md) - documentation map and integration transports.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,24 @@
-# LaPis
+# LaPis — Local AI Memory for Coding Agents
 
-Persistent memory for the [Pi coding agent](https://github.com/earendil-works/pi-coding-agent). LaPis gives Pi a local memory layer for decisions, bugfixes, patterns, indexed code, indexed docs, and session context.
+**LaPis is a local, persistent AI memory layer for coding agents.** It gives [Pi Coding Agent](https://github.com/earendil-works/pi-coding-agent), [Claude Code](https://code.claude.com/docs/en/overview), [Hermes Agent](https://hermes-agent.nousresearch.com/), and MCP-compatible clients long-term project memory backed by SQLite.
 
-It runs as one Pi extension plus one local Node.js backend. Storage is SQLite by default at `~/.pi/memory/memory.db`; there are no cloud dependencies and no API keys.
+LaPis remembers architectural decisions, bug fixes, project constraints, patterns, code context, documentation, discoveries, and previous work across sessions.
 
-![LaPis banner — persistent memory for the Pi coding agent](banner.jpeg)
+**Local-first:** project memory lives in one SQLite database by default, with no required hosted memory service and no API keys.
+
+![LaPis banner showing local, persistent AI memory for coding agents](banner.jpeg)
 
 ## Walkthrough
 
-A 30-second tour of the LaPis lifecycle. The GIF below autoplays inline (silent); click it to watch on YouTube with the voiceover.
+A 30-second tour of the LaPis memory lifecycle. The GIF below autoplays inline (silent); click it to watch on YouTube with the voiceover.
 
-[![LaPis 30s walkthrough — gem, memory types, lifecycle, dream, shipping](repo-media/html-video/lapis-slideshow-walkthrough.gif)](https://www.youtube.com/watch?v=dm5XT0b0jM4)
+[![LaPis coding-agent memory walkthrough showing memory types, lifecycle, Dream Cycle, and shipping](repo-media/html-video/lapis-slideshow-walkthrough.gif)](https://www.youtube.com/watch?v=dm5XT0b0jM4)
 
 Source composition lives at [`repo-media/html-video/lapis-slideshow/index.html`](repo-media/html-video/lapis-slideshow/index.html) — edit the prompts and re-render with [`npx hyperframes render`](https://hyperframes.heygen.com/).
 
-## Architecture
+## Quick Start
 
-LaPis is a modular monolith: one installable Pi extension with clear internal ownership between Pi adapters, CLI routing, feature services, and shared platform/storage code. The same backend also serves an MCP stdio server (`lapis mcp`) and a Claude Code hooks bridge (`lapis claude-code install`). The Pi extension calls the backend through in-process `dispatch()` when possible, with child-process fallback for streaming operations such as indexing.
-
-All three architecture views are interactive HTML — clickable nodes, themeable (light/dark), and animated request paths with marching dashes on highlighted edges.
-
-### Architecture overview
-
-The full stack from Pi prompt to SQLite row. Chips animate 3 representative request lifecycles.
-
-👉 **[Open the architecture overview](docs/diagrams/lapis-architecture.html)** — Save memory · Recall at start · Index code/docs
-
-### Module boundaries
-
-The dependency view. Highlights the layered architecture, peer relationships between feature services, and the trust-sync bridge (the only explicit memory↔code link).
-
-👉 **[Open the module boundaries diagram](docs/diagrams/lapis-module-boundaries.html)** — Request flow · Feature peers · Trust bridge
-
-### Memory lifecycle
-
-How data moves through the four primary operations into one local SQLite store. The trust path is highlighted in violet to mark it as the only memory↔code bridge.
-
-👉 **[Open the memory lifecycle diagram](docs/diagrams/lapis-memory-lifecycle.html)** — Write · Read · Index · Trust
-
-For dependency rules and module ownership details, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md).
-
-## Install
+Install LaPis for Pi Coding Agent:
 
 ```bash
 pi install git:github.com/GeneGulanesJr/LaPis
@@ -54,9 +32,22 @@ LaPis does not install npm dependencies at runtime. If you are running from a lo
 npm install
 ```
 
-### Use with Claude Code
+### Requirements
 
-LaPis also integrates with the [Claude Code CLI](https://code.claude.com/docs/en/overview) — same persistent memory, code guardrails, and session lifecycle as the Pi extension, wired through Claude Code's MCP + hooks config.
+- Node.js 20+
+- `better-sqlite3` for local SQLite access
+- No Python dependency
+- No API keys or cloud services
+
+## Supported Integrations
+
+### Pi Coding Agent Persistent Memory
+
+The native Pi extension provides automatic session recall, memory capture, code and documentation retrieval, and lifecycle integration. Install it with the [Quick Start](#quick-start) command above.
+
+### Claude Code Persistent Memory
+
+LaPis integrates with the [Claude Code CLI](https://code.claude.com/docs/en/overview) — the same persistent memory, code guardrails, and session lifecycle as the Pi extension, wired through Claude Code's MCP + hooks config.
 
 ```bash
 npx -y @genegulanesjr/lapis claude-code install
@@ -67,9 +58,9 @@ This writes `.mcp.json` (MCP tools) and `.claude/settings.json` (lifecycle hooks
 
 Full setup, hook mapping, troubleshooting, and install flags: [`docs/CLAUDE_CODE.md`](docs/CLAUDE_CODE.md).
 
-### Use with Hermes Agent
+### Hermes Agent Persistent Memory
 
-LaPis also integrates with [Hermes Agent](https://hermes-agent.nousresearch.com/) — same persistent memory, code guardrails, and trust tracking as the Pi extension, wired through Hermes' MCP client and shell-hook system.
+LaPis integrates with [Hermes Agent](https://hermes-agent.nousresearch.com/) — the same persistent memory, code guardrails, and trust tracking as the Pi extension, wired through Hermes' MCP client and shell-hook system.
 
 ```bash
 npx -y @genegulanesjr/lapis hermes install
@@ -80,9 +71,9 @@ This writes `mcp_servers.lapis` + `hooks:` into `$HERMES_HOME/config.yaml`, firs
 
 Full setup, hook mapping, troubleshooting, and install flags: [`docs/HERMES.md`](docs/HERMES.md).
 
-### MCP server (tools only)
+### MCP Server
 
-For MCP hosts that need LaPis tools without hooks:
+For MCP-compatible clients that need LaPis tools without hooks:
 
 ```bash
 npx -y @genegulanesjr/lapis mcp
@@ -90,13 +81,25 @@ npx -y @genegulanesjr/lapis mcp
 
 See [`docs/MCP.md`](docs/MCP.md).
 
-## What It Does
+## Why LaPis?
 
-- **Remembers across sessions** - decisions, bugfixes, patterns, discoveries, and constraints persist.
-- **Auto-injects context** - new sessions start with relevant memories loaded.
+Coding agents can lose useful project knowledge between sessions or depend on manually maintained context files. LaPis provides structured, persistent memory that can automatically preserve and retrieve useful project knowledge instead. Its local-first, SQLite-backed store can retain:
+
+- architectural decisions and their rationale
+- previous bugs and fixes
+- project conventions and constraints
+- discoveries from earlier sessions
+- relevant code and documentation context
+- stale or superseded information that should no longer be trusted
+
+## AI Memory for Coding Agents
+
+- **Persists memory across sessions** - decisions, bug fixes, patterns, discoveries, constraints, and previous work remain available.
+- **Automatically recalls context** - new sessions start with relevant memories loaded.
+- **Keeps AI memory local-first** - SQLite is the default store; no hosted memory service or API key is required.
 - **Indexes code** - web-tree-sitter parses JS/TS/TSX/Go/Python/Rust/SQL for semantic code lookup and analysis.
 
-  ![LaPis memory-code module](repo-media/modules/illustration-memory-code.jpeg)
+  ![LaPis code indexing and retrieval module for coding-agent memory](repo-media/modules/illustration-memory-code.jpeg)
 
 - **Indexes docs** - Markdown sections, links, glossary terms, and code examples become searchable.
 - **Tracks trust** - memories linked to changed code lose confidence; stable linked code recovers trust.
@@ -104,15 +107,41 @@ See [`docs/MCP.md`](docs/MCP.md).
 - **Manages workspaces** - project isolation is explicit through create/list/archive workflows.
 - **Cleans stale memory** - the Dream Cycle removes superseded, never-useful, and replaced memories based on quality signals.
 
-  ![LaPis dream-cycle module](repo-media/modules/illustration-dream-cycle.jpeg)
+  ![LaPis Dream Cycle for cleaning stale and superseded project memory](repo-media/modules/illustration-dream-cycle.jpeg)
 
 - **Exposes an HTTP API** - optional REST server for programmatic access to missions, milestones, working units, todo/ledger domain, and code analysis.
 
-  ![LaPis dispatch-flow module — in-process dispatch with child-process fallback](repo-media/modules/illustration-dispatch-flow.jpeg)
+  ![LaPis dispatch flow from coding-agent integration to the local memory backend](repo-media/modules/illustration-dispatch-flow.jpeg)
 
 - **Pre-coding intelligence** - preflight checks combine memory, code, and docs into before-coding context.
 - **Compresses CLI output** - token-saving output compression reduces context window usage automatically.
 - **Memory dashboard** - observability command for memory health, statistics, and index quality.
+
+## Architecture
+
+LaPis is a modular monolith: one installable Pi extension with clear internal ownership between Pi adapters, CLI routing, feature services, and shared platform/storage code. The same backend also serves an MCP stdio server (`lapis mcp`) and a Claude Code hooks bridge (`lapis claude-code install`). The Pi extension calls the backend through in-process `dispatch()` when possible, with child-process fallback for streaming operations such as indexing.
+
+All three architecture views are interactive HTML — clickable nodes, themeable (light/dark), and animated request paths with marching dashes on highlighted edges.
+
+### Architecture Overview
+
+The full stack from Pi prompt to SQLite row. Chips animate 3 representative request lifecycles.
+
+👉 **[Open the architecture overview](docs/diagrams/lapis-architecture.html)** — Save memory · Recall at start · Index code/docs
+
+### Module Boundaries
+
+The dependency view. Highlights the layered architecture, peer relationships between feature services, and the trust-sync bridge (the only explicit memory↔code link).
+
+👉 **[Open the module boundaries diagram](docs/diagrams/lapis-module-boundaries.html)** — Request flow · Feature peers · Trust bridge
+
+### Memory Lifecycle
+
+How data moves through the four primary operations into one local SQLite store. The trust path is highlighted in violet to mark it as the only memory↔code bridge.
+
+👉 **[Open the memory lifecycle diagram](docs/diagrams/lapis-memory-lifecycle.html)** — Write · Read · Index · Trust
+
+For dependency rules and module ownership details, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`docs/MODULE_MAP.md`](docs/MODULE_MAP.md).
 
 ## Benchmarks
 
@@ -153,9 +182,11 @@ Latest local run: May 24, 2026, with fresh reindexes for both repos. `call-hiera
 
 See [`bench/README.md`](bench/README.md) for benchmark usage and interpretation notes.
 
-### Paired Memory
+### AI Memory vs No Memory Benchmark
 
-The paired benchmark measures whether memory helps by running the same task twice: once with LaPis disabled and once with LaPis active. It is an internal regression and directional benchmark, not a comprehensive external evaluation. It is designed to catch regressions in LaPis behavior; it should not be read as a claim about typical real-world usage, where prompts, repositories, model behavior, provider cache state, and tool choices vary.
+In LaPis's paired regression benchmark, enabling persistent memory reduced active tokens by 92.6% while maintaining 18/18 fact accuracy.
+
+This is an internal regression and directional benchmark, not a comprehensive external evaluation. It measures the same task twice—once with LaPis disabled and once with LaPis active—and is designed to catch regressions in LaPis behavior. It should not be interpreted as a universal real-world performance claim: prompts, repositories, model behavior, provider cache state, and tool choices vary.
 
 Run it with:
 
@@ -197,13 +228,6 @@ Memory-on achieved perfect accuracy with 92.6% fewer active tokens overall. Memo
 
 The paired benchmark also reports behavior counters. In the latest run, memory-on used 6 total tools, 4 code-oriented tools, 4 memory tools, 12 assistant turns, and 0 failed tools. These counters help distinguish real memory regressions from normal provider cache and latency variance. The negative-control tasks are current-source questions; they should avoid memory facts and route quickly through `memory-code search` plus targeted reads when code verification is needed.
 
-## Requirements
-
-- Node.js 20+
-- `better-sqlite3` for local SQLite access
-- No Python dependency
-- No API keys or cloud services
-
 ## Documentation
 
 - [`docs/INDEX.md`](docs/INDEX.md) - documentation map and integration transports.
@@ -219,10 +243,35 @@ The paired benchmark also reports behavior counters. In the latest run, memory-o
 - [`docs/MCP.md`](docs/MCP.md) - standalone MCP server (tools only).
 - [`docs/DREAM_CYCLE.md`](docs/DREAM_CYCLE.md) - stale-memory cleanup behavior.
 - [`docs/TUTORIAL.md`](docs/TUTORIAL.md) - step-by-step usage guide.
-
 - [`docs/GITHUB_ISSUE_BREAKDOWN.md`](docs/GITHUB_ISSUE_BREAKDOWN.md) - modularization issue breakdown.
 - [`docs/code-indexing.md`](docs/code-indexing.md) - async code indexing.
 - [`docs/SKILL.md`](docs/SKILL.md) - extension skill overview.
+
+## FAQ
+
+### What is LaPis?
+
+LaPis is an open-source, local AI memory system for coding agents. It uses SQLite-backed persistent project memory to preserve useful knowledge across sessions.
+
+### Does LaPis give Claude Code persistent memory?
+
+Yes. LaPis connects its MCP tools to Claude Code and installs lifecycle hooks through `.mcp.json` and `.claude/settings.json`. The hooks provide the session lifecycle and guardrails described in the [Claude Code setup guide](docs/CLAUDE_CODE.md).
+
+### Does LaPis work with Pi Coding Agent?
+
+Yes. LaPis runs as a native Pi extension that automatically wires memory into session startup and uses the local backend for memory, code, and documentation tools.
+
+### Does LaPis work with Hermes Agent?
+
+Yes. LaPis configures its MCP server in the Hermes client, installs shell hooks and a Hermes skill, and provides persistent memory, code guardrails, and trust tracking. See the [Hermes setup guide](docs/HERMES.md).
+
+### Where does LaPis store its memory?
+
+By default, LaPis stores memory locally in the SQLite database at `~/.pi/memory/memory.db`.
+
+### Is LaPis an MCP server?
+
+LaPis exposes an MCP stdio server for compatible clients. It also provides deeper lifecycle integrations for Pi Coding Agent, Claude Code, and Hermes Agent through their respective extension or hook systems.
 
 ## License
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,31 @@
+# LaPis website
+
+The LaPis landing page is a static site with no build step. It can be deployed from the repository root to either Cloudflare Workers Static Assets or Cloudflare Pages.
+
+## Cloudflare Workers
+
+The root [`wrangler.jsonc`](../wrangler.jsonc) points Workers Static Assets at this directory.
+
+```bash
+npx wrangler dev
+npx wrangler deploy
+```
+
+For a Git-connected Worker, leave **Build command** empty and use `npx wrangler deploy` as the deploy command. The existing `wrangler.jsonc` supplies the asset directory.
+
+## Cloudflare Pages
+
+Use these build settings for a Git-connected Pages project:
+
+- **Framework preset:** None
+- **Build command:** leave empty
+- **Build output directory:** `website`
+- **Root directory:** `/`
+
+## Local preview
+
+Any static file server can preview the site:
+
+```bash
+npx serve website
+```

--- a/website/favicon.svg
+++ b/website/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#57e6c0"/>
+  <path d="M20 15h8v27h18v7H20z" fill="#07111f"/>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="LaPis is local, persistent AI memory for Pi Coding Agent, Claude Code, Hermes Agent, and MCP-compatible clients. SQLite-backed, open source, and API-key free."
+    />
+    <meta name="theme-color" content="#07111f" />
+    <meta property="og:title" content="LaPis — Local AI Memory for Coding Agents" />
+    <meta property="og:description" content="Persistent project memory for coding agents, stored locally in SQLite." />
+    <meta property="og:type" content="website" />
+    <title>LaPis — Local AI Memory for Coding Agents</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "LaPis",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Linux, macOS, Windows",
+        "description": "Local, persistent AI memory for coding agents backed by SQLite.",
+        "license": "https://opensource.org/license/isc-license-txt"
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <a class="brand" href="#top" aria-label="LaPis home">
+        <span class="brand-mark" aria-hidden="true">L</span>
+        <span>LaPis</span>
+      </a>
+      <nav aria-label="Primary navigation">
+        <a href="#why">Why LaPis</a>
+        <a href="#integrations">Integrations</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#benchmark">Benchmarks</a>
+      </nav>
+      <a class="header-link" href="https://github.com/GeneGulanesJr/LaPis">View on GitHub</a>
+    </header>
+
+    <main id="main">
+      <section class="hero" id="top">
+        <div class="hero-copy">
+          <p class="eyebrow"><span></span> Open source · Local first · SQLite backed</p>
+          <h1>Project memory that stays with your <em>coding agent.</em></h1>
+          <p class="hero-lede">
+            LaPis is a local, persistent AI memory layer for coding agents. It preserves decisions, bug fixes,
+            constraints, code context, documentation, and discoveries across sessions.
+          </p>
+          <div class="hero-actions">
+            <a class="button button-primary" href="#install">Install LaPis</a>
+            <a class="button button-secondary" href="https://github.com/GeneGulanesJr/LaPis">Read the source</a>
+          </div>
+          <ul class="hero-facts" aria-label="Key facts">
+            <li>No hosted memory service</li>
+            <li>No API keys</li>
+            <li>One local database</li>
+          </ul>
+        </div>
+
+        <div class="terminal" aria-label="Example LaPis installation and memory recall">
+          <div class="terminal-bar">
+            <div class="terminal-dots" aria-hidden="true"><i></i><i></i><i></i></div>
+            <span>terminal</span>
+            <span class="terminal-status">local</span>
+          </div>
+          <div class="terminal-body">
+            <p><span class="prompt">$</span> pi install git:github.com/GeneGulanesJr/LaPis</p>
+            <p class="muted">Installing extension…</p>
+            <p><span class="ok">✓</span> LaPis connected</p>
+            <div class="terminal-rule"></div>
+            <p><span class="prompt">›</span> New session</p>
+            <p class="muted">Recalling relevant project context…</p>
+            <div class="memory-card">
+              <span class="memory-type">DECISION</span>
+              <strong>Keep feature services independent</strong>
+              <small>Rationale and linked code available · trust 0.92</small>
+            </div>
+            <div class="memory-card">
+              <span class="memory-type bug">BUG FIX</span>
+              <strong>Sync trust after branch changes</strong>
+              <small>Historical failure mode preserved · trust 0.88</small>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="integration-strip" aria-label="Supported coding agents and clients">
+        <span>Works with</span>
+        <strong>Pi Coding Agent</strong>
+        <strong>Claude Code</strong>
+        <strong>Hermes Agent</strong>
+        <strong>MCP clients</strong>
+      </section>
+
+      <section class="section split" id="why">
+        <div>
+          <p class="section-label">Why LaPis?</p>
+          <h2>Useful context should not disappear at the end of a session.</h2>
+        </div>
+        <div class="section-copy">
+          <p>
+            Coding agents often start from scratch or rely on manually maintained context files. LaPis automatically
+            preserves structured project knowledge and retrieves it when it is relevant.
+          </p>
+          <p>
+            Memory remains on your machine in SQLite. Trust tracking helps flag knowledge linked to changed code, while
+            the Dream Cycle cleans up superseded or never-useful memories.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" aria-labelledby="memory-heading">
+        <p class="section-label">AI memory for coding agents</p>
+        <h2 id="memory-heading">More than a session transcript.</h2>
+        <div class="feature-grid">
+          <article>
+            <span class="feature-index">01</span>
+            <h3>Persistent memory</h3>
+            <p>Decisions, bug fixes, conventions, constraints, patterns, and discoveries survive across sessions.</p>
+          </article>
+          <article>
+            <span class="feature-index">02</span>
+            <h3>Automatic recall</h3>
+            <p>Relevant memories are loaded when a session starts and can be retrieved through structured tools.</p>
+          </article>
+          <article>
+            <span class="feature-index">03</span>
+            <h3>Code and docs indexing</h3>
+            <p>Semantic code analysis and Markdown indexing make current project context directly searchable.</p>
+          </article>
+          <article>
+            <span class="feature-index">04</span>
+            <h3>Trust-aware context</h3>
+            <p>Memories linked to changed code lose confidence so stale information is less likely to be trusted.</p>
+          </article>
+          <article>
+            <span class="feature-index">05</span>
+            <h3>Memory maintenance</h3>
+            <p>Deduplication and the Dream Cycle control clutter and remove superseded or low-value memories.</p>
+          </article>
+          <article>
+            <span class="feature-index">06</span>
+            <h3>Pre-coding context</h3>
+            <p>Preflight checks combine memory, code, and documentation before implementation begins.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section integrations" id="integrations">
+        <div class="section-heading-row">
+          <div>
+            <p class="section-label">Integrations</p>
+            <h2>One memory store. Multiple agent surfaces.</h2>
+          </div>
+          <p>Native lifecycle integration where available, standard MCP tools everywhere else.</p>
+        </div>
+        <div class="integration-grid">
+          <article>
+            <span class="integration-badge">PI</span>
+            <h3>Pi Coding Agent</h3>
+            <p>Native extension with automatic recall, capture, guardrails, and session lifecycle handling.</p>
+            <a href="https://github.com/GeneGulanesJr/LaPis#quick-start">Install for Pi →</a>
+          </article>
+          <article>
+            <span class="integration-badge">CC</span>
+            <h3>Claude Code</h3>
+            <p>MCP tools plus lifecycle hooks for persistent memory, retrieval guardrails, and trust sync.</p>
+            <a href="https://github.com/GeneGulanesJr/LaPis/blob/main/docs/CLAUDE_CODE.md">Claude Code setup →</a>
+          </article>
+          <article>
+            <span class="integration-badge">HA</span>
+            <h3>Hermes Agent</h3>
+            <p>MCP client configuration, shell hooks, and a skill connect Hermes to the local memory layer.</p>
+            <a href="https://github.com/GeneGulanesJr/LaPis/blob/main/docs/HERMES.md">Hermes setup →</a>
+          </article>
+          <article>
+            <span class="integration-badge">MCP</span>
+            <h3>MCP-compatible clients</h3>
+            <p>A standalone stdio server exposes LaPis tools to hosts that do not need lifecycle hooks.</p>
+            <a href="https://github.com/GeneGulanesJr/LaPis/blob/main/docs/MCP.md">MCP documentation →</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="section architecture" id="architecture">
+        <div class="architecture-copy">
+          <p class="section-label">Architecture</p>
+          <h2>A local backend with clear module boundaries.</h2>
+          <p>
+            LaPis is a modular monolith. Pi adapters, CLI routing, feature services, and shared platform and storage
+            code all connect to one SQLite database.
+          </p>
+          <a class="text-link" href="https://github.com/GeneGulanesJr/LaPis/blob/main/docs/ARCHITECTURE.md"
+            >Explore the architecture →</a
+          >
+        </div>
+        <div class="architecture-map" aria-label="Simplified LaPis architecture diagram">
+          <div class="map-row clients"><span>Pi</span><span>Claude</span><span>Hermes</span><span>MCP</span></div>
+          <div class="map-connector" aria-hidden="true"></div>
+          <div class="map-layer">Adapters &amp; lifecycle hooks</div>
+          <div class="map-connector" aria-hidden="true"></div>
+          <div class="map-row services"><span>Memory</span><span>Code</span><span>Docs</span><span>Trust</span></div>
+          <div class="map-connector" aria-hidden="true"></div>
+          <div class="database">
+            <span class="database-icon" aria-hidden="true"></span><strong>SQLite</strong
+            ><small>~/.pi/memory/memory.db</small>
+          </div>
+        </div>
+      </section>
+
+      <section class="section benchmark" id="benchmark">
+        <div>
+          <p class="section-label">Paired regression benchmark</p>
+          <h2><span>92.6%</span> fewer active tokens</h2>
+          <p>with persistent memory enabled while maintaining 18/18 fact accuracy in the latest paired run.</p>
+        </div>
+        <div class="benchmark-table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Metric</th>
+                <th>Memory on</th>
+                <th>Without memory</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Facts correct</td>
+                <td>18/18</td>
+                <td>18/18</td>
+              </tr>
+              <tr>
+                <td>Active tokens</td>
+                <td>3,192</td>
+                <td>42,954</td>
+              </tr>
+              <tr>
+                <td>Tool calls</td>
+                <td>6</td>
+                <td>49</td>
+              </tr>
+              <tr>
+                <td>Failed tools</td>
+                <td>0</td>
+                <td>4</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="caveat">
+            Internal directional and regression benchmark—not a universal real-world performance claim. Results vary
+            with prompts, repositories, models, cache state, and tool choices.
+          </p>
+        </div>
+      </section>
+
+      <section class="section install" id="install">
+        <div>
+          <p class="section-label">Quick start</p>
+          <h2>Keep the next session informed.</h2>
+          <p>Install the Pi extension, restart Pi, and LaPis wires itself into session startup.</p>
+        </div>
+        <div class="install-command">
+          <code><span>$</span> pi install git:github.com/GeneGulanesJr/LaPis</code>
+          <a href="https://github.com/GeneGulanesJr/LaPis#supported-integrations">Other integrations →</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <a class="brand" href="#top"><span class="brand-mark" aria-hidden="true">L</span><span>LaPis</span></a>
+      <p>Local AI memory for coding agents. ISC licensed.</p>
+      <div>
+        <a href="https://github.com/GeneGulanesJr/LaPis">GitHub</a>
+        <a href="https://github.com/GeneGulanesJr/LaPis/blob/main/docs/INDEX.md">Documentation</a>
+        <a href="https://github.com/GeneGulanesJr/LaPis/blob/main/CONTRIBUTING.md">Contribute</a>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,672 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg: #07111f;
+  --bg-deep: #040b14;
+  --panel: #0c1929;
+  --panel-light: #112235;
+  --line: #20344a;
+  --text: #eef5f3;
+  --muted: #9eb0b9;
+  --accent: #57e6c0;
+  --accent-soft: rgba(87, 230, 192, 0.12);
+  --blue: #75a9ff;
+  --max-width: 1180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+html {
+  scroll-behavior: smooth;
+}
+body {
+  margin: 0;
+  color: var(--text);
+  background: radial-gradient(circle at 76% 5%, rgba(37, 112, 135, 0.18), transparent 29rem), var(--bg);
+  font-family: 'Manrope', system-ui, sans-serif;
+  line-height: 1.6;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+.skip-link {
+  position: absolute;
+  top: -5rem;
+  left: 1rem;
+  z-index: 20;
+  padding: 0.6rem 1rem;
+  color: var(--bg);
+  background: var(--accent);
+}
+.skip-link:focus {
+  top: 1rem;
+}
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 74px;
+  padding: 0 max(24px, calc((100vw - var(--max-width)) / 2));
+  border-bottom: 1px solid rgba(117, 145, 159, 0.16);
+  background: rgba(7, 17, 31, 0.86);
+  backdrop-filter: blur(18px);
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  font-size: 1.12rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.brand-mark {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  color: var(--bg);
+  background: var(--accent);
+  border-radius: 7px;
+  font:
+    600 1rem 'DM Mono',
+    monospace;
+}
+nav {
+  display: flex;
+  gap: 2rem;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+nav a:hover,
+footer a:hover {
+  color: var(--accent);
+}
+.header-link {
+  padding: 0.52rem 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+.header-link:hover {
+  border-color: var(--accent);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: clamp(3rem, 7vw, 7rem);
+  align-items: center;
+  width: min(calc(100% - 48px), var(--max-width));
+  min-height: 680px;
+  margin: 0 auto;
+  padding: 6rem 0;
+}
+.eyebrow,
+.section-label {
+  color: var(--accent);
+  font:
+    500 0.72rem 'DM Mono',
+    monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+.eyebrow span {
+  width: 7px;
+  height: 7px;
+  background: var(--accent);
+  border-radius: 50%;
+  box-shadow: 0 0 12px var(--accent);
+}
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+h1 {
+  max-width: 700px;
+  margin: 1.3rem 0 1.4rem;
+  font-size: clamp(3rem, 5.5vw, 5.4rem);
+  font-weight: 500;
+  line-height: 1.03;
+  letter-spacing: -0.055em;
+}
+h1 em {
+  color: var(--accent);
+  font-style: normal;
+}
+.hero-lede {
+  max-width: 620px;
+  color: #b6c5cc;
+  font-size: 1.06rem;
+  line-height: 1.75;
+}
+.hero-actions {
+  display: flex;
+  gap: 0.8rem;
+  margin: 2rem 0;
+}
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.15rem;
+  border-radius: 6px;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+.button-primary {
+  color: #06120f;
+  background: var(--accent);
+}
+.button-primary:hover {
+  background: #75efd0;
+  transform: translateY(-1px);
+}
+.button-secondary {
+  border: 1px solid var(--line);
+}
+.button-secondary:hover {
+  border-color: #60798c;
+}
+.hero-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.4rem;
+  margin: 0;
+  padding: 0;
+  color: var(--muted);
+  font:
+    0.69rem 'DM Mono',
+    monospace;
+  list-style: none;
+}
+.hero-facts li::before {
+  margin-right: 0.45rem;
+  color: var(--accent);
+  content: '✓';
+}
+
+.terminal {
+  overflow: hidden;
+  border: 1px solid #294058;
+  border-radius: 11px;
+  background: rgba(5, 13, 23, 0.91);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.36);
+  font-family: 'DM Mono', monospace;
+  transform: perspective(1000px) rotateY(-1.5deg);
+}
+.terminal-bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--line);
+  color: #8498a6;
+  background: #0c1826;
+  font-size: 0.65rem;
+}
+.terminal-dots {
+  display: flex;
+  gap: 5px;
+}
+.terminal-dots i {
+  width: 7px;
+  height: 7px;
+  background: #385064;
+  border-radius: 50%;
+}
+.terminal-status {
+  justify-self: end;
+  color: var(--accent);
+}
+.terminal-status::before {
+  content: '● ';
+}
+.terminal-body {
+  min-height: 430px;
+  padding: 1.5rem;
+  font-size: 0.72rem;
+}
+.terminal-body p {
+  margin-bottom: 0.7rem;
+}
+.prompt,
+.ok {
+  margin-right: 0.5rem;
+  color: var(--accent);
+}
+.muted {
+  color: #718697;
+}
+.terminal-rule {
+  height: 1px;
+  margin: 1.3rem 0;
+  background: var(--line);
+}
+.memory-card {
+  margin: 0.8rem 0;
+  padding: 0.9rem 1rem;
+  border: 1px solid #24445a;
+  border-left: 2px solid var(--accent);
+  border-radius: 5px;
+  background: rgba(18, 42, 56, 0.54);
+}
+.memory-card > * {
+  display: block;
+}
+.memory-type {
+  margin-bottom: 0.45rem;
+  color: var(--accent);
+  font-size: 0.57rem;
+  letter-spacing: 0.13em;
+}
+.memory-type.bug {
+  color: var(--blue);
+}
+.memory-card strong {
+  margin-bottom: 0.3rem;
+  color: #dfeae9;
+  font-weight: 500;
+}
+.memory-card small {
+  color: #7f96a5;
+}
+
+.integration-strip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1.2rem, 4vw, 4rem);
+  min-height: 92px;
+  padding: 1.5rem;
+  border-block: 1px solid var(--line);
+  color: #b9c6cb;
+  background: var(--bg-deep);
+  font-size: 0.8rem;
+}
+.integration-strip span {
+  color: #657b89;
+  font:
+    0.65rem 'DM Mono',
+    monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.section {
+  width: min(calc(100% - 48px), var(--max-width));
+  margin: 0 auto;
+  padding: 7rem 0;
+  border-bottom: 1px solid var(--line);
+}
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6rem;
+}
+h2 {
+  max-width: 720px;
+  margin-bottom: 1.4rem;
+  font-size: clamp(2rem, 3.6vw, 3.4rem);
+  font-weight: 500;
+  line-height: 1.15;
+  letter-spacing: -0.04em;
+}
+h3 {
+  font-size: 1rem;
+}
+.section-copy {
+  padding-top: 2.2rem;
+  color: var(--muted);
+  font-size: 1rem;
+}
+.section-copy p {
+  margin-bottom: 1.3rem;
+}
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 3.5rem;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+.feature-grid article {
+  min-height: 230px;
+  padding: 2rem;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: rgba(12, 25, 41, 0.34);
+}
+.feature-index {
+  display: block;
+  margin-bottom: 2.8rem;
+  color: var(--accent);
+  font:
+    0.67rem 'DM Mono',
+    monospace;
+}
+.feature-grid h3 {
+  margin-bottom: 0.7rem;
+}
+.feature-grid p {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+.section-heading-row {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 4rem;
+}
+.section-heading-row > p {
+  max-width: 350px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+.integration-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  margin-top: 3rem;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+.integration-grid article {
+  min-height: 220px;
+  padding: 2rem;
+  background: var(--panel);
+}
+.integration-grid article:hover {
+  background: var(--panel-light);
+}
+.integration-badge {
+  display: inline-grid;
+  min-width: 35px;
+  height: 35px;
+  margin-bottom: 2rem;
+  padding: 0 0.45rem;
+  place-items: center;
+  border: 1px solid #355064;
+  border-radius: 5px;
+  color: var(--accent);
+  font:
+    0.63rem 'DM Mono',
+    monospace;
+}
+.integration-grid p {
+  color: var(--muted);
+  font-size: 0.83rem;
+}
+.integration-grid a,
+.text-link,
+.install-command a {
+  color: var(--accent);
+  font:
+    0.7rem 'DM Mono',
+    monospace;
+}
+.architecture {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 7rem;
+  align-items: center;
+}
+.architecture-copy > p:not(.section-label) {
+  color: var(--muted);
+}
+.architecture-map {
+  padding: 2.2rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg-deep);
+}
+.map-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+.map-row span,
+.map-layer {
+  padding: 0.8rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: #b6c6cd;
+  background: var(--panel);
+  text-align: center;
+  font:
+    0.65rem 'DM Mono',
+    monospace;
+}
+.map-layer {
+  color: var(--accent);
+}
+.map-connector {
+  width: 1px;
+  height: 24px;
+  margin: auto;
+  background: var(--line);
+}
+.services span {
+  color: var(--blue);
+}
+.database {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.8rem;
+  align-items: center;
+  width: 250px;
+  margin: auto;
+  padding: 0.9rem 1.1rem;
+  border: 1px solid rgba(87, 230, 192, 0.4);
+  border-radius: 5px;
+  background: var(--accent-soft);
+  font:
+    0.72rem 'DM Mono',
+    monospace;
+}
+.database small {
+  grid-column: 2;
+  color: var(--muted);
+  font-size: 0.57rem;
+}
+.database-icon {
+  grid-row: 1 / span 2;
+  width: 24px;
+  height: 29px;
+  border: 2px solid var(--accent);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 -5px 0 var(--bg),
+    inset 0 -7px 0 var(--accent);
+}
+.benchmark {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 7rem;
+}
+.benchmark h2 span {
+  color: var(--accent);
+}
+.benchmark > div > p:not(.section-label, .caveat) {
+  color: var(--muted);
+}
+.benchmark table {
+  width: 100%;
+  border-collapse: collapse;
+  font:
+    0.71rem 'DM Mono',
+    monospace;
+}
+.benchmark th,
+.benchmark td {
+  padding: 0.8rem;
+  border-bottom: 1px solid var(--line);
+  text-align: right;
+}
+.benchmark th:first-child,
+.benchmark td:first-child {
+  text-align: left;
+}
+.benchmark th {
+  color: #718a99;
+  font-weight: 400;
+}
+.benchmark td:nth-child(2) {
+  color: var(--accent);
+}
+.caveat {
+  margin: 1.2rem 0 0;
+  color: #738895;
+  font-size: 0.69rem;
+}
+.install {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5rem;
+  align-items: center;
+}
+.install > div > p:not(.section-label) {
+  color: var(--muted);
+}
+.install-command {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+.install-command code {
+  width: 100%;
+  padding: 1.3rem;
+  overflow-x: auto;
+  border: 1px solid #315066;
+  border-radius: 6px;
+  color: #d9e5e4;
+  background: var(--bg-deep);
+  font:
+    0.72rem 'DM Mono',
+    monospace;
+  white-space: nowrap;
+}
+.install-command code span {
+  color: var(--accent);
+}
+footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(calc(100% - 48px), var(--max-width));
+  min-height: 130px;
+  margin: 0 auto;
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+footer p {
+  margin: 0;
+}
+footer > div {
+  display: flex;
+  gap: 1.5rem;
+}
+
+@media (max-width: 850px) {
+  nav {
+    display: none;
+  }
+  .hero,
+  .split,
+  .architecture,
+  .benchmark,
+  .install {
+    grid-template-columns: 1fr;
+    gap: 3rem;
+  }
+  .hero {
+    padding: 4rem 0;
+  }
+  .feature-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .section-heading-row {
+    display: block;
+  }
+  .architecture-copy {
+    max-width: 650px;
+  }
+}
+
+@media (max-width: 580px) {
+  .site-header {
+    height: 64px;
+  }
+  .header-link {
+    display: none;
+  }
+  .hero {
+    width: min(calc(100% - 32px), var(--max-width));
+    min-height: auto;
+    padding: 3.2rem 0;
+  }
+  h1 {
+    font-size: 2.65rem;
+  }
+  .hero-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .terminal {
+    transform: none;
+  }
+  .terminal-body {
+    min-height: 0;
+    padding: 1rem;
+    font-size: 0.62rem;
+  }
+  .integration-strip {
+    flex-wrap: wrap;
+    gap: 0.7rem 1.4rem;
+    justify-content: flex-start;
+  }
+  .section {
+    width: min(calc(100% - 32px), var(--max-width));
+    padding: 4.5rem 0;
+  }
+  .feature-grid,
+  .integration-grid {
+    grid-template-columns: 1fr;
+  }
+  .map-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .database {
+    width: 100%;
+  }
+  footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 1.3rem;
+    padding: 2.5rem 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "lapis",
+  "compatibility_date": "2026-05-24",
+  "assets": {
+    "directory": "./website",
+  },
+}


### PR DESCRIPTION
### Motivation

- Improve positioning and discoverability for LaPis as “AI memory → persistent memory → coding agents” while avoiding marketing language.
- Make the README hierarchy more onboarding-friendly so install and integrations appear before architecture and deep technical details.
- Clarify supported integrations, storage model, and practical examples of what the memory stores, and add an FAQ for common user questions.

### Description

- Change the main title to `# LaPis — Local AI Memory for Coding Agents` and rewrite the opening 100–150 word section to clearly associate `LaPis → AI memory → persistent memory → coding agents`, note SQLite-backed local storage, and list supported clients (`Pi`, `Claude Code`, `Hermes`, MCP).  
- Reorganize the top-level flow: Banner/walkthrough, `Quick Start`/`Install`, `Supported Integrations`, `Why LaPis?`, `AI Memory for Coding Agents` (renamed from `What It Does`), then `Architecture`, `Benchmarks`, `Documentation`, `FAQ`, and `License` to surface install and integration info first.  
- Add `## Why LaPis?` explaining memory loss between agent sessions and listing concrete examples (architectural decisions, bug fixes, conventions, discoveries, code/docs context, stale/superseded info).  
- Rename and refine features under `## AI Memory for Coding Agents` to lead with persistence, automatic recall, and local-first storage, while preserving code indexing, docs indexing, trust tracking, deduplication, Dream Cycle, workspace management, preflight, dashboard, API, and compression features.  
- Improve integration headings for clarity to `### Pi Coding Agent Persistent Memory`, `### Claude Code Persistent Memory`, `### Hermes Agent Persistent Memory`, and `### MCP Server`, keeping all original install/setup commands and links intact.  
- Rename the paired-memory section to `### AI Memory vs No Memory Benchmark`, prepend the succinct benchmark summary that enabling persistent memory reduced active tokens by 92.6% while maintaining 18/18 fact accuracy, and retain the original caveat that this is an internal directional/regression benchmark.  
- Add a concise `FAQ` covering what LaPis is, how it integrates with Claude Code, Pi, and Hermes, where memory is stored (default `~/.pi/memory/memory.db`), and MCP server behavior.  
- Adjust several image alt texts to describe LaPis as an AI/coding-agent memory system and move the Architecture section lower while preserving diagrams, implementation details, commands, benchmark tables, and links.

### Testing

- Ran formatting check with `npm run format:check` (which runs `oxfmt --check`) and it completed successfully with no formatting changes required.  
- Verified local README link targets with a small Python checker that confirmed all repository-local links referenced by `README.md` exist.  
- Performed basic repository validation (`format` and link checks) with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9776eacc84832f8ce390af31828436)