### PR TITLE
fix: P2 batch 4 — retryable gateway init, main-thread dream guard, daemon timeout, hermes allowlist, proto-safe maps

### DIFF
--- a/extensions/memory-layer/host/memory-client.ts
+++ b/extensions/memory-layer/host/memory-client.ts
@@ -109,6 +109,12 @@ async function memViaChildProcess(
 }
 
 export async function memCmd(cmd: string): Promise<MemResult | null> {
+  // Same contract as mem(): blocking commands (dream, reindex, …) must always
+  // take the child-process path — running them through the in-process gateway
+  // freezes the UI thread for the whole multi-phase cycle.
+  if (MAIN_THREAD_BLOCKING_COMMANDS.has(cmd)) {
+    return memViaChildProcess(cmd, {});
+  }
   const dispatch = await getInProcessDispatch();
   if (dispatch) {
     try {

--- a/src/claude-code/dispatch-client.js
+++ b/src/claude-code/dispatch-client.js
@@ -41,6 +41,11 @@ function loadDirectDispatch() {
   return _directDispatch;
 }
 
+// A daemon that accepts the connection but never responds (wedged event
+// loop, stuck write) must degrade to the direct-mode fallback instead of
+// hanging the calling hook until the external timeout kills it.
+const DAEMON_TIMEOUT_MS = 5000;
+
 /**
  * POST to a running daemon. Injectable fetch/http for tests.
  */
@@ -59,6 +64,7 @@ async function dispatchViaDaemon(baseUrl, cmd, args, opts = {}) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
+        signal: opts.timeoutMs === null ? undefined : AbortSignal.timeout(opts.timeoutMs ?? DAEMON_TIMEOUT_MS),
       });
     if (!res.ok) {
       let message = `Daemon dispatch failed (${res.status})`;

--- a/src/cli/gateway.js
+++ b/src/cli/gateway.js
@@ -136,7 +136,13 @@ async function dispatch(cmd, args) {
             });
           }
         }
-      })();
+      })().catch((e) => {
+        // A rejected init must not be cached forever: drop it so the next
+        // dispatch re-runs initialization (a transient locked-DB error at
+        // startup would otherwise brick every MCP tool call until restart).
+        _initPromise = null;
+        throw e;
+      });
     }
     await _initPromise;
   }

--- a/src/hermes/install.js
+++ b/src/hermes/install.js
@@ -148,6 +148,12 @@ function mergeAllowlist(filePath, command) {
   } catch {
     data = { approvals: [] };
   }
+  // JSON.parse succeeds for any valid JSON — including `null` and scalars,
+  // which would crash the approvals access below. Degrade to a fresh
+  // allowlist, same as a parse failure.
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    data = { approvals: [] };
+  }
   if (!Array.isArray(data.approvals)) {
     data.approvals = [];
   }

