### PR TITLE
fix: P1 batch 2 — lossless compact wire format, persist compressed mission state

### DIFF
--- a/db.js
+++ b/db.js
@@ -175,6 +175,7 @@ class MemoryError extends Error {
         { to: 23, run: runMigrationV23 },
         { to: 24, run: runMigrationV24 },
         { to: 25, run: runMigrationV25 },
+        { to: 26, run: runMigrationV26 },
       ],
       LATEST_MIGRATION_VERSION = MIGRATIONS.reduce((max, m) => Math.max(max, m.to), 0);
 
@@ -1130,6 +1131,27 @@ class MemoryError extends Error {
         });
       } catch (e) {
         errors.push(`V25: ${e.message}`);
+      }
+      return errors;
+    }
+
+    function runMigrationV26() {
+      const errors = [];
+      try {
+        withTransaction(() => {
+          // Store the compressed mission state itself, not just the
+          // bookkeeping (summary/tokens_saved) — see issue #284.
+          try {
+            sqlRaw('ALTER TABLE mission_compression_log ADD COLUMN important_output TEXT');
+          } catch (e) {
+            if (!/duplicate column/i.test(e.message)) {
+              throw e;
+            }
+          }
+          sqlRaw('PRAGMA user_version = 26');
+        });
+      } catch (e) {
+        errors.push(`V26: ${e.message}`);
       }
       return errors;
     }

