### PR TITLE
fix: P1 batch 3 — per-file index guards, derived-error surfacing, loopback-only keyless server

### DIFF
--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -63,6 +63,20 @@ function logDerivedError(step, e) {
   console.error(`[indexer] derived phase failed (${step}): ${e.message}`);
 }
 
+// Collects per-builder failures so indexRepository/reindexRepository can
+// report them (derived_errors + partial) instead of advertising success with
+// silently-empty graphs. Logging stays as before.
+function makeDerivedErrorCollector() {
+  const errors = [];
+  return {
+    errors,
+    log(step, e) {
+      logDerivedError(step, e);
+      errors.push({ builder: step, error: e instanceof Error ? e.message : String(e) });
+    },
+  };
+}
+
 function emitProgress(args, phase, detail, stats) {
   if (!args) {
     return;
@@ -361,7 +375,8 @@ function insertSymbols(repository, repoId, fileId, filePath, symbols) {
 }
 
 function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCount, changedFileIds, deletedFileIds) {
-  const stats = { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
+  const derivedErrors = makeDerivedErrorCollector(),
+    stats = { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
     useIncremental = Array.isArray(changedFileIds) && Array.isArray(deletedFileIds);
 
   if (useIncremental) {
@@ -380,7 +395,7 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
           importEdges = ig.edges;
         }
       } catch (e) {
-        logDerivedError('import-graph', e);
+        derivedErrors.log('import-graph', e);
       }
 
       // ── Scope resolution (v10) ────────────────────────────────
@@ -404,7 +419,7 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     });
     scopeResolved = sr.resolved;
   } catch (e) {
-    logDerivedError('scope-resolution', e);
+    derivedErrors.log('scope-resolution', e);
   }
 
   emitProgress(args, 'analysis', { step: 'build-call-graph', message: 'Step 5/5: building call graph...' }, stats);
@@ -426,7 +441,7 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
       callEdges = cg.calls;
     }
   } catch (e) {
-    logDerivedError('call-graph', e);
+    derivedErrors.log('call-graph', e);
   }
   emitProgress(
     args,
@@ -440,7 +455,7 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
       complexityCount = cc.symbols;
     }
   } catch (e) {
-    logDerivedError('complexity', e);
+    derivedErrors.log('complexity', e);
   }
 
   let relationEdges = 0,
@@ -457,7 +472,7 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
           relationEdges = re.count;
         }
       } catch (e) {
-        logDerivedError('relations', e);
+        derivedErrors.log('relations', e);
       }
 
       return 0;
@@ -469,7 +484,7 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
       cochangeEdges = cc2.count;
     }
   } catch (e) {
-    logDerivedError('cochange', e);
+    derivedErrors.log('cochange', e);
   }
 
   return {
@@ -480,6 +495,7 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     relationEdges,
     cochangeEdges,
     derived_scope: 'repo',
+    derived_errors: derivedErrors.errors,
   };
 }
 
@@ -596,6 +612,124 @@ function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, dele
     derived_scope: 'file',
     derived_files_changed: changedFileIds.length,
     derived_files_deleted: deletedFileIds.length,
