### PR TITLE
chore(seo): README agent-context keywords + complete website meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ See [`docs/MCP.md`](docs/MCP.md).
 
 ## Why LaPis?
 
-Coding agents can lose useful project knowledge between sessions or depend on manually maintained context files. LaPis provides structured, persistent memory that can automatically preserve and retrieve useful project knowledge instead. Its local-first, SQLite-backed store can retain:
+Coding agents can lose useful project knowledge between sessions or depend on manually maintained context files like `CLAUDE.md` and `AGENTS.md`. LaPis provides structured, persistent memory that can automatically preserve and retrieve useful project knowledge instead. Its local-first, SQLite-backed store can retain:
 
 - architectural decisions and their rationale
 - previous bugs and fixes
 - project conventions and constraints
 - discoveries from earlier sessions
 - relevant code and documentation context
-- stale or superseded information that should no longer be trusted
+- trust signals for memories linked to changed code, so stale or superseded knowledge is flagged instead of silently trusted
 
 ## AI Memory for Coding Agents
 

--- a/website/index.html
+++ b/website/index.html
@@ -10,8 +10,13 @@
     <meta name="theme-color" content="#f4efe4" />
     <meta property="og:title" content="LaPis — Local AI Memory for Coding Agents" />
     <meta property="og:description" content="Persistent project memory for coding agents, stored locally in SQLite." />
-    <meta property="og:image" content="/assets/social-preview.jpg" />
+    <!-- TODO: update absolute URLs below when the permanent domain replaces lapis.gulanesgene.workers.dev -->
+    <meta property="og:url" content="https://lapis.gulanesgene.workers.dev/" />
+    <meta property="og:image" content="https://lapis.gulanesgene.workers.dev/assets/social-preview.jpg" />
     <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="LaPis" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="canonical" href="https://lapis.gulanesgene.workers.dev/" />
     <title>LaPis — Local AI Memory for Coding Agents</title>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="/styles.css" />
@@ -23,6 +28,8 @@
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Linux, macOS, Windows",
         "description": "Local, persistent AI memory for coding agents backed by SQLite.",
+        "url": "https://lapis.gulanesgene.workers.dev/",
+        "codeRepository": "https://github.com/GeneGulanesJr/LaPis",
         "license": "https://opensource.org/license/isc-license-txt"
       }
     </script>


### PR DESCRIPTION
## What

Two file-based fixes from the SEO review, scoped to things that don't touch repo settings.

### README.md
- **CLAUDE.md / AGENTS.md positioning** — "Why LaPis?" now names the hand-maintained context files it replaces. These terms carry the largest search volume in this niche and were previously described only generically ("manually maintained context files").
- **Reworded the stale-memory bullet** — "stale or superseded information that should no longer be trusted" read as a con in a benefits list; now framed as the trust-signal feature it is.

### website/index.html
- **canonical link + og:url** pointing at https://lapis.gulanesgene.workers.dev/ (verified live, HTTP 200)
- **og:image made absolute** — the previous relative path is ignored by most social scrapers; image confirmed 200 on the domain
- **og:site_name + twitter:card** (summary_large_image) for proper social cards
- **SoftwareApplication JSON-LD**: added url and codeRepository

## Notes

- ⚠️ The absolute URLs use the temporary lapis.gulanesgene.workers.dev domain — update canonical, og:url, og:image, and JSON-LD url together when the permanent domain lands (marked with a TODO comment in the head).
- Merging auto-deploys the site (Git-connected Worker), so these go live immediately.
- No FAQPage schema was added: the landing page has no FAQ section, and marking up invisible content violates search-engine guidelines. If an FAQ section is added to the site later, mirror the README FAQ there and add the schema then.

## Follow-ups (repo settings, not PR-able)

- [ ] Add GitHub topics: mcp, claude-code, llm, ai-memory, developer-tools
- [ ] Set repo homepage URL to https://lapis.gulanesgene.workers.dev/
