### PR TITLE
ci: fix failing pack-verify (npm 10 Arborist crash) and audit gate

### DIFF
--- a/.github/workflows/hermes-pack-verify.yml
+++ b/.github/workflows/hermes-pack-verify.yml
@@ -65,6 +65,14 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Upgrade npm to 11.x
+        # Node 22 bundles npm 10.x, whose Arborist crashes with "Cannot read
+        # properties of null (reading 'edgesOut')" (@npmcli/arborist
+        # #loadPeerSet) while resolving the lockfile-less production tree of
+        # the extracted tarball — reproduced on npm 10.9.4, clean on 11.x and
+        # 12.x. Keep Node 22; only replace its bundled npm.
+        run: npm install -g npm@11
+
       - name: Install dev dependencies (for pack + tree-sitter grammars)
         # We need the dev tree to build/verify grammar wasms before packing.
         run: npm ci

--- a/.github/workflows/pack-verify.yml
+++ b/.github/workflows/pack-verify.yml
@@ -58,6 +58,14 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Upgrade npm to 11.x
+        # Node 22 bundles npm 10.x, whose Arborist crashes with "Cannot read
+        # properties of null (reading 'edgesOut')" (@npmcli/arborist
+        # #loadPeerSet) while resolving the lockfile-less production tree of
+        # the extracted tarball — reproduced on npm 10.9.4, clean on 11.x and
+        # 12.x. Keep Node 22; only replace its bundled npm.
+        run: npm install -g npm@11
+
       - name: Install dev dependencies (for pack + tree-sitter grammars)
         # We need the dev tree to build/verify grammar wasms before packing.
         run: npm ci
@@ -222,8 +230,8 @@ jobs:
       # (6) npm audit against the PRODUCTION tree of the packed artifact
       # ─────────────────────────────────────────────────────────────────────
       - name: npm audit (production, high+)
-        # Mirrors the audit gate in test.yml: --omit=dev because the only
-        # remaining high findings are dev-only transitives under
-        # @earendil-works/pi-coding-agent. The production tree must audit clean.
+        # Mirrors the audit gate in test.yml: --omit=dev keeps the gate
+        # production-scoped so dev-only advisories cannot block CI. The
+        # production tree must audit clean.
         working-directory: ${{ env.EXTRACT }}
         run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,10 @@ jobs:
         run: npm install
 
       - name: Audit dependencies (high+)
-        # --omit=dev: the only remaining high-severity findings are dev-only
-        # transitive vulns nested under @earendil-works/pi-coding-agent@0.80.x
-        # (it pins undici exactly to 8.5.0; npm overrides do not reach that
-        # subtree, and the only fix npm offers is a breaking downgrade). The
-        # production dependency tree audits clean — that is what ships.
+        # --omit=dev: this gate is production-scoped so a future dev-only
+        # advisory (e.g. a transitive under @earendil-works/pi-coding-agent,
+        # which pins undici exactly and blocks npm overrides) cannot block CI.
+        # The production dependency tree must audit clean — that is what ships.
         run: npm audit --audit-level=high --omit=dev
 
       - name: Lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -588,7 +588,6 @@
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.4.tgz",
       "integrity": "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w==",
       "dev": true,
-      "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.84.4",
@@ -1601,16 +1600,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1620,37 +1609,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -1669,53 +1627,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -1725,24 +1642,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
@@ -1997,13 +1896,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -2090,29 +1982,6 @@
       "engines": {
         "node": ">= 20"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
       "version": "1.0.0",
@@ -2217,16 +2086,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -2283,27 +2142,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -2315,29 +2153,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
@@ -2367,13 +2182,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
@@ -2391,35 +2199,12 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
       "engines": {
         "node": ">= 8"
       }
@@ -5035,9 +4820,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -6481,9 +6266,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Fixes the three currently-red CI checks (test, pack-verify, hermes-pack-verify). They fail for two independent reasons; no product code is touched.

## 1. pack-verify / hermes-pack-verify: npm 10 Arborist crash

Both jobs died in **"Install production deps in extracted package"** with:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

That install is lockfile-less by design — the extracted tarball has no `package-lock.json`, so npm builds a fresh ideal tree, exactly like a real consumer. The crash is an npm 10.x Arborist bug in `#loadPeerSet` (`@npmcli/arborist/build-ideal-tree.js`) that the current transitive graph now triggers. Notably this is **not** caused by any repo change: pack-verify was green on `9ac1281` (Sep 2) and started failing Sep 5, when fresh resolution began picking a newly published in-range transitive version.

Reproduced locally on the identical tarball:

| npm | result |
| --- | --- |
| 10.9.4 (what Node 22 bundles) | 💥 `Cannot read properties of null (reading 'edgesOut')` |
| 11.x | ✅ installs, `better-sqlite3` native build OK |
| 12.0.1 | ✅ installs, native OK, 0 vulnerabilities |

**Fix:** add `npm install -g npm@11` after `setup-node` in both workflows. Node 22 is kept (it's the consumer/publish target) — only its bundled npm is replaced. `publish.yml` needs no change: it only runs lockfile-driven `npm ci`, and its `pack-verify` gate inherits the fix via `workflow_call`.

## 2. test: `npm audit --audit-level=high --omit=dev` fails

The recently published `fast-uri` advisories ([GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8) and friends) flag `fast-uri@3.1.5`, a production transitive via `@modelcontextprotocol/sdk → ajv`.

**Fix:** `npm audit fix` — lockfile only:
- `fast-uri` 3.1.5 → 3.1.7
- `qs` 6.15.3 → 6.16.0 (moderate)
- dedupes nested duplicates under `pi-coding-agent` (validated with `npm ci --dry-run`)

Full audit now reports **0 vulnerabilities** (the previously documented dev-only undici findings are gone too, so the stale audit-step comments in test.yml / pack-verify.yml are refreshed).

## Verification

- `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities
- `npm ci --dry-run` → lockfile/package.json consistent
- Full test suite: **137 files, 2000 tests passed**
- Extracted-tarball install re-verified with npm 11 (native module roundtrip OK)