+  };
+}
+
+function rebuildDerivedIncremental(db, repoId, args, stats, changedFileIds, deletedFileIds) {
+  const derivedErrors = makeDerivedErrorCollector();
+  emitProgress(
+    args,
+    'analysis',
+    {
+      step: 'build-import-graph',
+      message: `Step 5/5: incrementally rebuilding import graph for ${changedFileIds.length + deletedFileIds.length} affected files...`,
+    },
+    stats,
+  );
+
+  let importEdges = 0,
+    callEdges = 0,
+    complexityCount = 0,
+    scopeResolved = (() => {
+      try {
+        const ig = buildImportEdgesForFiles(db, repoId, changedFileIds, deletedFileIds);
+        if (ig.success) {
+          importEdges = ig.edges;
+        }
+      } catch (e) {
+        derivedErrors.log('import-graph-incremental', e);
+      }
+
+      // ── Scope resolution (v10) ────────────────────────────────
+
+      return 0;
+    })(),
+    relationEdges = (() => {
+      emitProgress(
+        args,
+        'analysis',
+        {
+          step: 'resolve-scopes',
+          message: 'Step 5/5: incrementally resolving scope bindings for affected files...',
+        },
+        stats,
+      );
+      try {
+        const sr = resolveScopeBindingsForFiles(db, repoId, changedFileIds, deletedFileIds);
+        scopeResolved = sr.resolved || 0;
+      } catch (e) {
+        derivedErrors.log('scope-resolution-incremental', e);
+      }
+
+      emitProgress(
+        args,
+        'analysis',
+        {
+          step: 'build-call-graph',
+          message: `Step 5/5: incrementally rebuilding call graph for affected files...`,
+        },
+        stats,
+      );
+      try {
+        const cg = buildCallEdgesForFiles(db, repoId, changedFileIds, deletedFileIds, {
+          onProgress: (p) => {
+            emitProgress(
+              args,
+              'analysis',
+              {
+                step: 'build-call-graph',
+                message: `Step 5/5: rebuilding call graph... ${p.filesProcessed}/${p.totalFiles} files, ${p.callsFound} calls`,
+              },
+              stats,
+            );
+          },
+        });
+        if (cg.success) {
+          callEdges = cg.calls;
+        }
+      } catch (e) {
+        derivedErrors.log('call-graph-incremental', e);
+      }
+
+      emitProgress(
+        args,
+        'analysis',
+        {
+          step: 'compute-complexity',
+          message: 'Step 5/5: incrementally computing complexity metrics...',
+        },
+        stats,
+      );
+      try {
+        const cc = buildComplexityMetricsForFiles(db, repoId, changedFileIds, deletedFileIds);
+        if (cc.success) {
+          complexityCount = cc.symbols;
+        }
+      } catch (e) {
+        derivedErrors.log('complexity-incremental', e);
+      }
+
+      return 0;
+    })();
+  try {
+    const re = buildRelationEdges(db, repoId);
+    if (re.success) {
+      relationEdges = re.count;
+    }
+  } catch (e) {
+    derivedErrors.log('relations-incremental', e);
+  }
+
+  return {
+    importEdges,
+    callEdges,
+    complexityCount,
+    scopeResolved,
+    relationEdges,
+    derived_scope: 'file',
+    derived_files_changed: changedFileIds.length,
+    derived_files_deleted: deletedFileIds.length,
+    derived_errors: derivedErrors.errors,
   };
 }
 
