### PR TITLE
fix: P0/P1 batch — runCommand hang, Dream Cycle deletions, git-delta staleness

### DIFF
--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -214,40 +214,74 @@ function getGitDelta(repoPath, baseCommit) {
         maxBuffer: 10 * 1024 * 1024,
         stdio: ['ignore', 'pipe', 'ignore'],
       }),
+      // Working-tree state (staged + unstaged vs HEAD). Without this, any
+      // File edited but not yet committed — the normal state while an agent
+      // works — is invisible to delta mode and stays stale after head_commit
+      // advances past it.
+      wtOutput = execFileSync('git', ['diff', '--name-status', 'HEAD'], {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        timeout: 15000,
+        maxBuffer: 10 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+      // Untracked-but-not-ignored files are new work; they appear in no diff.
+      untrackedOutput = execFileSync('git', ['ls-files', '--others', '--exclude-standard'], {
+        cwd: repoPath,
+        encoding: 'utf-8',
+        timeout: 15000,
+        maxBuffer: 10 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
       changed = new Set(),
       deleted = new Set(),
       renamed = [],
       rejected = [],
       absRoot = path.resolve(repoPath);
-    for (const line of output.split('\n')) {
+    const parseNameStatus = (raw) => {
+      for (const line of raw.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          // oxlint-disable-next-line no-continue
+          continue;
+        }
+        const parts = trimmed.split('\t'),
+          status = parts[0];
+        if (status.startsWith('D') && parts[1]) {
+          // Deleted files no longer exist on disk; use the existence-tolerant resolver so they are recorded as deleted.
+          const abs = resolveRepoScopedDeletedPath(absRoot, parts[1], rejected);
+          if (abs) {
+            deleted.add(abs);
+          }
+        } else if (status.startsWith('R') && parts[1] && parts[2]) {
+          const fromAbs = resolveRepoScopedDeletedPath(absRoot, parts[1], rejected),
+            toAbs = resolveRepoScopedPath(repoPath, parts[2], rejected);
+          if (fromAbs) {
+            deleted.add(fromAbs);
+          }
+          if (toAbs) {
+            changed.add(toAbs);
+          }
+          renamed.push({ from: parts[1], to: parts[2], status });
+        } else if (parts[1]) {
+          const abs = resolveRepoScopedPath(repoPath, parts[1], rejected);
+          if (abs) {
+            changed.add(abs);
+          }
+        }
+      }
+    };
+    parseNameStatus(output);
+    parseNameStatus(wtOutput);
+    for (const line of untrackedOutput.split('\n')) {
       const trimmed = line.trim();
       if (!trimmed) {
         // oxlint-disable-next-line no-continue
         continue;
       }
-      const parts = trimmed.split('\t'),
-        status = parts[0];
-      if (status.startsWith('D') && parts[1]) {
-        // Deleted files no longer exist on disk; use the existence-tolerant resolver so they are recorded as deleted.
-        const abs = resolveRepoScopedDeletedPath(absRoot, parts[1], rejected);
-        if (abs) {
-          deleted.add(abs);
-        }
-      } else if (status.startsWith('R') && parts[1] && parts[2]) {
-        const fromAbs = resolveRepoScopedDeletedPath(absRoot, parts[1], rejected),
-          toAbs = resolveRepoScopedPath(repoPath, parts[2], rejected);
-        if (fromAbs) {
-          deleted.add(fromAbs);
-        }
-        if (toAbs) {
-          changed.add(toAbs);
-        }
-        renamed.push({ from: parts[1], to: parts[2], status });
-      } else if (parts[1]) {
-        const abs = resolveRepoScopedPath(repoPath, parts[1], rejected);
-        if (abs) {
-          changed.add(abs);
-        }
+      const abs = resolveRepoScopedPath(repoPath, trimmed, rejected);
+      if (abs) {
+        changed.add(abs);
       }
     }
     return { currentHead, changed: [...changed], deleted: [...deleted], renamed, rejected };
@@ -1637,6 +1671,7 @@ module.exports = {
   fileRecordToParams,
   getHeadCommit,
   getCurrentBranch,
+  getGitDelta,
   parseChangedPathsInput,
   getCodeRepoHealth,
   indexRepository,

--- a/src/memory-domain/compaction.js
+++ b/src/memory-domain/compaction.js
@@ -144,8 +144,10 @@ function dream(deps, args = {}) {
            r.source_id AS newer_id, r.relation, r.confidence
     FROM observations o
     JOIN observation_relations r ON r.target_id = o.id
+    JOIN observations newer ON newer.id = r.source_id
     WHERE r.relation IN ('duplicate', 'supersedes')
       AND o.deleted_at IS NULL
+      AND newer.deleted_at IS NULL
       AND r.confidence >= ${DEDUP.DREAM_SUPERSEDED_CONFIDENCE}
   `);
       })();
@@ -177,6 +179,7 @@ function dream(deps, args = {}) {
         ) rl ON rl.memory_id = o.id
         WHERE o.type = ? AND o.deleted_at IS NULL
           AND (rl.recall_count IS NULL OR rl.recall_count = 0)
+          ${args.bypassAgeGates ? '' : `AND o.created_at < datetime('now', '-${TIME_WINDOWS.DREAM_AUTO_DETECTED_MIN_AGE_DAYS} days')`}
       `,
               [type],
             );
@@ -230,6 +233,7 @@ function dream(deps, args = {}) {
     FROM observations
     WHERE (title LIKE 'CORRECTION:%' OR title LIKE 'Correction:%')
       AND deleted_at IS NULL
+      ${args.bypassAgeGates ? '' : `AND created_at < datetime('now', '-${TIME_WINDOWS.DREAM_AUTO_DETECTED_MIN_AGE_DAYS} days')`}
   `),
           obsoleteConfigs = (() => {
             for (const row of corrections) {
@@ -255,6 +259,7 @@ function dream(deps, args = {}) {
     JOIN observation_relations r ON r.target_id = o1.id
     JOIN observations o2 ON o2.id = r.source_id
     WHERE r.relation IN ('duplicate', 'supersedes')
+      AND r.confidence >= ${DEDUP.DREAM_SUPERSEDED_CONFIDENCE}
       AND o1.deleted_at IS NULL
       AND o2.deleted_at IS NULL
       AND o1.type IN ('decision', 'config', 'architecture')
@@ -273,6 +278,7 @@ function dream(deps, args = {}) {
       AND o2.type IN ('decision', 'config', 'architecture')
     JOIN observation_relations r2 ON r2.target_id = o1.id AND r2.source_id = o2.id
       AND r2.relation IN ('duplicate', 'supersedes')
+      AND r2.confidence >= ${DEDUP.DREAM_SUPERSEDED_CONFIDENCE}
     WHERE o1.deleted_at IS NULL
       AND o1.topic_key IS NOT NULL AND o1.topic_key != ''
       AND o1.topic_key = o2.topic_key
@@ -346,10 +352,12 @@ function dream(deps, args = {}) {
                     .join('\n\n---\n\n'),
                   mergedTitle = `${group.topic_key} — consolidated (${entries.length} entries)`;
 
-                deps.sqlRun('UPDATE observations SET content = ?, title = ?, type = ? WHERE id = ?', [
+                // Keep the kept row's own type — forcing every consolidated
+                // Group to 'decision' permanently broke --type filtering for
+                // merged bugfix/pattern/preference entries.
+                deps.sqlRun('UPDATE observations SET content = ?, title = ? WHERE id = ?', [
                   mergedContent,
                   mergedTitle,
-                  'decision',
                   keepId,
                 ]);
 

--- a/src/token-saver/run-command.js
+++ b/src/token-saver/run-command.js
@@ -30,40 +30,63 @@ function runCommand(commandArgs, options = {}) {
         cwd,
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
       });
     } else {
       const escaped = commandArgs.map(shellEscape).join(' ');
+      // Detached: the command becomes its own process-group leader so the
+      // timeout kill below can take down pipeline grandchildren. Killing only
+      // the shell leaves grandchildren alive holding the stdio pipe write
+      // ends, and then 'close' never fires and this promise never resolves.
       child = spawn('/bin/sh', ['-c', escaped], {
         cwd,
         env,
         stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
       });
     }
 
+    // setEncoding decodes through a StringDecoder, so a multi-byte character
+    // split across two 'data' chunks no longer becomes U+FFFD.
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
     child.stdout.on('data', (chunk) => {
-      stdout += chunk.toString();
-      if (stdout.length >= maxBufferChars) {
-        truncated = true;
-        stdout = stdout.slice(0, maxBufferChars);
-        // Stop reading further stdout chunks — we already have the cap and
-        // Continuing to drain the stream wastes CPU and lets the OS pipe
-        // Buffer fill up. The child will still exit on its own.
-        child.stdout.pause();
+      // Keep draining after the cap and discard — pausing the stream would
+      // block the child on a full pipe, and 'close' would only fire after the
+      // timeout SIGKILL (misreporting finished commands as timed out).
+      if (stdout.length < maxBufferChars) {
+        stdout += chunk;
+        if (stdout.length >= maxBufferChars) {
+          truncated = true;
+          stdout = stdout.slice(0, maxBufferChars);
+        }
       }
     });
 
     child.stderr.on('data', (chunk) => {
-      stderr += chunk.toString();
-      if (stderr.length >= maxBufferChars) {
-        truncated = true;
-        stderr = stderr.slice(0, maxBufferChars);
-        child.stderr.pause();
+      if (stderr.length < maxBufferChars) {
+        stderr += chunk;
+        if (stderr.length >= maxBufferChars) {
+          truncated = true;
+          stderr = stderr.slice(0, maxBufferChars);
+        }
       }
     });
 
     timer = setTimeout(() => {
       killed = true;
-      child.kill('SIGKILL');
+      if (isWindows) {
+        child.kill('SIGKILL');
+        return;
+      }
+      // Kill the entire process group; fall back to the direct kill if the
+      // group is already gone (leader exited, no other members).
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        child.kill('SIGKILL');
+      }
     }, timeoutMs);
 
     child.on('close', (code) => {

--- a/test/dream-phase-guards.test.js
+++ b/test/dream-phase-guards.test.js
@@ -1,0 +1,145 @@
+// Regression tests for issue #281: Dream Cycle phases that deleted live
+// Memories. Runs against an isolated temp DB (LAPIS_HOME is set before any
+// Project module loads) so real dream() runs never touch the user's DB.
+const os = require('node:os'),
+  path = require('node:path'),
+  fs = require('node:fs');
+
+process.env.LAPIS_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-dream-guards-'));
+
+const dbModule = require('../db'),
+  { dream } = require('../src/memory-domain/compaction');
+
+const PROJECT = 'dream-phase-guards';
+
+function deps() {
+  return {
+    sqlJson: dbModule.sqlJson,
+    sqlRun: dbModule.sqlRun,
+    sqlRaw: dbModule.sqlRaw,
+    jsonErrNoExit: dbModule.jsonErrNoExit,
+    softDeleteObservation: (id) => {
+      dbModule.sqlRun("UPDATE observations SET deleted_at = datetime('now') WHERE id = ?", [Number(id)]);
+    },
+  };
+}
+
+function seed({ title, type = 'decision', content = 'body', ageDays = 0 }) {
+  const created = ageDays > 0 ? `datetime('now', '-${ageDays} days')` : "datetime('now')";
+  return dbModule.sqlJson(
+    `INSERT INTO observations (session_id, type, title, content, project, created_at)
+     VALUES ('dream-test', ?, ?, ?, ?, ${created}) RETURNING id`,
+    [type, title, content, PROJECT],
+  )[0].id;
+}
+
+function relate(sourceId, targetId, relation, confidence) {
+  dbModule.sqlRun(
+    'INSERT INTO observation_relations (source_id, target_id, relation, confidence) VALUES (?, ?, ?, ?)',
+    [sourceId, targetId, relation, confidence],
+  );
+}
+
+function softDelete(id) {
+  dbModule.sqlRun("UPDATE observations SET deleted_at = datetime('now') WHERE id = ?", [id]);
+}
+
+function isDeleted(id) {
+  return dbModule.sqlJson('SELECT deleted_at FROM observations WHERE id = ?', [id])[0].deleted_at !== null;
+}
+
+beforeAll(() => {
+  dbModule.ensureDb();
+});
+
+describe('dream phase guards (#281)', () => {
+  it('Phase 1: does not delete a superseded memory whose replacement is already gone', () => {
+    const orphanedTarget = seed({ title: 'old decision, replacement purged' }),
+      deadReplacement = seed({ title: 'newer decision, later deleted' });
+    relate(deadReplacement, orphanedTarget, 'supersedes', 0.9);
+    softDelete(deadReplacement);
+
+    const liveTarget = seed({ title: 'old decision, replacement live' }),
+      liveReplacement = seed({ title: 'newer decision, still live' });
+    relate(liveReplacement, liveTarget, 'supersedes', 0.9);
+
+    const report = dream(deps());
+
+    expect(report.ok).toBe(true);
+    expect(isDeleted(liveTarget)).toBe(true);
+    expect(isDeleted(orphanedTarget)).toBe(false);
+  });
+
+  it('Phase 1: ignores duplicate/supersedes relations below the confidence threshold', () => {
+    const target = seed({ title: 'decision with only an uncertain duplicate' }),
+      source = seed({ title: 'uncertain duplicate source' });
+    relate(source, target, 'duplicate', 0.3);
+
+    dream(deps());
+
+    expect(isDeleted(target)).toBe(false);
+  });
+
+  it('Phase 2: spares never-recalled progress memories younger than the age gate', () => {
+    const young = seed({ title: 'progress written minutes ago', type: 'progress', ageDays: 0 }),
+      old = seed({ title: 'progress written weeks ago', type: 'progress', ageDays: 30 });
+
+    const report = dream(deps());
+
+    expect(report.ok).toBe(true);
+    expect(isDeleted(young)).toBe(false);
+    expect(isDeleted(old)).toBe(true);
+  });
+
+  it('Phase 2: bypassAgeGates still deletes young progress', () => {
+    const young = seed({ title: 'progress, gates bypassed', type: 'progress', ageDays: 0 });
+
+    dream(deps(), { bypassAgeGates: true });
+
+    expect(isDeleted(young)).toBe(true);
+  });
+
+  it('Phase 4: only deletes corrections past the age gate, not fresh ones', () => {
+    const fresh = seed({ title: 'CORRECTION: written minutes ago', ageDays: 0 }),
+      stale = seed({ title: 'CORRECTION: written weeks ago', ageDays: 30 });
+
+    dream(deps());
+
+    expect(isDeleted(fresh)).toBe(false);
+    expect(isDeleted(stale)).toBe(true);
+  });
+
+  it('Phase 5: spares setup/decision memories targeted only by low-confidence relations', () => {
+    const uncertain = seed({ title: 'setup decision, uncertain dupe', content: 'initial setup was replaced here' }),
+      uncertainSource = seed({ title: 'uncertain source' });
+    relate(uncertainSource, uncertain, 'duplicate', 0.2);
+
+    const confident = seed({ title: 'setup decision, confident dupe', content: 'initial setup was replaced here' }),
+      confidentSource = seed({ title: 'confident source' });
+    relate(confidentSource, confident, 'supersedes', 0.9);
+
+    dream(deps());
+
+    expect(isDeleted(uncertain)).toBe(false);
+    expect(isDeleted(confident)).toBe(true);
+  });
+
+  it('Phase 7: consolidation preserves the kept memory type instead of forcing decision', () => {
+    const keep = seed({ title: 'bugfix one', type: 'bugfix', content: 't1' }),
+      second = seed({ title: 'bugfix two', type: 'bugfix', content: 't2' }),
+      third = seed({ title: 'bugfix three', type: 'bugfix', content: 't3' });
+    for (const id of [keep, second, third]) {
+      dbModule.sqlRun('UPDATE observations SET topic_key = ? WHERE id = ?', ['guard-topic-a', id]);
+    }
+
+    const report = dream(deps());
+
+    expect(report.ok).toBe(true);
+    const kept = dbModule.sqlJson('SELECT type, title, deleted_at FROM observations WHERE id = ?', [keep])[0];
+    expect(kept.deleted_at).toBeNull();
+    expect(kept.title).toContain('consolidated');
+    expect(kept.type).toBe('bugfix');
+    expect(isDeleted(second)).toBe(true);
+    expect(isDeleted(third)).toBe(true);
+  });
+});

--- a/test/git-delta-working-tree.test.js
+++ b/test/git-delta-working-tree.test.js
@@ -1,0 +1,91 @@
+// Regression tests for issue #282: getGitDelta only diffed baseCommit..HEAD,
+// So uncommitted working-tree edits (the normal state while a coding agent
+// Works) were invisible to delta mode, and head_commit still advanced —
+// Leaving those files stale until a full reindex.
+const { execFileSync } = require('node:child_process'),
+  fs = require('node:fs'),
+  os = require('node:os'),
+  path = require('node:path'),
+  { getGitDelta } = require('../src/code-index/incremental-indexer');
+
+function makeRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-git-delta-')),
+    git = (...args) => execFileSync('git', args, { cwd: repo });
+  git('init');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  fs.writeFileSync(path.join(repo, 'a.js'), 'function alpha() {\n  return 1;\n}\n');
+  fs.writeFileSync(path.join(repo, 'b.js'), 'function beta() {\n  return 2;\n}\n');
+  git('add', '-A');
+  git('commit', '-m', 'init');
+  return { repo, git, base: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo }).toString().trim() };
+}
+
+describe('getGitDelta working-tree coverage (#282)', () => {
+  it('returns null when HEAD has not moved (delta mode not applicable)', () => {
+    const { repo, base } = makeRepo();
+    try {
+      expect(getGitDelta(repo, base)).toBeNull();
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('includes uncommitted modifications and untracked files, not just the committed range', () => {
+    const { repo, git, base } = makeRepo();
+    try {
+      // Commit a change to a.js only…
+      fs.writeFileSync(path.join(repo, 'a.js'), 'function alpha() {\n  return 10;\n}\n');
+      git('add', 'a.js');
+      git('commit', '-m', 'touch a');
+      // …while b.js has uncommitted edits and c.js is brand-new untracked work.
+      fs.writeFileSync(path.join(repo, 'b.js'), 'function beta() {\n  return 3;\n}\n');
+      fs.writeFileSync(path.join(repo, 'c.js'), 'function gamma() {\n  return 4;\n}\n');
+
+      const delta = getGitDelta(repo, base);
+
+      expect(delta).not.toBeNull();
+      const changed = delta.changed.map((p) => path.basename(p));
+      expect(changed).toContain('a.js');
+      expect(changed).toContain('b.js');
+      expect(changed).toContain('c.js');
+      expect(delta.currentHead).not.toBe(base);
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('reports uncommitted working-tree deletions', () => {
+    const { repo, git, base } = makeRepo();
+    try {
+      fs.rmSync(path.join(repo, 'b.js'));
+      fs.writeFileSync(path.join(repo, 'a.js'), 'function alpha() {\n  return 20;\n}\n');
+      git('add', 'a.js');
+      git('commit', '-m', 'touch a again');
+
+      const delta = getGitDelta(repo, base);
+
+      expect(delta).not.toBeNull();
+      expect(delta.deleted.map((p) => path.basename(p))).toContain('b.js');
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it('respects .gitignore when collecting untracked files', () => {
+    const { repo, git, base } = makeRepo();
+    try {
+      fs.writeFileSync(path.join(repo, '.gitignore'), 'ignored.js\n');
+      fs.writeFileSync(path.join(repo, 'ignored.js'), 'function noise() {}\n');
+      git('add', '.gitignore');
+      git('commit', '-m', 'gitignore');
+
+      const delta = getGitDelta(repo, base);
+
+      expect(delta).not.toBeNull();
+      expect(delta.changed.map((p) => path.basename(p))).not.toContain('ignored.js');
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/token-saver-run-command.test.js
+++ b/test/token-saver-run-command.test.js
@@ -1,0 +1,56 @@
+// Regression tests for issue #280: runCommand used to pause stdout at the
+// Buffer cap (blocking children on a full pipe), kill only the shell on
+// Timeout (leaving pipeline grandchildren alive holding the pipe so 'close'
+// Never fired → the promise hung forever), and decode each chunk
+// Independently (splitting multi-byte UTF-8 into U+FFFD).
+const { runCommand } = require('../src/token-saver/run-command');
+
+const posixDescribe = process.platform === 'win32' ? describe.skip : describe;
+
+describe('runCommand buffer cap + drain (#280)', () => {
+  posixDescribe('process-group handling (POSIX)', () => {
+    it('resolves when a pipeline output exceeds the cap (stream keeps draining)', async () => {
+      const result = await runCommand(['sh', '-c', 'yes x | head -c 200000'], {
+        maxBufferChars: 1000,
+        timeoutMs: 15000,
+      });
+      expect(result.stdout).toHaveLength(1000);
+      expect(result.truncated).toBe(true);
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('timeout kills the whole process group so compound commands resolve', async () => {
+      // `sleep 30 | cat`: after SIGKILL of the shell alone, cat survives
+      // Holding the stdout write end and 'close' never fires. With the group
+      // Kill, cat dies too and the promise resolves.
+      const result = await runCommand(['sh', '-c', 'sleep 30 | cat'], {
+        maxBufferChars: 1000000,
+        timeoutMs: 500,
+      });
+      expect(result.timedOut).toBe(true);
+      expect(result.exitCode).toBeNull();
+    }, 15000);
+  });
+
+  it('reports timeout for a stubborn child', async () => {
+    const result = await runCommand([process.execPath, '-e', 'setTimeout(() => {}, 60000)'], {
+      timeoutMs: 400,
+    });
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBeNull();
+  }, 15000);
+
+  it('preserves multi-byte characters split across chunk boundaries', async () => {
+    // 你 = E4 BD A0. Write the first two bytes, flush, then the rest after a
+    // Pause — the decoder must carry the partial sequence across chunks.
+    const script =
+      "process.stdout.write(Buffer.from([0xe4, 0xbd])); setTimeout(() => { process.stdout.write(Buffer.from([0xa0])); process.stdout.write('!'); }, 80)";
+    const result = await runCommand([process.execPath, '-e', script], {
+      maxBufferChars: 1000000,
+      timeoutMs: 10000,
+    });
+    expect(result.stdout).toBe('你!');
+    expect(result.timedOut).toBe(false);
+  }, 15000);
+});


### PR DESCRIPTION
First batch of fixes from the 2026-09-06 full-codebase review (issues #280–#304). Three independent fixes, one commit each; each ships with regression tests.

## 1. token-saver: runCommand could hang forever (#280) — P0

`runCommand` paused stdout at `maxBufferChars`, blocking the child on a full pipe; the timeout SIGKILLed only `/bin/sh`, so pipeline grandchildren survived holding the stdio write ends and `close` never fired — **the promise never resolved** for any piped command exceeding the cap (`npm test 2>&1 | tee`, CI logs, …). It also decoded each chunk independently, turning multi-byte characters split at chunk boundaries into U+FFFD.

**Fix:** keep draining and discard past the cap; spawn the child detached (process-group leader) and SIGKILL the whole group on timeout (POSIX; direct kill on Windows); decode via `setEncoding` (StringDecoder carries partial sequences across chunks).

**Tests:** `test/token-saver-run-command.test.js` — the pipeline-over-cap case (previously hung forever, now resolves in ~7 ms), the group-kill case, a stubborn-child timeout, and a deterministic split-`你` UTF-8 case.

## 2. memory: Dream Cycle phases deleted live memories (#281) — P1

Four destructive-wrong-deletion bugs in `src/memory-domain/compaction.js`:

- **Phase 1** soft-deleted a memory whose "replacement" (`r.source_id`) no longer existed or was itself soft-deleted — knowledge fully lost. Now joins the replacement and requires it live (confidence floor unchanged).
- **Phase 2** deleted never-recalled `progress`/`accomplished` notes with **no age gate** — a note saved minutes before the first dream run was deleted same-day. Now gated on `DREAM_AUTO_DETECTED_MIN_AGE_DAYS` (7 days), honoring `bypassAgeGates` exactly like Phase 3.
- **Phase 4** deleted **every** `CORRECTION:` entry unconditionally on each dream run (which fires at turn 50 of every session). Now age-gated the same way.
- **Phase 5** lacked the `DREAM_SUPERSEDED_CONFIDENCE` floor in both UNION branches — a low-confidence (uncertain) dupe relation plus the word "setup" could destroy a real decision. Both branches now require the threshold.
- **Phase 7** consolidation overwrote the kept memory's `type` to `'decision'`, permanently breaking `--type` filtering for merged bugfix/pattern/preference entries. The kept row now retains its own type.

**Tests:** `test/dream-phase-guards.test.js` runs real `dream()` cycles against an isolated temp DB (`LAPIS_HOME` set before module load) — orphaned-replacement survivor, confidence floor, both age gates + `bypassAgeGates`, and type preservation.

## 3. code-index: git-delta mode missed uncommitted work (#282) — P1

`getGitDelta` diffed `baseCommit..HEAD` only. With any new commit landed, delta mode skipped every file with **uncommitted modifications** — the normal state while a coding agent works — and `head_commit` still advanced, so those files stayed stale across subsequent incremental runs. Untracked new files were also invisible while uncommitted.

**Fix:** the delta now also parses `git diff --name-status HEAD` (staged + unstaged vs HEAD) and collects untracked-but-not-ignored files via `git ls-files --others --exclude-standard`; `getGitDelta` is exported for testing.

**Tests:** `test/git-delta-working-tree.test.js` builds temp git repos — uncommitted edit + untracked file picked up alongside the committed change, uncommitted deletion routed through the deleted resolver, `.gitignore` respected, and the no-op case still returns null.

## Verification

- New tests: 15 (4 + 7 + 4), all passing
- Full suite: **140 files, 2015 tests passed**
- `npm run lint`: 0 errors (warning count unchanged by this PR's source edits); `npm run format:check`: clean

Fixes #280
Fixes #281
Fixes #282