--- a/src/token-saver/rules/list-output.js
+++ b/src/token-saver/rules/list-output.js
@@ -18,7 +18,9 @@ const COLLAPSE_DIRS = [
 function compressListOutput({ stdout, stderr }) {
   const combined = `${stdout}\n${stderr}`.trim(),
     lines = combined ? combined.split('\n') : undefined,
-    sourceDirs = combined ? {} : undefined,
+    // Object.create(null): top dirs come from arbitrary tool output
+    // ('__proto__' must not pollute Object.prototype) (#299).
+    sourceDirs = combined ? Object.create(null) : undefined,
     collapsed = combined ? {} : undefined;
   if (!combined) {
     return {

--- a/src/token-saver/rules/logs.js
+++ b/src/token-saver/rules/logs.js
@@ -5,7 +5,9 @@ function compressLogs({ stdout, stderr }) {
   const combined = `${stdout}\n${stderr}`.trim(),
     lines = combined ? combined.split('\n') : undefined,
     errors = combined ? [] : undefined,
-    uniqueMessages = combined ? {} : undefined;
+    // Object.create(null): log lines are arbitrary tool output — a line
+    // reading '__proto__' must not touch Object.prototype (#299).
+    uniqueMessages = combined ? Object.create(null) : undefined;
   if (!combined) {
     return {
       summary: 'No log output.',

--- a/src/token-saver/rules/search.js
+++ b/src/token-saver/rules/search.js
@@ -4,7 +4,9 @@ const MAX_MATCHES_PER_FILE = 10,
 function compressSearchOutput({ stdout, stderr, commandArgs }) {
   const combined = `${stdout}\n${stderr}`.trim(),
     lines = combined ? combined.split('\n') : undefined,
-    fileMap = combined ? {} : undefined,
+    // Object.create(null): file paths come from arbitrary tool output
+    // ('__proto__' must not pollute Object.prototype) (#299).
+    fileMap = combined ? Object.create(null) : undefined,
     headerLines = [];
   if (!combined) {
     return {

--- a/test/p2-batch4-fixes.test.js
+++ b/test/p2-batch4-fixes.test.js
@@ -1,0 +1,140 @@
+// Regression tests for review batch 4: #289 (cached rejected gateway init),
+// #290 (memCmd bypassing MAIN_THREAD_BLOCKING_COMMANDS), #297 (daemon POST
+// without a timeout), #298 (hermes allowlist crash on null JSON), and
+// #299 (prototype pollution via token-saver rule maps).
+const fs = require('node:fs'),
+  http = require('node:http'),
+  os = require('node:os'),
+  path = require('node:path');
+
+process.env.LAPIS_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-p2-batch4-'));
+
+describe('#289 gateway init failure is retryable', () => {
+  it('re-runs init after a transient failure instead of caching the rejection', async () => {
+    const dbModule = require('../db'),
+      gateway = require('../src/cli/gateway'),
+      originalEnsureDb = dbModule.ensureDb;
+    dbModule.ensureDb = () => {
+      throw new Error('transient lock at startup');
+    };
+    try {
+      await expect(gateway.dispatch('search', {})).rejects.toThrow('transient lock at startup');
+    } finally {
+      dbModule.ensureDb = originalEnsureDb;
+    }
+    // Without the fix, this call re-awaited the same cached rejection forever.
+    const result = await gateway.dispatch('search', {});
+    expect(result).toBeDefined();
+    expect(JSON.stringify(result)).not.toContain('transient lock at startup');
+  });
+});
+
+describe('#290 memCmd honors MAIN_THREAD_BLOCKING_COMMANDS', () => {
+  it('routes blocking commands to the child-process path before any in-process dispatch', () => {
+    const fsMod = require('node:fs'),
+      src = fsMod.readFileSync(
+        path.join(__dirname, '..', 'extensions', 'memory-layer', 'host', 'memory-client.ts'),
+        'utf8',
+      ),
+      body = src.slice(src.indexOf('export async function memCmd')),
+      dispatchCall = body.indexOf('getInProcessDispatch()');
+    expect(dispatchCall).toBeGreaterThan(-1);
+    // The blocking gate must appear before the in-process dispatch lookup,
+    // and route to memViaChildProcess like mem() does.
+    const gate = body.indexOf('MAIN_THREAD_BLOCKING_COMMANDS.has(cmd)');
+    expect(gate).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(dispatchCall);
+    expect(body).toContain('return memViaChildProcess(cmd, {});');
+  });
+});
+
+describe('#297 daemon dispatch timeout falls back to direct mode', () => {
+  it('aborts a stalled daemon POST and rejects', async () => {
+    const { dispatchViaDaemon } = require('../src/claude-code/dispatch-client'),
+      hanging = http.createServer(() => {}); // accepts connections, never responds
+    await new Promise((resolve) => hanging.listen(0, '127.0.0.1', resolve));
+    try {
+      const url = `http://127.0.0.1:${hanging.address().port}`;
+      await expect(dispatchViaDaemon(url, 'search', { query: 'x' }, { timeoutMs: 250 })).rejects.toThrow();
+    } finally {
+      hanging.close();
+    }
+  }, 15000);
+
+  it('falls back to the direct dispatcher when the daemon wedges', async () => {
+    const { dispatch } = require('../src/claude-code/dispatch-client'),
+      hanging = http.createServer(() => {});
+    await new Promise((resolve) => hanging.listen(0, '127.0.0.1', resolve));
+    try {
+      const url = `http://127.0.0.1:${hanging.address().port}`,
+        result = await dispatch(
+          'search',
+          { query: 'x' },
+          {
+            resolveDaemonUrl: () => url,
+            directDispatch: (cmd) => ({ via: 'direct', cmd }),
+            timeoutMs: 300,
+          },
+        );
+      expect(result.via).toBe('direct');
+    } finally {
+      hanging.close();
+    }
+  }, 15000);
+});
+
+describe('#298 hermes mergeAllowlist tolerates non-object JSON', () => {
+  const { mergeAllowlist } = require('../src/hermes/install'),
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-allowlist-'));
+
+  it('degrades a null allowlist file instead of crashing', () => {
+    const file = path.join(dir, 'null.json');
+    fs.writeFileSync(file, 'null');
+    expect(() => mergeAllowlist(file, 'lapis hook cmd')).not.toThrow();
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(Array.isArray(data.approvals)).toBe(true);
+    expect(data.approvals.length).toBeGreaterThan(0);
+  });
+
+  it('degrades a scalar allowlist file instead of silently dropping approvals', () => {
+    const file = path.join(dir, 'scalar.json');
+    fs.writeFileSync(file, '"weird"');
+    expect(() => mergeAllowlist(file, 'lapis hook cmd')).not.toThrow();
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(Array.isArray(data.approvals)).toBe(true);
+    expect(data.approvals.length).toBeGreaterThan(0);
+  });
+
+  it('still merges into an existing valid allowlist', () => {
+    const file = path.join(dir, 'valid.json');
+    fs.writeFileSync(file, JSON.stringify({ approvals: [{ event: 'on_session_start', command: 'lapis hook cmd' }] }));
+    expect(() => mergeAllowlist(file, 'lapis hook cmd')).not.toThrow();
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    // Deduped: no duplicate entry for the same event+command.
+    expect(data.approvals.filter((a) => a.event === 'on_session_start')).toHaveLength(1);
+  });
+});
+
+describe('#299 token-saver rule maps are prototype-pollution safe', () => {
+  it('compressLogs ignores __proto__ log lines without polluting Object.prototype', () => {
+    const { compressLogs } = require('../src/token-saver/rules/logs'),
+      out = compressLogs({ stdout: '__proto__\nplain line\n__proto__\nplain line', stderr: '' });
+    expect(out).toBeDefined();
+    expect({}.count).toBeUndefined();
+    expect(Object.prototype.count).toBeUndefined();
+  });
+
+  it('compressSearchOutput keeps a __proto__ file path instead of dropping it', () => {
+    const { compressSearchOutput } = require('../src/token-saver/rules/search'),
+      out = compressSearchOutput({ stdout: '__proto__:12: some match here\n', stderr: '', commandArgs: ['needle'] });
+    expect(JSON.stringify(out)).toContain('some match here');
+    expect({}.polluted).toBeUndefined();
+  });
+
+  it('compressListOutput tolerates a __proto__ directory', () => {
+    const { compressListOutput } = require('../src/token-saver/rules/list-output'),
+      out = compressListOutput({ stdout: '__proto__\nsrc\n', stderr: '' });
+    expect(out).toBeDefined();
+    expect({}.polluted).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fourth batch from the 2026-09-06 full-codebase review. Five small fixes, one commit per issue, each with regression tests in `test/p2-batch4-fixes.test.js`.

## #289 — gateway: one transient init failure bricked every MCP tool call
`dispatch()` cached `_initPromise` and never cleared it on rejection: a single startup error (locked DB, FS hiccup) made every subsequent `tools/call` re-await the same rejected promise until restart. The promise now clears itself on rejection so the next dispatch re-runs init.
**Test:** monkey-patched `ensureDb` throws once → first dispatch rejects, second succeeds against the isolated DB.

## #290 — pi-extension: `dream` ran on Pi's main thread
`memCmd()` never consulted `MAIN_THREAD_BLOCKING_COMMANDS`, and it is the path used for dream (passive-capture's turn-50 auto-dream, memory tools) — so the whole multi-phase Dream Cycle ran synchronously in-process, exactly what the blocking set exists to prevent. `memCmd` now applies the same gate as `mem()` and delegates to the child-process path (ABI-safe since #277).
**Test:** source-level assertion (per `memory-client-dispatch.test.ts` conventions) that the gate precedes the in-process dispatch and routes to `memViaChildProcess`.

## #297 — claude-code: a wedged daemon hung every hook
`dispatchViaDaemon` had no timeout and the direct-mode fallback only fires when fetch *throws* — a daemon that accepts but never responds hung hooks until Claude Code's external timeout killed them (blank context injection, lost Stop/SessionEnd captures). The POST now carries an `AbortSignal.timeout` (5s default; `opts.timeoutMs` to override, `null` to disable); an abort degrades to the existing direct fallback.
**Tests:** a real never-responding server — `dispatchViaDaemon` rejects; `dispatch()` falls back to the direct dispatcher.

## #298 — hermes: `install` crashed on a `null` allowlist file
`JSON.parse` succeeds for any valid JSON, so `shell-hooks-allowlist.json` containing `null` crashed `mergeAllowlist` with a raw TypeError and aborted install before writing config. Parsed non-objects now degrade to a fresh allowlist (same as a parse failure); valid files still merge deduped.
**Tests:** `null`, scalar, and valid-file cases.

## #299 — token-saver: `__proto__` log lines polluted `Object.prototype`
The logs/search/list rules keyed plain objects by arbitrary tool output; a line reading `__proto__` set `Object.prototype.count = NaN` process-wide (verified) and `__proto__` entries silently vanished from output. All three maps are now `Object.create(null)`.
**Tests:** pollution assertions plus output-content checks for each rule.

## Verification
- Full suite: **146 files / 2053 tests passed**
- `npm run lint`: 0 errors; `npm run format:check`: clean

Fixes #289
Fixes #290
Fixes #297
Fixes #298
Fixes #299