@@ -850,19 +984,26 @@ async function parsePhase(files, deps, repoId, args) {
           const workerInputs = validReads.map((r) => ({ filePath: r.filePath, content: r.content })),
             // oxlint-disable-next-line no-await-in-loop
             workerResults = await pool.parseAll(workerInputs),
-            symbolMap = new Map(workerResults.map((r) => [r.filePath, r.symbols]));
+            symbolMap = new Map(workerResults.map((r) => [r.filePath, r.symbols])),
+            workerErrors = new Map(workerResults.filter((r) => r.error).map((r) => [r.filePath, r.error]));
           for (const record of validReads) {
-            const symbols = symbolMap.get(record.filePath) || [],
+            const parseError = workerErrors.get(record.filePath),
+              symbols = parseError ? [] : symbolMap.get(record.filePath) || [],
               hotSymbols = (() => {
                 validateSymbols(record, symbols);
                 recordDiagnostic(
                   repository,
                   repoId,
                   record,
-                  symbols.length === 0 && record.content.trim().length > 0 ? 'zero_symbols' : 'ok',
-                  symbols.length === 0 && record.content.trim().length > 0
-                    ? 'No symbols extracted from non-empty file'
-                    : '',
+                  parseError
+                    ? 'error'
+                    : symbols.length === 0 && record.content.trim().length > 0
+                      ? 'zero_symbols'
+                      : 'ok',
+                  parseError ||
+                    (symbols.length === 0 && record.content.trim().length > 0
+                      ? 'No symbols extracted from non-empty file'
+                      : ''),
                   symbols.length,
                   { defer: args.deferIndexWrites },
                 );
@@ -883,41 +1024,57 @@ async function parsePhase(files, deps, repoId, args) {
       if (!useWorkers || parsedRecords.length === 0) {
         let parsedInBatch = 0;
         for (const record of validReads) {
-          const {
+          let hotSymbols, coldSymbols, tree;
+          try {
+            ({
               hot: hotSymbols,
               cold: coldSymbols,
               tree,
-            } = extractSymbolsSplit(record.filePath, registry, record.content),
-            symbols = hotSymbols,
-            absoluteDone = (() => {
-              validateSymbols(record, symbols);
-              recordDiagnostic(
-                repository,
-                repoId,
-                record,
-                symbols.length === 0 && record.content.trim().length > 0 ? 'zero_symbols' : 'ok',
-                symbols.length === 0 && record.content.trim().length > 0
-                  ? 'No symbols extracted from non-empty file'
-                  : '',
-                symbols.length,
-                { defer: args.deferIndexWrites },
-              );
-              parsedRecords.push({ record, hotSymbols, coldSymbols, tree });
-              parsedInBatch++;
+            } = extractSymbolsSplit(record.filePath, registry, record.content));
+          } catch (e) {
+            // One pathological file must not abort the whole index: record an
+            // Error diagnostic and skip it (same contract as the incremental
+            // path's per-file guard).
+            const message = e instanceof Error ? e.message : String(e);
+            skipped.push({ file: record.filePath, error: message });
+            recordDiagnostic(repository, repoId, record, 'error', `Symbol extraction failed: ${message}`, 0, {
+              defer: args.deferIndexWrites,
+            });
+            // oxlint-disable-next-line no-continue
+            continue;
+          }
+          {
+            const symbols = hotSymbols,
+              absoluteDone = (() => {
+                validateSymbols(record, symbols);
+                recordDiagnostic(
+                  repository,
+                  repoId,
+                  record,
+                  symbols.length === 0 && record.content.trim().length > 0 ? 'zero_symbols' : 'ok',
+                  symbols.length === 0 && record.content.trim().length > 0
+                    ? 'No symbols extracted from non-empty file'
+                    : '',
+                  symbols.length,
+                  { defer: args.deferIndexWrites },
+                );
+                parsedRecords.push({ record, hotSymbols, coldSymbols, tree });
+                parsedInBatch++;
 
-              return i + parsedInBatch;
-            })();
-          if (shouldEmitFileProgress(absoluteDone, totalFiles)) {
-            emitProgress(
-              args,
-              'parsing',
-              {
-                step: 'extract-symbols',
-                current_file: progressPath(record.filePath, repoRoot),
-                message: `Extracted symbols ${absoluteDone}/${totalFiles}: ${progressPath(record.filePath, repoRoot)} (${symbols.length} symbols)`,
-              },
-              { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
-            );
+                return i + parsedInBatch;
+              })();
+            if (shouldEmitFileProgress(absoluteDone, totalFiles)) {
+              emitProgress(
+                args,
+                'parsing',
+                {
+                  step: 'extract-symbols',
+                  current_file: progressPath(record.filePath, repoRoot),
+                  message: `Extracted symbols ${absoluteDone}/${totalFiles}: ${progressPath(record.filePath, repoRoot)} (${symbols.length} symbols)`,
+                },
+                { files_total: totalFiles, files_done: fileCount, symbols: symbolCount },
+              );
+            }
           }
         }
       }
@@ -1138,6 +1295,10 @@ async function indexRepository(deps, repoPath, repoName) {
       totalMs = Date.now() - t0,
       result = {
         success: true,
+        // Symbols are committed, but if any derived builder failed the graphs
+        // are incomplete — say so instead of advertising a clean success.
+        partial: (derived.derived_errors || []).length > 0,
+        derived_errors: derived.derived_errors || [],
         repo: repoName,
         path: absPath,
         files_indexed: parseResult.fileCount,
@@ -1555,6 +1716,8 @@ async function reindexRepository(deps, repo, mode = 'incremental') {
       repo,
       mode,
       name: repo,
+      partial: (derived.derived_errors || []).length > 0,
+      derived_errors: derived.derived_errors || [],
       file_count: reindexed + unchanged,
       symbol_count: (() => {
         try {

--- a/src/code-index/parse-worker.js
+++ b/src/code-index/parse-worker.js
@@ -1,6 +1,21 @@
 const { parentPort } = require('worker_threads'),
   codeParser = require('../../parse-code');
 
+// Parse a batch of files, isolating failures per file: one pathological
+// input must not throw out of the message handler (killing the worker and
+// with it every batch in flight across the pool).
+function parseFiles(files) {
+  const results = [];
+  for (const { filePath, content } of files) {
+    try {
+      results.push({ filePath, symbols: codeParser.parseContent(filePath, content) });
+    } catch (e) {
+      results.push({ filePath, symbols: [], error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  return results;
+}
+
 async function init() {
   try {
     await codeParser.init();
@@ -11,19 +26,20 @@ async function init() {
   parentPort.postMessage({ type: 'ready' });
 }
 
-parentPort.on('message', (msg) => {
-  if (msg.type === 'parse') {
-    const results = [];
-    for (const { filePath, content } of msg.files) {
-      const symbols = codeParser.parseContent(filePath, content);
-      results.push({ filePath, symbols });
+// parentPort only exists inside a worker thread; the guard keeps this module
+// require-able from the main thread (tests import parseFiles directly).
+if (parentPort) {
+  parentPort.on('message', (msg) => {
+    if (msg.type === 'parse') {
+      parentPort.postMessage({ type: 'results', id: msg.id, results: parseFiles(msg.files) });
     }
-    parentPort.postMessage({ type: 'results', id: msg.id, results });
-  }
 
-  if (msg.type === 'shutdown') {
-    process.exit(0);
-  }
-});
+    if (msg.type === 'shutdown') {
+      process.exit(0);
+    }
+  });
 
-init();
+  init();
+}
+
+module.exports = { parseFiles };

--- a/src/http/auth.js
+++ b/src/http/auth.js
@@ -60,6 +60,21 @@ function isAuthorized(req, apiKey) {
 function requireHttpAuth(apiKey) {
   return (req, res) => {
     if (!apiKey) {
+      // Unauthenticated server: refuse anything that is not addressed to this
+      // machine's loopback interface. This is what keeps a web page from
+      // driving the API (browsers always attach an Origin on cross-origin
+      // requests) and defeats DNS rebinding (Host would name the attacker's
+      // domain, not loopback).
+      const reason = assertLocalOnlyRequest(req);
+      if (reason) {
+        jsonError(
+          res,
+          403,
+          'forbidden',
+          `Local-only server: refused ${reason}. Set LAPIS_HTTP_API_KEY to enable authenticated remote use.`,
+        );
+        return false;
+      }
       return true;
     }
     if (req.method === 'GET' && new URL(req.url, 'http://localhost').pathname === '/health') {
@@ -73,11 +88,51 @@ function requireHttpAuth(apiKey) {
   };
 }
 
+// Hostnames that resolve to this machine's loopback interface.
+function isLoopbackHost(hostname) {
+  if (!hostname) {
+    return false;
+  }
+  const host = String(hostname).trim().toLowerCase().replace(/\.$/, ''),
+    bare = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  return (
+    bare === 'localhost' ||
+    bare.endsWith('.localhost') ||
+    bare === '::1' ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(bare)
+  );
+}
+
+// Returns null when the request is addressed locally, or a short reason
+// string when the unauthenticated server must refuse it.
+function assertLocalOnlyRequest(req) {
+  const hostHeader = headerValue(req.headers.host),
+    hostname = hostHeader ? hostHeader.replace(/:\d+$/, '').replace(/^\[/, '').replace(/\]$/, '') : '',
+    origin = headerValue(req.headers.origin);
+  if (!isLoopbackHost(hostname)) {
+    return `non-loopback Host "${hostHeader ?? ''}"`;
+  }
+  if (origin) {
+    try {
+      if (!isLoopbackHost(new URL(origin).hostname)) {
+        return `cross-origin Origin "${origin}"`;
+      }
+    } catch {
+      return `malformed Origin "${origin}"`;
+    }
+  }
+  return null;
+}
+
 function assertServeHostPolicy(host, apiKey) {
-  const unrestricted = host === '0.0.0.0' || host === '::';
-  if (unrestricted && !apiKey) {
+  if (apiKey) {
+    return;
+  }
+  // Any non-loopback bind is unrestricted — not just the literal 0.0.0.0/::
+  // wildcards. A LAN address like 192.168.1.5 exposes the API just the same.
+  if (!isLoopbackHost(host)) {
     throw new Error(
-      'Refusing to bind HTTP server to an unrestricted address without an API key. Pass --api-key, set LAPIS_HTTP_API_KEY, or bind to 127.0.0.1.',
+      'Refusing to bind HTTP server to a non-loopback address without an API key. Pass --api-key, set LAPIS_HTTP_API_KEY, or bind to 127.0.0.1.',
     );
   }
 }
@@ -87,5 +142,7 @@ module.exports = {
   isAuthorized,
   requireHttpAuth,
   assertServeHostPolicy,
+  assertLocalOnlyRequest,
+  isLoopbackHost,
   keysMatch,
 };

--- a/src/http/server.js
+++ b/src/http/server.js
@@ -1,7 +1,7 @@
 const http = require('http'),
   { matchRoute } = require('./routes'),
   { jsonError } = require('./errors'),
-  { resolveHttpApiKey, requireHttpAuth, assertServeHostPolicy } = require('./auth'),
+  { resolveHttpApiKey, requireHttpAuth, assertServeHostPolicy, isLoopbackHost } = require('./auth'),
   MAX_BODY_BYTES = 1024 * 1024;
 
 function createHttpServer(deps) {
@@ -247,8 +247,8 @@ async function startHttpServer(opts) {
       apiKey,
     });
 
-  if (host === '0.0.0.0') {
-    console.log('[lapis serve] WARNING: binding to 0.0.0.0 exposes memory APIs on your network.');
+  if (!isLoopbackHost(host)) {
+    console.log(`[lapis serve] WARNING: binding to ${host} exposes memory APIs beyond this machine.`);
     console.log('[lapis serve] Use only on trusted networks or behind a proxy.');
     if (apiKey) {
       console.log('[lapis serve] API key authentication is enabled (x-api-key or Authorization: Bearer).');

--- a/test/derived-errors-surface.test.js
+++ b/test/derived-errors-surface.test.js
@@ -1,0 +1,49 @@
+// Regression test for issue #287: derived-builder failures were reduced to a
+// console line, so a "successful" index could report success with silently
+// empty graphs. The indexer now collects thrown builder failures into
+// `derived_errors` on the returned stats (vi.mock does not intercept this
+// repo's CJS require graph, so this drives the real builders with a db that
+// makes them throw).
+const dbModule = require('../db');
+
+// No test file may create the real user DB in CI, but the db module needs a
+// resolvable path; isolate it before first require already happened above —
+// ensureDb is never called here, only builder code paths that throw.
+const brokenDb = {};
+
+describe('derived-builder failures are surfaced (#287)', () => {
+  it('collects thrown repo-wide builder failures into derived_errors instead of throwing', async () => {
+    const { derivedPhase } = require('../src/code-index/incremental-indexer');
+    const stats = await derivedPhase(brokenDb, 'repo-x', null, 10, 5, 20);
+
+    // A broken db makes the builders that do not swallow errors internally
+    // throw; those throws must land in derived_errors, not vanish.
+    expect(Array.isArray(stats.derived_errors)).toBe(true);
+    expect(stats.derived_errors.length).toBeGreaterThanOrEqual(1);
+    for (const entry of stats.derived_errors) {
+      expect(typeof entry.builder).toBe('string');
+      expect(entry.error).toContain('prepare is not a function');
+    }
+    expect(stats.derived_scope).toBe('repo');
+  });
+
+  it('collects thrown incremental builder failures too', async () => {
+    const { derivedPhase } = require('../src/code-index/incremental-indexer');
+    const stats = await derivedPhase(brokenDb, 'repo-x', null, 10, 5, 20, [1, 2], [3]);
+
+    expect(Array.isArray(stats.derived_errors)).toBe(true);
+    expect(stats.derived_errors.length).toBeGreaterThanOrEqual(1);
+    expect(stats.derived_errors.some((e) => e.builder.includes('incremental'))).toBe(true);
+  });
+
+  it('reports an empty derived_errors array on a clean run', async () => {
+    process.env.LAPIS_HOME =
+      process.env.LAPIS_HOME ||
+      require('node:fs').mkdtempSync(require('node:path').join(require('node:os').tmpdir(), 'lapis-derived-clean-'));
+    dbModule.ensureDb();
+    delete require.cache[require.resolve('../src/code-index/incremental-indexer')];
+    const { derivedPhase } = require('../src/code-index/incremental-indexer');
+    const stats = await derivedPhase(dbModule.getDb(), 'repo-missing', null, 0, 0, 0);
+    expect(stats.derived_errors).toEqual([]);
+  });
+});

--- a/test/http-local-only.test.js
+++ b/test/http-local-only.test.js
@@ -1,0 +1,131 @@
+// Regression tests for issue #285: the default (no API key) HTTP server
+// accepted any Host header and any Origin, so a web page the developer
+// visits could drive the API with a no-cors fetch, and DNS rebinding could
+// make responses readable. Without a key the server is now loopback-only:
+// non-loopback Host headers and cross-origin Origins are refused, and
+// non-loopback binds are refused at startup.
+const { createHttpServer } = require('../src/http/server'),
+  http = require('http');
+
+function request(server, { method = 'GET', path = '/health', headers = {} } = {}) {
+  return new Promise((resolve, reject) => {
+    const addr = server.address(),
+      req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: addr.port,
+          path,
+          method,
+          headers,
+        },
+        (res) => {
+          let body = '';
+          res.on('data', (chunk) => (body += chunk));
+          res.on('end', () => resolve({ status: res.statusCode, body }));
+        },
+      );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('local-only enforcement without an API key (#285)', () => {
+  let server;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+      server = null;
+    }
+  });
+
+  function startNoKeyServer() {
+    server = createHttpServer({
+      repositories: { aurex: {} },
+      sqlJson: () => [],
+      sqlRun: () => {},
+      apiKey: null,
+    });
+    return new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  }
+
+  it('serves loopback-addressed requests without a key', async () => {
+    await startNoKeyServer();
+    const res = await request(server, { path: '/health' });
+    expect(res.status).toBe(200);
+  });
+
+  it('refuses a non-loopback Host header (DNS-rebinding shape)', async () => {
+    await startNoKeyServer();
+    const res = await request(server, { path: '/health', headers: { host: 'evil.example' } });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain('Local-only');
+  });
+
+  it('refuses cross-origin Origin headers (browser drive-by shape)', async () => {
+    await startNoKeyServer();
+    const res = await request(server, {
+      method: 'POST',
+      path: '/dispatch',
+      headers: { 'content-type': 'text/plain', origin: 'https://evil.example' },
+    });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain('cross-origin');
+  });
+
+  it('allows same-machine Origins (loopback dev servers)', async () => {
+    await startNoKeyServer();
+    const res = await request(server, {
+      path: '/health',
+      headers: { origin: 'http://localhost:5173' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('a configured API key supersedes the local-only checks', async () => {
+    server = createHttpServer({
+      repositories: { aurex: {} },
+      sqlJson: () => [],
+      sqlRun: () => {},
+      apiKey: 'test-key',
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const res = await request(server, {
+      path: '/health',
+      headers: { host: 'evil.example', 'x-api-key': 'test-key' },
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('serve host policy covers every non-loopback address (#285)', () => {
+  const { assertServeHostPolicy, isLoopbackHost } = require('../src/http/auth');
+
+  it('refuses LAN addresses without an API key, not just 0.0.0.0', () => {
+    expect(() => assertServeHostPolicy('192.168.1.5', null)).toThrow(/API key/);
+    expect(() => assertServeHostPolicy('10.0.0.1', null)).toThrow(/API key/);
+  });
+
+  it('still allows loopback binds without an API key', () => {
+    expect(() => assertServeHostPolicy('127.0.0.1', null)).not.toThrow();
+    expect(() => assertServeHostPolicy('localhost', null)).not.toThrow();
+    expect(() => assertServeHostPolicy('::1', null)).not.toThrow();
+  });
+
+  it('allows any bind when an API key is configured', () => {
+    expect(() => assertServeHostPolicy('192.168.1.5', 'test-key')).not.toThrow();
+    expect(() => assertServeHostPolicy('0.0.0.0', 'test-key')).not.toThrow();
+  });
+
+  it('classifies loopback hostnames', () => {
+    expect(isLoopbackHost('127.0.0.1')).toBe(true);
+    expect(isLoopbackHost('127.127.0.3')).toBe(true);
+    expect(isLoopbackHost('localhost')).toBe(true);
+    expect(isLoopbackHost('api.localhost')).toBe(true);
+    expect(isLoopbackHost('::1')).toBe(true);
+    expect(isLoopbackHost('[::1]')).toBe(true);
+    expect(isLoopbackHost('evil.example')).toBe(false);
+    expect(isLoopbackHost('127.0.0.1.evil.example')).toBe(false);
+    expect(isLoopbackHost('')).toBe(false);
+  });
+});

--- a/test/parse-phase-perfile.test.js
+++ b/test/parse-phase-perfile.test.js
@@ -1,0 +1,85 @@
+// Regression tests for issue #286: one file that makes symbol extraction
+// throw aborted the entire full index — the sequential fallback loop had no
+// per-file guard, so a single RangeError from a pathological file failed the
+// whole run. Extraction failures must now be isolated per file.
+const fs = require('node:fs'),
+  os = require('node:os'),
+  path = require('node:path');
+
+describe('parsePhase sequential per-file guard (#286)', () => {
+  it('skips a throwing file with an error diagnostic and still parses the rest', async () => {
+    const incremental = require('../src/code-index/incremental-indexer'),
+      { createParserRegistry } = require('../src/code-index/parser-registry'),
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-parse-phase-'));
+    try {
+      for (const name of ['good1.js', 'boom.js', 'good2.js']) {
+        fs.writeFileSync(path.join(dir, name), 'function example() {\n  return 1;\n}\n');
+      }
+
+      const realRegistry = createParserRegistry();
+      expect(await realRegistry.ensureReady()).toBe(true);
+      // A plain delegating wrapper (not a Proxy — the real registry's methods
+      // are non-configurable, which breaks Proxy invariants): any call that
+      // receives the boom file path throws, simulating the pathological-file
+      // RangeError from the issue without depending on tree-sitter internals.
+      const registry = {};
+      for (let obj = realRegistry; obj && obj !== Object.prototype; obj = Object.getPrototypeOf(obj)) {
+        for (const key of Object.getOwnPropertyNames(obj)) {
+          if (key === 'constructor' || key in registry) {
+            continue;
+          }
+          const d = Object.getOwnPropertyDescriptor(obj, key);
+          if (typeof d.value === 'function') {
+            registry[key] = function (...args) {
+              if (args.some((a) => typeof a === 'string' && a.endsWith('boom.js'))) {
+                throw new Error('simulated parser crash');
+              }
+              return d.value.apply(realRegistry, args);
+            };
+          } else if (d.get) {
+            Object.defineProperty(registry, key, { get: () => realRegistry[key], configurable: true });
+          } else {
+            registry[key] = d.value;
+          }
+        }
+      }
+
+      const diagnostics = [],
+        repository = {
+          upsertFileDiagnostic: (d) => diagnostics.push(d),
+          insertFile: () => 1,
+          insertSymbolBulk: () => {},
+          insertSymbolBatch: () => {},
+          insertSymbol: () => {},
+        },
+        result = await incremental.parsePhase(
+          [path.join(dir, 'good1.js'), path.join(dir, 'boom.js'), path.join(dir, 'good2.js')],
+          { parserRegistry: registry, repository },
+          'repo-1',
+          {}, // store mode: the error diagnostic must be recorded immediately
+        );
+
+      expect(result.fileCount).toBe(2);
+      const boomSkip = result.skipped.find((s) => s.file.endsWith('boom.js'));
+      expect(boomSkip).toBeDefined();
+      expect(boomSkip.error).toContain('simulated parser crash');
+      const boomDiag = diagnostics.find((d) => d.filePath.endsWith('boom.js'));
+      expect(boomDiag.status).toBe('error');
+      expect(boomDiag.message).toContain('simulated parser crash');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it('parse-worker is require-able from the main thread and isolates per file', () => {
+    // The parentPort guard keeps the worker module side-effect-free when
+    // loaded outside a worker thread; parseFiles is the same per-file guard
+    // the worker message handler uses.
+    const worker = require('../src/code-index/parse-worker');
+    expect(typeof worker.parseFiles).toBe('function');
+    const results = worker.parseFiles([{ filePath: '/repo/good.js', content: 'function f() {\n}\n' }]);
+    expect(results).toHaveLength(1);
+    expect(results[0].filePath).toBe('/repo/good.js');
+    expect(results[0].error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Third batch from the 2026-09-06 full-codebase review (after #305, #306). Two commits, three issues fixed, tests included.

## 1. indexer: one bad file no longer aborts the whole index (#286)

The full-index sequential fallback loop had **no per-file try/catch** — a single file that made symbol extraction throw (deeply nested AST → stack overflow in the recursive tree walker) failed the entire `index-repo`, deterministically, on every retry. The parse-worker message handler was equally unguarded: one throw killed the worker and `worker-pool` then rejected every batch in flight across the pool.

**Fix:** extraction is wrapped per file in both places. A failing file records an `'error'` diagnostic (visible in `getCodeRepoHealth`, which already counts `error` diagnostics) and the run continues. `parse-worker.js` also gained a `parentPort` guard and an exported `parseFiles` so the per-file guard is require-able and testable from the main thread.

## 2. indexer: derived-builder failures are surfaced, not swallowed (#287)

Every derived-graph builder's failure (imports, scopes, calls, complexity, relations, cochange — repo-wide **and** incremental variants) was reduced to a console line, so a run whose builders all failed reported `success: true` with `import_edges: 0` etc. — and the `partial: true` path was unreachable.

**Fix:** both rebuild functions collect failures into `derived_errors: [{builder, error}]`; `indexRepository`/`reindexRepository` include it in the result and set `partial: true` when any builder failed. Callers and the HTTP/tool layers can now distinguish a complete index from an incomplete one.

## 3. http: keyless server is loopback-only (#285)

With no API key (the default), the gateway accepted any Host and any Origin. Live-verified before this fix: a `POST /dispatch` with `Content-Type: text/plain` and `Origin: https://evil.example` executed — the exact shape a browser sends with a no-cors fetch, no preflight required; DNS rebinding made responses readable too, including `GET /settings/:key` (integration tokens).

**Fix (default-posture change):**
- No key → requests whose `Host` header is not loopback are refused (403, kills DNS rebinding); requests with a present-but-non-loopback `Origin` are refused (403, kills browser drive-by; curl/agents send no Origin). Loopback dev-server origins (`http://localhost:5173`) keep working.
- A configured API key **supersedes both checks** — authenticated remote use is unchanged.
- `assertServeHostPolicy` now refuses **every** non-loopback bind without a key (previously only literal `0.0.0.0`/`::`), and the startup exposure warning covers the same set.

## Tests

- `test/parse-phase-perfile.test.js` — throwing registry for one file: the other files still parse, the bad file lands in `skipped` + an `'error'` diagnostic; worker module guard.
- `test/derived-errors-surface.test.js` — builder throws land in `derived_errors` (repo-wide + incremental), clean run reports `[]`.
- `test/http-local-only.test.js` — loopback served keyless; non-loopback Host 403; cross-origin Origin 403; loopback Origin allowed; key supersedes; host-policy unit tests.

Full suite: **145 files / 2043 tests passed**. `npm run lint`: 0 errors; `npm run format:check`: clean.

Fixes #285
Fixes #286
Fixes #287