--- a/src/compression/mission-state.js
+++ b/src/compression/mission-state.js
@@ -106,6 +106,7 @@ function compressMissionState({ sqlJson, missionId, windowSize = 50 }) {
     if (sections.length === 0) {
       return {
         summary: 'Mission has no compressible state yet (no findings, handoffs, verdicts, or cost entries).',
+        compressed: '',
         tokensSaved: 0,
       };
     }
@@ -123,6 +124,9 @@ function compressMissionState({ sqlJson, missionId, windowSize = 50 }) {
 
       return {
         summary: compressed.summary,
+        // The compressed state itself — persisting this is the whole point;
+        // summary/tokensSaved alone describe a compression nobody can read.
+        compressed: compressed.importantOutput || '',
         tokensSaved,
       };
     }

--- a/src/compression/persistence.js
+++ b/src/compression/persistence.js
@@ -7,14 +7,21 @@ const { getDb } = require('../../db');
  * @param {object} args
  * @param {string} args.missionId
  * @param {string} args.trigger - one of "post_milestone" | "manual" | "budget_threshold"
- * @param {{ summary?: string|null, tokensSaved?: number, error?: string }} args.result
+ * @param {{ summary?: string|null, compressed?: string|null, tokensSaved?: number, error?: string }} args.result
  */
 function recordCompressionRun({ missionId, trigger, result }) {
   const stmt = `INSERT INTO mission_compression_log
-    (mission_id, trigger, summary, tokens_saved, error)
-    VALUES (?, ?, ?, ?, ?)`,
+    (mission_id, trigger, summary, tokens_saved, error, important_output)
+    VALUES (?, ?, ?, ?, ?, ?)`,
     db = getDb();
-  db.prepare(stmt).run(missionId, trigger, result.summary ?? '', result.tokensSaved ?? 0, result.error ?? null);
+  db.prepare(stmt).run(
+    missionId,
+    trigger,
+    result.summary ?? '',
+    result.tokensSaved ?? 0,
+    result.error ?? null,
+    result.compressed ?? null,
+  );
 }
 
 module.exports = { recordCompressionRun };

--- a/src/platform/protocol/compact-format.js
+++ b/src/platform/protocol/compact-format.js
@@ -8,6 +8,15 @@
  * 1. Homogeneous list of objects → tagged CSV with _header + pipe-delimited rows
  * 2. Path prefix interning when ≥3 rows share the same prefix
  * 3. Non-homogeneous results, single results, errors stay as JSON
+ * 4. Cell type markers keep decode lossless:
+ *    - null/undefined    → `` (empty)          decodes back to null
+ *    - boolean           → `!true` / `!false`
+ *    - number            → digits              decodes back to Number
+ *    - ambiguous string  → `'` + value         decodes back to the literal string
+ *    A string is ambiguous when it is empty, starts with the literal or
+ *    boolean marker, looks numeric (decode would coerce it), or starts with
+ *    an `@` prefix reference it did not receive from interning (decode would
+ *    expand it). Everything else encodes verbatim.
  *
  * Lossless round-trip: decode(encode(obj)) === obj
  */
@@ -38,6 +47,67 @@ function _escapePipe(val) {
  */
 function _unescapePipe(val) {
   return val.replace(/\uE001/g, '|').replace(/\uE000/g, '\\');
+}
+
+// Marker prefixing a cell whose value must decode back as a literal string
+// (as opposed to null / boolean / Number coercion).
+const LITERAL_MARKER = "'";
+
+/**
+ * Encode a single cell value with its type marker (see file header).
+ *
+ * @param {*} val — raw cell value
+ * @param {boolean} hasPrefixes — the column has a prefix map (a leading '@'
+ *   would be expanded on decode)
+ * @param {boolean} [interned] — the value was just rewritten by interning,
+ *   so its leading '@' is intentional and must NOT be marker-escaped
+ */
+function _encodeCell(val, hasPrefixes, interned = false) {
+  if (val == null) {
+    return '';
+  }
+  if (typeof val === 'number') {
+    return _escapePipe(String(val));
+  }
+  if (typeof val === 'boolean') {
+    return val ? '!true' : '!false';
+  }
+  const str = String(val),
+    ambiguous =
+      str === '' ||
+      str.startsWith(LITERAL_MARKER) ||
+      str.startsWith('!') ||
+      (hasPrefixes && !interned && str.startsWith('@')) ||
+      (str.trim() !== '' && !isNaN(str));
+  return (ambiguous ? LITERAL_MARKER : '') + _escapePipe(str);
+}
+
+/**
+ * Decode a single cell value, reversing _encodeCell (and still accepting
+ * legacy unmarked cells, which keep the pre-marker coercion behavior).
+ */
+function _decodeCell(val, prefixList) {
+  if (val.startsWith(LITERAL_MARKER)) {
+    return val.slice(1);
+  }
+  if (val === '!true') {
+    return true;
+  }
+  if (val === '!false') {
+    return false;
+  }
+  if (prefixList && val.startsWith('@')) {
+    for (let idx = 0; idx < prefixList.length; idx++) {
+      const marker = `@${idx}`;
+      if (val.startsWith(marker)) {
+        return prefixList[idx] + val.slice(marker.length);
+      }
+    }
+  }
+  if (val !== '' && val.trim() !== '' && !isNaN(val)) {
+    return Number(val);
+  }
+  return val === '' ? null : val;
 }
 
 // ══════════════════════════════════════════════════════════
@@ -89,19 +159,21 @@ function _encodeList(rows, opts = {}) {
 
   for (const row of rows) {
     const parts = header.map((key) => {
-      let val = row[key];
+      let val = row[key],
+        interned = false;
 
       // Apply prefix interning
       if (prefixes[key] && typeof val === 'string') {
         for (const [idx, prefix] of Object.entries(prefixes[key])) {
           if (val.startsWith(`${prefix}/`)) {
             val = `@${idx}${val.slice(prefix.length)}`;
+            interned = true;
             break;
           }
         }
       }
 
-      return _escapePipe(val);
+      return _encodeCell(val, Boolean(prefixes[key]), interned);
     });
     encodedRows.push(parts.join('|'));
   }
@@ -215,27 +287,7 @@ function _decodeList(compact) {
     const values = row.split('|').map((v) => _unescapePipe(v)),
       obj = {};
     header.forEach((key, i) => {
-      let val = values[i] || '';
-
-      // Expand prefix references
-      if (val.startsWith('@') && prefixes[key]) {
-        for (let idx = 0; idx < prefixes[key].length; idx++) {
-          const marker = `@${idx}`;
-          if (val.startsWith(marker)) {
-            val = prefixes[key][idx] + val.slice(marker.length);
-            break;
-          }
-        }
-      }
-
-      // Try numeric conversion
-      if (val !== '' && !isNaN(val) && val.trim() !== '') {
-        obj[key] = Number(val);
-      } else if (val === '') {
-        obj[key] = null;
-      } else {
-        obj[key] = val;
-      }
+      obj[key] = _decodeCell(values[i] || '', prefixes[key]);
     });
 
     // Restore stripped fields as null
@@ -284,6 +336,37 @@ function _isHomogeneous(arr) {
 }
 
 /**
+ * Check that every column can be represented losslessly in a pipe-delimited
+ * cell: either all its cells are primitives (or null), or the column is
+ * uniform across rows (hoisted whole by _encodeList, preserving the object).
+ * Columns mixing differing objects/arrays per row would be stringified
+ * ("[object Object]") — such lists stay as JSON instead.
+ */
+function _isCompactable(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return true;
+  }
+  for (const key of Object.keys(rows[0])) {
+    let allPrimitive = true,
+      uniform = true;
+    const first = JSON.stringify(rows[0][key]);
+    for (const row of rows) {
+      const v = row[key];
+      if (!(v == null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean')) {
+        allPrimitive = false;
+      }
+      if (JSON.stringify(v) !== first) {
+        uniform = false;
+      }
+      if (!allPrimitive && !uniform) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
  * Find the first array-like field in the data that's homogeneous.
  * Returns { key, rows } or null.
  */
@@ -295,7 +378,7 @@ function _findEncodableList(data) {
   // Try common container keys
   const candidates = [];
   for (const [key, value] of Object.entries(data)) {
-    if (Array.isArray(value) && _isHomogeneous(value)) {
+    if (Array.isArray(value) && _isHomogeneous(value) && _isCompactable(value)) {
       candidates.push({ key, rows: value, len: value.length });
     }
   }
@@ -348,7 +431,7 @@ function compactResponse(data, opts = {}) {
   const result = { ...data };
 
   for (const [key, value] of Object.entries(result)) {
-    if (Array.isArray(value) && _isHomogeneous(value) && value.length >= 2) {
+    if (Array.isArray(value) && _isHomogeneous(value) && value.length >= 2 && _isCompactable(value)) {
       result[key] = _encodeList(value, opts);
       modified = true;
     }
@@ -416,6 +499,7 @@ module.exports = {
   _encodeList,
   _decodeList,
   _isHomogeneous,
+  _isCompactable,
   _findEncodableList,
   _escapePipe,
   _unescapePipe,

--- a/test/compact-format-roundtrip.test.js
+++ b/test/compact-format-roundtrip.test.js
@@ -1,0 +1,121 @@
+// Regression tests for issue #283: the compact wire format's decode lost
+// Data — numeric-looking strings were coerced ('1.10' → 1.1), '' became
+// Null, any '@N'-leading value in an interned column was prefix-expanded,
+// And per-row object/array cells were String()-destroyed. The encode side
+// Now emits type markers and decode restores them; lists whose columns
+// Can't be represented losslessly stay as JSON.
+const wireFormat = require('../src/platform/protocol/compact-format');
+
+const { _encodeList, _decodeList, compactResponse, expandResponse, autoFormat, _isCompactable } = wireFormat;
+
+function roundTrip(rows, opts) {
+  return _decodeList(_encodeList(rows, opts));
+}
+
+describe('compact-format lossless round-trip (#283)', () => {
+  it('preserves numeric-looking strings instead of coercing them', () => {
+    const rows = [{ v: '1.10' }, { v: '42' }, { v: '0x1f' }, { v: 'Infinity' }, { v: '1e5' }, { v: ' 42 ' }],
+      decoded = roundTrip(rows);
+    expect(decoded.map((r) => r.v)).toEqual(['1.10', '42', '0x1f', 'Infinity', '1e5', ' 42 ']);
+  });
+
+  it('preserves empty strings instead of nulling them', () => {
+    const decoded = roundTrip([{ note: '' }, { note: 'x' }, { note: null }]);
+    expect(decoded[0].note).toBe('');
+    expect(decoded[1].note).toBe('x');
+    expect(decoded[2].note).toBeNull();
+  });
+
+  it('round-trips booleans', () => {
+    const decoded = roundTrip([
+      { ok: true, stale: false },
+      { ok: false, stale: true },
+    ]);
+    expect(decoded[0].ok).toBe(true);
+    expect(decoded[0].stale).toBe(false);
+    expect(decoded[1].ok).toBe(false);
+    expect(decoded[1].stale).toBe(true);
+  });
+
+  it('keeps plain numbers and strings intact', () => {
+    const decoded = roundTrip([
+      { n: 5, r: 0.5, z: 0, neg: -3, big: 1e21, s: 'plain', p: 'src/a/b.js' },
+      { n: 10, r: 0.8, z: 0, neg: -4, big: 2e21, s: 'names', p: 'src/c/d.js' },
+    ]);
+    expect(decoded[0]).toEqual({ n: 5, r: 0.5, z: 0, neg: -3, big: 1e21, s: 'plain', p: 'src/a/b.js' });
+    expect(decoded[1]).toEqual({ n: 10, r: 0.8, z: 0, neg: -4, big: 2e21, s: 'names', p: 'src/c/d.js' });
+  });
+
+  it('protects literal strings that start with the markers', () => {
+    const decoded = roundTrip([{ v: "'quoted" }, { v: '!important' }, { v: '!true' }, { v: '' }]);
+    expect(decoded.map((r) => r.v)).toEqual(["'quoted", '!important', '!true', '']);
+  });
+
+  it('does not prefix-expand literal @N values in interned columns', () => {
+    const rows = [
+        { file: 'src/utils/a.js' },
+        { file: 'src/utils/b.js' },
+        { file: 'src/utils/@0notes' },
+        { file: 'src/utils/@0/x' },
+      ],
+      compact = _encodeList(rows),
+      decoded = _decodeList(compact);
+    // Interning must still apply to genuine prefix matches…
+    expect(compact._prefixes).toBeDefined();
+    expect(decoded[0].file).toBe('src/utils/a.js');
+    // …but literal '@'-leading names must survive verbatim.
+    expect(decoded[2].file).toBe('src/utils/@0notes');
+    expect(decoded[3].file).toBe('src/utils/@0/x');
+  });
+
+  it('leaves lists with differing per-row object/array cells as JSON (compactResponse)', () => {
+    const data = {
+      total: 2,
+      affected_files: [
+        { path: 'src/a.ts', signals: ['call'] },
+        { path: 'src/b.ts', signals: ['import', 'cochange'] },
+      ],
+    };
+    const compacted = compactResponse(data);
+    // Not compacted — the array key survives structurally intact.
+    expect(compacted.affected_files).toBe(data.affected_files);
+    expect(expandResponse(compacted)).toEqual(data);
+    expect(autoFormat(data)).toBe('json');
+  });
+
+  it('still compacts and restores uniform object columns (hoisted whole)', () => {
+    const data = {
+      affected_files: [
+        { path: 'src/a.ts', meta: { repo: 'r1' } },
+        { path: 'src/b.ts', meta: { repo: 'r1' } },
+      ],
+    };
+    const compacted = compactResponse(data);
+    expect(compacted.affected_files._header).toEqual(['path']);
+    expect(expandResponse(compacted)).toEqual(data);
+  });
+
+  it('_isCompactable accepts primitive columns and rejects mixed non-primitive ones', () => {
+    expect(
+      _isCompactable([
+        { a: 1, b: 'x' },
+        { a: 2, b: 'y' },
+      ]),
+    ).toBe(true);
+    expect(_isCompactable([{ a: [1] }, { a: [2] }])).toBe(false);
+    expect(
+      _isCompactable([
+        { a: 1, u: { k: 1 } },
+        { a: 2, u: { k: 1 } },
+      ]),
+    ).toBe(true);
+  });
+
+  it('keeps legacy decode behavior for unmarked cells', () => {
+    // Hand-written / pre-marker compact data must decode as before.
+    const decoded = _decodeList({ _header: ['a', 'b', 'c'], _rows: ['42|hello|'] });
+    expect(decoded[0].a).toBe(42);
+    expect(decoded[0].b).toBe('hello');
+    expect(decoded[0].c).toBeNull();
+  });
+});

--- a/test/compression-mission-state.test.js
+++ b/test/compression-mission-state.test.js
@@ -32,6 +32,25 @@ describe('compressMissionState', () => {
     const result = compressMissionState({ sqlJson: makeSqlJson({}), missionId: 'm-1' });
     expect(result.summary).toMatch(/no compressible state/i);
     expect(result.tokensSaved).toBe(0);
+    expect(result.compressed).toBe('');
+  });
+
+  it('returns the compressed state itself, not just the bookkeeping (#284)', () => {
+    const sqlJson = makeSqlJson({
+        findings: [
+          {
+            title: 'Auth uses JWT',
+            content: 'JWT signed with HS256, validated in middleware.ts',
+            relevance: 'high',
+            status: 'verified',
+          },
+        ],
+      }),
+      result = compressMissionState({ sqlJson, missionId: 'm-1' });
+    expect(typeof result.compressed).toBe('string');
+    // The compressed output must carry the section content forward — it is
+    // the part the HTTP handler persists for later reads.
+    expect(result.compressed).toContain('Auth uses JWT');
   });
 
   it('aggregates findings, verdicts, and costs into a single summary', () => {

--- a/test/compression-persistence.test.js
+++ b/test/compression-persistence.test.js
@@ -1,0 +1,60 @@
+// Regression tests for issue #284: compressMissionState computed the
+// Compressed mission state and then discarded it — only summary/tokensSaved
+// Were returned and persisted, so the feature stored nothing recoverable.
+// Uses an isolated temp DB (LAPIS_HOME before any project module loads).
+const os = require('node:os'),
+  path = require('node:path'),
+  fs = require('node:fs');
+
+process.env.LAPIS_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-compression-284-'));
+
+const dbModule = require('../db'),
+  { recordCompressionRun } = require('../src/compression/persistence');
+
+beforeAll(() => {
+  dbModule.ensureDb();
+});
+
+describe('mission compression persistence (#284)', () => {
+  it('migration V26 adds the important_output column', () => {
+    const version = dbModule.sqlJson('PRAGMA user_version')[0].user_version;
+    expect(version).toBeGreaterThanOrEqual(26);
+    const columns = dbModule.sqlJson('PRAGMA table_info(mission_compression_log)').map((c) => c.name);
+    expect(columns).toContain('important_output');
+  });
+
+  it('recordCompressionRun persists the compressed state and it reads back', () => {
+    dbModule.sqlRun("INSERT INTO missions (id, description, status) VALUES ('m-284', 'test mission', 'planning')");
+    dbModule.sqlRun('DELETE FROM mission_compression_log WHERE mission_id = ?', ['m-284']);
+
+    recordCompressionRun({
+      missionId: 'm-284',
+      trigger: 'manual',
+      result: {
+        summary: '3 sections compressed. Kept head (2 lines)…',
+        compressed: '## Findings\nAuth uses JWT\n\n## Verdicts\n1 failed',
+        tokensSaved: 123,
+      },
+    });
+
+    const row = dbModule.sqlJson(
+      'SELECT summary, tokens_saved, important_output, error FROM mission_compression_log WHERE mission_id = ?',
+      ['m-284'],
+    )[0];
+    expect(row.summary).toContain('3 sections compressed');
+    expect(row.tokens_saved).toBe(123);
+    expect(row.important_output).toContain('Auth uses JWT');
+    expect(row.error).toBeNull();
+  });
+
+  it('recordCompressionRun tolerates a missing compressed field (legacy callers)', () => {
+    expect(() =>
+      recordCompressionRun({ missionId: 'm-284', trigger: 'manual', result: { summary: 's', tokensSaved: 1 } }),
+    ).not.toThrow();
+    const row = dbModule.sqlJson(
+      'SELECT important_output FROM mission_compression_log WHERE mission_id = ? ORDER BY id DESC LIMIT 1',
+      ['m-284'],
+    )[0];
+    expect(row.important_output).toBeNull();
+  });
+});

--- a/test/review-fixes.test.js
+++ b/test/review-fixes.test.js
@@ -43,12 +43,15 @@ describe('review fixes', () => {
             .some((c) => c.name === 'source_module'),
           churnCols = reopened.prepare('PRAGMA table_info(churn_metrics)').all(),
           hasTotalFilesChanged = churnCols.some((c) => c.name === 'total_files_changed'),
-          hasTopFilesJson = churnCols.some((c) => c.name === 'top_files_json');
-        expect(version).toBe(25);
+          hasTopFilesJson = churnCols.some((c) => c.name === 'top_files_json'),
+          compressionCols = reopened.prepare('PRAGMA table_info(mission_compression_log)').all(),
+          hasImportantOutput = compressionCols.some((c) => c.name === 'important_output');
+        expect(version).toBe(26);
         expect(table).toBeTruthy();
         expect(sourceModuleCol).toBe(true);
         expect(hasTotalFilesChanged).toBe(true);
         expect(hasTopFilesJson).toBe(true);
+        expect(hasImportantOutput).toBe(true);
       }
     });
   });


### PR DESCRIPTION
Second batch of fixes from the 2026-09-06 full-codebase review (follows #305). Two independent fixes, one commit each.

## 1. compact wire format: lossless round-trip (#283)

`decode(encode(obj)) === obj` was documented but false in four ways, all silently mutating LLM-facing payloads (`formatAnalysisForLlm`):

| input | old round-trip |
| --- | --- |
| `'1.10'` | `1.1` (numeric coercion) |
| `''` | `null` |
| `'@0notes'` in an interned column | `'src/utilsnotes'` (any `@N`-leading value was expanded) |
| per-row `signals: ['call']` / `['import','cochange']` | `'call'` / `'import,cochange'` (cells `String()`-ed) |

**Fix:** cells now carry minimal type markers. A string that is empty, marker-leading, numeric-looking, or `@`-leading without having been interned gets a literal-string marker (`'` prefix); booleans encode as `!true`/`!false`; interned refs stay unmarked so prefix expansion applies only to them. Decode strips markers first, then expansion/coercion — **legacy unmarked payloads decode exactly as before**. Lists whose columns mix differing per-row objects/arrays are no longer compacted at all (they stay as JSON — lossless); uniform object columns still hoist whole and restore as objects.

**Tests:** `test/compact-format-roundtrip.test.js` — every corruption case above plus interning regression, hoisted-object round-trip, and legacy-decode compatibility. All existing `wire-format.test.js` expectations pass unchanged.

## 2. compression: persist the compressed mission state (#284)

`compressMissionState` computed `compressed.importantOutput` and threw it away — the handler persisted only `summary`/`tokensSaved` into `mission_compression_log`, so the feature stored nothing recoverable while reporting token savings for content that no longer existed anywhere.

**Fix:** the result now carries `compressed`; `recordCompressionRun` persists it into a new `important_output` column (migration **V26**, with the repo's standard duplicate-column tolerance); the HTTP handler returns it to callers. Read-side consumers can follow later — the data finally survives the call.

**Tests:** `test/compression-persistence.test.js` (isolated temp DB: migration adds the column, round-trip through `recordCompressionRun`, legacy-caller tolerance), new assertions in `compression-mission-state.test.js`, and `review-fixes.test.js`'s migration ladder updated to V26 (now also asserting the new column).

## Verification

- Full suite: **142 files, 2029 tests passed**
- `npm run lint`: 0 errors; `npm run format:check`: clean

Fixes #283
Fixes #284