### PR TITLE
Potential fix for code scanning alert no. 20: Inefficient regular expression

### DIFF
--- a/src/agent-intel/stale-flags.js
+++ b/src/agent-intel/stale-flags.js
@@ -25,7 +25,7 @@ const ONE_SIDED_IF_PATTERNS = [
   /\bif\s*\(\s*![^)]+\)\s*\{\s*\/(?:\/|\*)[^\}]*\}\s*else/g,
   // if (constant_expression) { never_runs(); } else { always_runs(); }
   // Detect when if body clearly never executes (throw, return, etc.)
-  /\bif\s*\(\s*(?:true|false|1\s*==\s*1|0\s*==\s*1)\s*\)\s*\{(?:\s| |\n)*(?:return|throw|break|continue)[^}]*\}\s*else/g,
+  /\bif\s*\(\s*(?:true|false|1\s*==\s*1|0\s*==\s*1)\s*\)\s*\{\s*(?:return|throw|break|continue)[^}]*\}\s*else/g,
 ];
 
 const ALWAYS_TRUE_CONTEXT = ['process.env.NODE_ENV', 'process.env.DEBUG', 'process.env.TESTING'];


### PR DESCRIPTION
Potential fix for [https://github.com/GeneGulanesJr/LaPis/security/code-scanning/20](https://github.com/GeneGulanesJr/LaPis/security/code-scanning/20)

The best fix is to replace the ambiguous repeated alternation `(?:\s| |\n)*` with a single, non-overlapping whitespace matcher. Since `\s` already includes space and newline in JavaScript, the simplest equivalent is `\s*`.

**Change required:** in `src/agent-intel/stale-flags.js`, update the regex on line 28 in `ONE_SIDED_IF_PATTERNS`:
- from: `\)\s*\{(?:\s| |\n)*(?:return|throw|break|continue)...`
- to: `\)\s*\{\s*(?:return|throw|break|continue)...`

No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
