### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
   # ── Gate: validate the packed tarball as a real consumer would install it ──
   # (builds better-sqlite3, exercises the bin, audits the prod tree)
   pack-verify:
+    permissions:
+      contents: read
     uses: ./.github/workflows/pack-verify.yml
 
   # ── Gate: lint + test must pass before publish ──


### PR DESCRIPTION
Potential fix for [https://github.com/GeneGulanesJr/LaPis/security/code-scanning/30](https://github.com/GeneGulanesJr/LaPis/security/code-scanning/30)

Add an explicit `permissions` block to the `pack-verify` job in `.github/workflows/publish.yml` (the reusable workflow call). The least-privilege baseline for a verification gate is typically `contents: read`. This addresses the specific CodeQL finding at line 11 without changing workflow behavior.

Concretely:
- File: `.github/workflows/publish.yml`
- Region: `jobs.pack-verify` block
- Change: insert
  ```yml
  permissions:
    contents: read
  ```
  directly under `pack-verify:` and before `uses:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
