### PR TITLE
Potential fix for code scanning alert no. 19: Bad HTML filtering regexp

### DIFF
--- a/src/doc-index/html-parser.js
+++ b/src/doc-index/html-parser.js
@@ -19,8 +19,8 @@ function classifyHtmlRole(title, content, classAttrs) {
 
 function stripHtmlTags(html) {
   return html
-    .replace(/<script[\s\S]*?<\/script\s*>/gi, '')
-    .replace(/<style[\s\S]*?<\/style\s*>/gi, '')
+    .replace(/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi, '')
+    .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, '')
     .replace(/<[^>]+>/g, ' ')
     .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')


### PR DESCRIPTION
Potential fix for [https://github.com/GeneGulanesJr/LaPis/security/code-scanning/19](https://github.com/GeneGulanesJr/LaPis/security/code-scanning/19)

Best general fix: avoid custom HTML filtering regex and use a robust HTML parser/sanitizer library.  
Within the shown snippet (and minimizing functional change), the best direct fix is to make the script/style stripping regexes accept malformed closing tags with extra non-`>` characters before `>`, as CodeQL recommends.

In `src/doc-index/html-parser.js`, update `stripHtmlTags`:

- Replace:
  - `/<script[\s\S]*?<\/script\s*>/gi`
  - `/<style[\s\S]*?<\/style\s*>/gi`
- With patterns that allow invalid-but-browser-tolerated end tags:
  - `/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi`
  - `/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi`

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
