### PR TITLE
fix: P2 batch 6 — cochange scale, deferred-index memory, working cancellation

### DIFF
--- a/git-analysis.js
+++ b/git-analysis.js
@@ -125,6 +125,7 @@ function getFirstSeen(repoPath, filePath) {
     const fullLog = execFileSync('git', ['-C', repoPath, 'log', '--follow', '--format=%aI', '--', filePath], {
         encoding: 'utf8',
         timeout: 10000,
+        maxBuffer: 10 * 1024 * 1024,
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim(),
       allDates = fullLog.split('\n').filter(Boolean).sort();
@@ -161,7 +162,7 @@ function computeFileChurn(db, repo, filePath, days, since) {
     const log = execFileSync(
       'git',
       ['-C', repo.path, 'log', '--follow', '--format=%H|%an|%aI', `--since=${since}`, '--', filePath],
-      { encoding: 'utf8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] },
+      { encoding: 'utf8', timeout: 10000, maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] },
     ).trim();
 
     if (!log) {
@@ -186,6 +187,7 @@ function computeRepoChurn(db, repo, days, since) {
     const log = execFileSync('git', ['-C', repo.path, 'log', `--since=${since}`, '--format=', '--name-only'], {
         encoding: 'utf8',
         timeout: 30000,
+        maxBuffer: 10 * 1024 * 1024,
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim(),
       fileCounts = new Map();
@@ -208,6 +210,7 @@ function computeRepoChurn(db, repo, days, since) {
       uniqueAuthorsRaw = execFileSync('git', ['-C', repo.path, 'log', `--since=${since}`, '--format=%an'], {
         encoding: 'utf8',
         timeout: 10000,
+        maxBuffer: 10 * 1024 * 1024,
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim(),
       uniqueAuthors = new Set(uniqueAuthorsRaw.split('\n').filter(Boolean)).size,
@@ -303,7 +306,7 @@ function getProvenance(db, repoId, symbolName) {
     const logOutput = execFileSync(
       'git',
       ['-C', repo.path, 'log', '--follow', '--format=%H|%an|%aI|%s', '--', symbol.file_path],
-      { encoding: 'utf8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
+      { encoding: 'utf8', timeout: 15000, maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] },
     ).trim();
 
     if (!logOutput) {
@@ -329,7 +332,7 @@ function getProvenance(db, repoId, symbolName) {
     const blameOutput = execFileSync(
         'git',
         ['-C', repo.path, 'blame', `-L${symbol.start_line},${symbol.end_line}`, '--', symbol.file_path],
-        { encoding: 'utf8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'] },
+        { encoding: 'utf8', timeout: 15000, maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] },
       ).trim(),
       blameHashes = new Set(),
       blameRe = /^([a-f0-9]{8,})/gm;

--- a/services/code-indexing.js
+++ b/services/code-indexing.js
@@ -54,6 +54,10 @@ function indexStatusInternal(jobId) {
   return jobStore.getJob(storeDeps, jobId);
 }
 
+async function cancelIndexJobInternal(jobId) {
+  return getQueue().cancel(jobId);
+}
+
 function listIndexJobsInternal({ onlyRunning = false, limit = 20 } = {}) {
   const dbModule = require('../db'),
     storeDeps = { sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun };
@@ -67,6 +71,7 @@ module.exports = {
   reindexRepoInternal,
   codeRepoHealthInternal,
   indexRepoAsyncInternal,
+  cancelIndexJobInternal,
   indexStatusInternal,
   listIndexJobsInternal,
 };

--- a/src/code-analysis/cochange-builder.js
+++ b/src/code-analysis/cochange-builder.js
@@ -4,6 +4,10 @@
  */
 const { execFileSync } = require('child_process');
 
+// Commits touching more files than this (deps-lock bumps, mass renames) are
+// skipped for pairing: N files would generate N(N-1)/2 meaningless pairs.
+const MAX_FILES_PER_COMMIT = 50;
+
 /**
  * Parse git log output grouped by COMMIT: markers.
  * Returns a map of "fileA::fileB" → co_commit_count.
@@ -28,13 +32,14 @@ function parseGitLogForCochange(logOutput) {
 }
 
 function processCommitFiles(files, pairs) {
-  if (files.length >= 2) {
-    const sorted = [...files].sort();
-    for (let i = 0; i < sorted.length; i++) {
-      for (let j = i + 1; j < sorted.length; j++) {
-        const key = `${sorted[i]}::${sorted[j]}`;
-        pairs[key] = (pairs[key] || 0) + 1;
-      }
+  if (files.length < 2 || files.length > MAX_FILES_PER_COMMIT) {
+    return;
+  }
+  const sorted = [...files].sort();
+  for (let i = 0; i < sorted.length; i++) {
+    for (let j = i + 1; j < sorted.length; j++) {
+      const key = `${sorted[i]}::${sorted[j]}`;
+      pairs[key] = (pairs[key] || 0) + 1;
     }
   }
 }
@@ -50,7 +55,17 @@ function storeCochangePairs(db, repoId, pairs, pathToId, windowDays) {
        co_commit_count = excluded.co_commit_count,
        strength = excluded.strength`,
     ),
-    maxCount = Math.max(...Object.values(pairs), 1);
+    // Loop instead of Math.max(...values): the spread throws for very large
+    // pair maps.
+    maxCount = (() => {
+      let max = 1;
+      for (const count of Object.values(pairs)) {
+        if (count > max) {
+          max = count;
+        }
+      }
+      return max;
+    })();
 
   for (const [key, count] of Object.entries(pairs)) {
     const [pathA, pathB] = key.split('::'),
@@ -82,8 +97,10 @@ function buildCochangeEdges(db, repoId, opts = {}) {
     logOutput = execFileSync('git', ['-C', repo.path, 'log', `--since=${since}`, '--format=COMMIT:%H', '--name-only'], {
       encoding: 'utf8',
       timeout: 30000,
+      maxBuffer: 10 * 1024 * 1024,
     });
   } catch (e) {
+    console.warn(`[cochange] git log failed for repo ${repoId}: ${e.message}`);
     return { success: false, count: 0, reason: `git error: ${e.message}` };
   }
 
@@ -96,9 +113,15 @@ function buildCochangeEdges(db, repoId, opts = {}) {
     const files = db.prepare('SELECT id, path FROM code_files WHERE repo_id = ?').all(repoId),
       pathToId = new Map(files.map((f) => [f.path, f.id])),
       pairCount = (() => {
-        db.prepare('DELETE FROM file_cochange WHERE repo_id = ? AND window_days = ?').run(repoId, windowDays);
-
-        storeCochangePairs(db, repoId, pairs, pathToId, windowDays);
+        // One transaction for the whole rewrite: previously millions of
+        // autocommit statements stalled the index for minutes on active
+        // repos. better-sqlite3 nests this as a savepoint if the caller is
+        // already inside a transaction.
+        const write = db.transaction(() => {
+          db.prepare('DELETE FROM file_cochange WHERE repo_id = ? AND window_days = ?').run(repoId, windowDays);
+          storeCochangePairs(db, repoId, pairs, pathToId, windowDays);
+        });
+        write();
 
         return Object.keys(pairs).length;
       })();
@@ -109,5 +132,7 @@ function buildCochangeEdges(db, repoId, opts = {}) {
 module.exports = {
   buildCochangeEdges,
   parseGitLogForCochange,
+  processCommitFiles,
   storeCochangePairs,
+  MAX_FILES_PER_COMMIT,
 };

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -325,6 +325,48 @@ function fileRecordToParams(repoId, record) {
   };
 }
 
+// Precompute everything the commit needs from a parsed record, then drop the
+// raw content. Deferring used to buffer the full source of every parsed file
+// (plus its live tree-sitter tree) until the single final commit — multi-GB
+// RSS on large repos (#294). Scope bindings are computed here, while the
+// content (and the tree) are still available, and only compact write
+// instructions are buffered.
+function buildDeferredEntry(entry, repoId, registry, scopeDb) {
+  const { record, hotSymbols, coldSymbols, tree } = entry,
+    fileParams = fileRecordToParams(repoId, record);
+  let scopeBindings = [];
+  if (scopeDb) {
+    try {
+      const scopeBuilder = require('./scope-builder').getScopeBuilder,
+        builder = scopeBuilder(record.filePath);
+      if (builder) {
+        let parsedTree = tree || null;
+        if (!parsedTree) {
+          const fallback = registry.parseTree(record.filePath, record.content);
+          parsedTree = fallback ? fallback.tree : null;
+        }
+        if (parsedTree) {
+          scopeBindings = builder(parsedTree, record.content, record.filePath) || [];
+          parsedTree.delete();
+        }
+      }
+    } catch {}
+  }
+  if (tree) {
+    // The immediate path deletes inside commitParsedBatch; the deferred path
+    // must free the WASM tree now or it stays alive until the final commit.
+    tree.delete();
+  }
+  return {
+    deferred: true,
+    filePath: record.filePath,
+    fileParams,
+    hotSymbols,
+    coldSymbols,
+    scopeBindings,
+  };
+}
+
 function recordDiagnostic(repository, repoId, record, status, message, symbolCount = 0, options = {}) {
   if (options.defer) {
     return;
@@ -809,16 +851,28 @@ function commitParsedBatch(repository, repoId, parsedRecords, ctx) {
   const { args, repoRoot, registry, scopeDb, insideTransaction = false } = ctx,
     batchSymbols = [];
 
-  for (const { record, hotSymbols, coldSymbols, tree: parsedTree } of parsedRecords) {
+  for (const entry of parsedRecords) {
+    // Deferred entries (full-index) arrive precomputed with no raw content;
+    // immediate entries (incremental path) carry the parsed record + tree.
+    const deferred = entry.deferred === true,
+      filePath = deferred ? entry.filePath : entry.record.filePath,
+      record = deferred ? null : entry.record;
     try {
-      const fileId = repository.insertFile(fileRecordToParams(repoId, record));
+      let fileParams, hotSymbols, coldSymbols, parsedTree;
+      if (deferred) {
+        ({ fileParams, hotSymbols, coldSymbols } = entry);
+      } else {
+        ({ hotSymbols, coldSymbols, tree: parsedTree } = entry);
+        fileParams = fileRecordToParams(repoId, record);
+      }
+      const fileId = repository.insertFile(fileParams);
       for (let si = 0; si < hotSymbols.length; si++) {
         const hot = hotSymbols[si],
           cold = coldSymbols[si] || {};
         batchSymbols.push({
           repoId,
           fileId,
-          filePath: record.filePath,
+          filePath,
           name: hot.name,
           kind: hot.kind,
           qualifiedName: hot.qualified_name,
@@ -843,24 +897,31 @@ function commitParsedBatch(repository, repoId, parsedRecords, ctx) {
       ctx.symbolCount += hotSymbols.length;
       ctx.fileCount++;
 
-      try {
-        const scopeBuilder = require('./scope-builder').getScopeBuilder,
-          builder = scopeBuilder(record.filePath);
-        if (builder && scopeDb) {
-          let tree = parsedTree || null;
-          if (!tree) {
-            const fallback = registry.parseTree(record.filePath, record.content);
-            tree = fallback ? fallback.tree : null;
-          }
-          if (tree) {
-            const scopeBindings = builder(tree, record.content, record.filePath);
-            if (scopeBindings.length > 0) {
-              insertScopeBindings(scopeDb, repoId, fileId, scopeBindings);
+      // Deferred entries already computed (and freed) their scope bindings
+      // at parse time (#294); the immediate path still owns the live tree.
+      if (!deferred) {
+        try {
+          const scopeBuilder = require('./scope-builder').getScopeBuilder,
+            builder = scopeBuilder(filePath);
+          if (builder && scopeDb) {
+            let tree = parsedTree || null;
+            if (!tree) {
+              const fallback = registry.parseTree(filePath, record.content);
+              tree = fallback ? fallback.tree : null;
             }
-            tree.delete();
+            if (tree) {
+              const scopeBindings = builder(tree, record.content, filePath);
+              if (scopeBindings.length > 0) {
+                insertScopeBindings(scopeDb, repoId, fileId, scopeBindings);
+              }
+              tree.delete();
+            }
           }
-        }
-      } catch {}
+        } catch {}
+      }
+      if (deferred && entry.scopeBindings.length > 0 && scopeDb) {
+        insertScopeBindings(scopeDb, repoId, fileId, entry.scopeBindings);
+      }
 
       if (args && shouldEmitFileProgress(ctx.fileCount, ctx.totalFiles)) {
         emitProgress(
@@ -868,15 +929,29 @@ function commitParsedBatch(repository, repoId, parsedRecords, ctx) {
           'parsing',
           {
             step: 'store-index',
-            current_file: progressPath(record.filePath, repoRoot),
-            message: `Stored index ${ctx.fileCount}/${ctx.totalFiles}: ${progressPath(record.filePath, repoRoot)} (${hotSymbols.length} symbols)`,
+            current_file: progressPath(filePath, repoRoot),
+            message: `Stored index ${ctx.fileCount}/${ctx.totalFiles}: ${progressPath(filePath, repoRoot)} (${hotSymbols.length} symbols)`,
           },
           { files_total: ctx.totalFiles, files_done: ctx.fileCount, symbols: ctx.symbolCount },
         );
       }
     } catch (e) {
-      ctx.skipped.push({ file: record.filePath, error: e.message });
-      recordDiagnostic(repository, repoId, record, 'error', e.message, 0);
+      ctx.skipped.push({ file: filePath, error: e.message });
+      if (deferred) {
+        // Raw content was dropped at parse time; use the stashed hash.
+        if (typeof repository.upsertFileDiagnostic === 'function') {
+          repository.upsertFileDiagnostic({
+            repoId,
+            filePath,
+            status: 'error',
+            message: e.message,
+            symbolCount: 0,
+            contentHash: entry.fileParams.contentHash ?? null,
+          });
+        }
+      } else {
+        recordDiagnostic(repository, repoId, record, 'error', e.message, 0);
+      }
     }
   }
 
@@ -1101,7 +1176,7 @@ async function parsePhase(files, deps, repoId, args) {
           symbolCount += entry.hotSymbols.length;
           fileCount++;
         }
-        deferredBatches.push(parsedRecords);
+        deferredBatches.push(parsedRecords.map((entry) => buildDeferredEntry(entry, repoId, registry, scopeDb)));
         // oxlint-disable-next-line no-continue
         continue;
       }

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -77,18 +77,27 @@ function makeDerivedErrorCollector() {
   };
 }
 
+// Thrown by the async worker's onProgress hook to abort the index; must
+// propagate through emitProgress instead of being swallowed (previously
+// cancellation was dead-wired: the abort never reached the indexer) (#295).
+const CANCELLED = 'lapis-index-cancelled';
+
 function emitProgress(args, phase, detail, stats) {
   if (!args) {
     return;
   }
   // Worker hook: forward every progress event to a callback (used by the
   // Async worker to update the index_jobs ledger). Errors are swallowed
-  // Because a failing callback must never break the indexer.
+  // Because a failing callback must never break the indexer — except the
+  // Cancellation sentinel, which IS the indexer's stop signal.
   if (typeof args.onProgress === 'function') {
     try {
       const callbackPayload = { phase, ...(detail || {}), ...(stats || {}) };
       args.onProgress(callbackPayload);
-    } catch (_) {
+    } catch (e) {
+      if (e === CANCELLED) {
+        throw e;
+      }
       /* Best-effort */
     }
   }
@@ -1909,6 +1918,7 @@ function buildHealthRecommendations({ pathExists, stale, diagnosticCounts, scan 
 }
 
 module.exports = {
+  CANCELLED,
   emitProgress,
   fileRecordToParams,
   getHeadCommit,

--- a/src/code-index/incremental-indexer.js
+++ b/src/code-index/incremental-indexer.js
@@ -482,6 +482,10 @@ function rebuildDerivedIndexes(db, repoId, args, totalFiles, fileCount, symbolCo
     const cc2 = buildCochangeEdges(db, repoId);
     if (cc2.success) {
       cochangeEdges = cc2.count;
+    } else {
+      // A silent {success:false} here used to leave cochange data empty with
+      // no trace in the result (#293).
+      derivedErrors.log('cochange', new Error(cc2.reason || 'cochange builder failed'));
     }
   } catch (e) {
     derivedErrors.log('cochange', e);

--- a/src/code-index/index-worker.js
+++ b/src/code-index/index-worker.js
@@ -7,7 +7,7 @@
 
 const { parentPort, workerData } = require('worker_threads'),
   dbModule = require('../../db'),
-  { indexRepository, reindexRepository } = require('./incremental-indexer'),
+  { indexRepository, reindexRepository, CANCELLED } = require('./incremental-indexer'),
   { getLanguageForFile } = require('./parser-registry'),
   jobStore = require('./job-store');
 
@@ -79,7 +79,9 @@ async function main() {
       emit('done', { result, languageBreakdown: Object.fromEntries(languageCounters) });
       function onProgress({ phase, files_total, files_done, current_file, language }) {
         if (cancelled) {
-          throw new Error('cancelled');
+          // The sentinel propagates through emitProgress and aborts the
+          // index; the outer catch below reports the job as cancelled.
+          throw CANCELLED;
         }
         // Derive language from current_file if not provided by the indexer.
         const lang = language || (current_file ? safeGetLanguage(current_file) : null),

--- a/src/code-index/job-queue.js
+++ b/src/code-index/job-queue.js
@@ -8,7 +8,9 @@ const path = require('path'),
   { EventEmitter } = require('events'),
   WORKER_SCRIPT = path.resolve(__dirname, 'index-worker.js');
 
-function createJobQueue({ Worker: WorkerCtor = Worker, jobStore, deps }) {
+const CANCEL_GRACE_MS = 3000;
+
+function createJobQueue({ Worker: WorkerCtor = Worker, jobStore, deps, cancelGraceMs = CANCEL_GRACE_MS }) {
   const workers = new Map(), // jobId -> { worker, status }
     emitter = new EventEmitter();
 
@@ -89,10 +91,41 @@ function createJobQueue({ Worker: WorkerCtor = Worker, jobStore, deps }) {
     if (!entry) {
       return false;
     }
+    // Ask the worker to cancel cooperatively first (postMessage → the
+    // worker's onProgress hook aborts the index and its repo lock is
+    // released by the normal finally path). Previously cancel() only called
+    // terminate(), which killed the thread with the lock held — and because
+    // worker threads share the parent pid, the stranded lock looked alive
+    // and stalled every future index of that repo (#295).
     try {
-      await entry.worker.terminate();
+      entry.worker.postMessage({ type: 'cancel' });
     } catch (_) {
       /* Ignore */
+    }
+    const exitedCleanly = await new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(false), cancelGraceMs);
+      entry.worker.once('exit', () => {
+        clearTimeout(timer);
+        resolve(true);
+      });
+    });
+    if (!exitedCleanly) {
+      try {
+        await entry.worker.terminate();
+      } catch (_) {
+        /* Ignore */
+      }
+      // The terminated thread never ran its finally: drop any repo locks it
+      // still holds. Worker threads share the parent pid, so the holder
+      // prefix must also match this worker's threadId.
+      if (typeof entry.worker.threadId === 'number' && typeof deps?.sqlRun === 'function') {
+        try {
+          const { releaseLocksForHolderPrefix } = require('./repo-lock');
+          releaseLocksForHolderPrefix(deps.sqlRun, `${process.pid}:${entry.worker.threadId}`);
+        } catch (_) {
+          /* Best-effort */
+        }
+      }
     }
     entry.status = 'cancelled';
     try {

--- a/src/code-index/repo-lock.js
+++ b/src/code-index/repo-lock.js
@@ -1,11 +1,27 @@
 const crypto = require('crypto'),
   os = require('os'),
+  { threadId } = require('worker_threads'),
   localHolding = new Set(),
   DEFAULT_LOCK_TIMEOUT_MS = 10 * 60 * 1000,
   LOCK_POLL_MS = 200;
 
+// Holder ids embed the (pid, threadId) pair: worker threads share the
+// parent's pid, so a lock stranded by worker.terminate() would otherwise
+// look alive forever and stall every future index of that repo (#295).
 function makeHolderId() {
-  return `${process.pid}:${crypto.randomBytes(4).toString('hex')}`;
+  return `${process.pid}:${threadId}:${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function locksForCurrentThreadPrefix() {
+  return `${process.pid}:${threadId}:%`;
+}
+
+/**
+ * Delete every repo lock held by a (pid, threadId) prefix — used by the job
+ * queue after forcibly terminating a worker whose lock release never ran.
+ */
+function releaseLocksForHolderPrefix(sqlRun, prefix) {
+  sqlRun('DELETE FROM repo_index_locks WHERE holder_id LIKE ?', [`${prefix}%`]);
 }
 
 function sleep(ms) {
@@ -111,4 +127,11 @@ async function withRepoIndexLock(repoName, fn) {
   }
 }
 
-module.exports = { withRepoIndexLock, makeHolderId, tryAcquireSqliteLock, releaseSqliteLock };
+module.exports = {
+  withRepoIndexLock,
+  makeHolderId,
+  tryAcquireSqliteLock,
+  releaseSqliteLock,
+  releaseLocksForHolderPrefix,
+  locksForCurrentThreadPrefix,
+};

--- a/test/derived-errors-surface.test.js
+++ b/test/derived-errors-surface.test.js
@@ -44,6 +44,9 @@ describe('derived-builder failures are surfaced (#287)', () => {
     delete require.cache[require.resolve('../src/code-index/incremental-indexer')];
     const { derivedPhase } = require('../src/code-index/incremental-indexer');
     const stats = await derivedPhase(dbModule.getDb(), 'repo-missing', null, 0, 0, 0);
-    expect(stats.derived_errors).toEqual([]);
+    // On a repo row that does not exist, the cochange builder reports
+    // {success:false, reason:'repo not found'} — surfaced since #293, no
+    // longer swallowed. Nothing else fails on an empty schema.
+    expect(stats.derived_errors).toEqual([{ builder: 'cochange', error: 'repo not found' }]);
   });
 });

--- a/test/p2-batch6-fixes.test.js
+++ b/test/p2-batch6-fixes.test.js
@@ -1,0 +1,195 @@
+// Regression tests for review batch 6: #293 (cochange quadratic blowup +
+// unbuffered git log), #294 (deferred full-index batches no longer buffer
+// raw file content), and #295 (index cancellation actually works; repo
+// locks are thread-aware). Uses an isolated temp DB.
+const fs = require('node:fs'),
+  os = require('node:os'),
+  path = require('node:path');
+
+process.env.LAPIS_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-p2-batch6-'));
+
+describe('#293 cochange-builder caps quadratic pair generation', () => {
+  const {
+    parseGitLogForCochange,
+    processCommitFiles,
+    MAX_FILES_PER_COMMIT,
+  } = require('../src/code-analysis/cochange-builder');
+
+  it('skips pair generation for commits touching more than the cap', () => {
+    expect(MAX_FILES_PER_COMMIT).toBe(50);
+    const bigCommit = Array.from({ length: 60 }, (_, i) => `file${i}.js`),
+      pairs = {};
+    processCommitFiles(bigCommit, pairs);
+    expect(Object.keys(pairs)).toHaveLength(0);
+  });
+
+  it('still pairs commits at or under the cap', () => {
+    const pairs = {};
+    processCommitFiles(['a.js', 'b.js', 'c.js'], pairs);
+    expect(Object.keys(pairs)).toHaveLength(3); // C(3,2)
+    expect(pairs['a.js::b.js']).toBe(1);
+  });
+
+  it('parses mixed logs with oversized and normal commits', () => {
+    const bigCommit = Array.from({ length: 80 }, (_, i) => `f${i}.js`).join('\n'),
+      log = `COMMIT:abc\n${bigCommit}\nCOMMIT:def\nx.js\ny.js\n`,
+      pairs = parseGitLogForCochange(log);
+    expect(pairs).toEqual({ 'x.js::y.js': 1 });
+  });
+
+  it('buffers git log output (maxBuffer) in cochange and git-analysis builders', () => {
+    const fsMod = require('node:fs');
+    const cochange = fsMod.readFileSync('src/code-analysis/cochange-builder.js', 'utf8');
+    expect(cochange).toMatch(/maxBuffer: 10 \* 1024 \* 1024/);
+    expect(cochange).toMatch(/db\.transaction\(/);
+    const gitAnalysis = fsMod.readFileSync('git-analysis.js', 'utf8');
+    const buffers = gitAnalysis.match(/maxBuffer: 10 \* 1024 \* 1024/g) || [];
+    expect(buffers.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('#294 deferred batches carry no raw file content', () => {
+  it('parsePhase buffers precomputed entries without record.content', async () => {
+    const incremental = require('../src/code-index/incremental-indexer'),
+      { createParserRegistry } = require('../src/code-index/parser-registry'),
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-defer-'));
+    try {
+      for (const name of ['a.js', 'b.js']) {
+        fs.writeFileSync(path.join(dir, name), 'function sample() {\n  return 1;\n}\n');
+      }
+      const registry = createParserRegistry();
+      expect(await registry.ensureReady()).toBe(true);
+
+      const result = await incremental.parsePhase(
+        [path.join(dir, 'a.js'), path.join(dir, 'b.js')],
+        { parserRegistry: registry, repository: { upsertFileDiagnostic: () => {} } },
+        'repo-1',
+        { deferIndexWrites: true, noWorkers: true },
+      );
+
+      expect(result.fileCount).toBe(2);
+      const batch = result.deferredBatches[0];
+      expect(batch).toHaveLength(2);
+      for (const entry of batch) {
+        expect(entry.deferred).toBe(true);
+        expect(entry.record).toBeUndefined(); // raw content dropped
+        expect(entry.fileParams.path.endsWith('.js')).toBe(true);
+        expect(entry.fileParams.contentHash).toBeTruthy();
+        expect(entry.hotSymbols.length).toBeGreaterThan(0);
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30000);
+});
+
+describe('#295 index cancellation and thread-aware locks', () => {
+  it('emitProgress lets the cancellation sentinel propagate but swallows ordinary errors', () => {
+    const { emitProgress, CANCELLED } = require('../src/code-index/incremental-indexer');
+    expect(typeof CANCELLED).toBe('string');
+    expect(() =>
+      emitProgress(
+        {
+          onProgress: () => {
+            throw CANCELLED;
+          },
+        },
+        'p',
+        {},
+        {},
+      ),
+    ).toThrow(CANCELLED);
+    expect(() =>
+      emitProgress(
+        {
+          onProgress: () => {
+            throw new Error('ordinary callback bug');
+          },
+        },
+        'p',
+        {},
+        {},
+      ),
+    ).not.toThrow();
+  });
+
+  it('cancel posts the cancel message and terminates after the grace window', async () => {
+    const { EventEmitter } = require('events');
+
+    class StubWorker extends EventEmitter {
+      constructor(behavior) {
+        super();
+        this.threadId = 5;
+        this.postMessage = (msg) => behavior.onPostMessage && behavior.onPostMessage(msg);
+        this.terminateCalls = 0;
+        this.terminate = () => {
+          this.terminateCalls++;
+          return Promise.resolve(0);
+        };
+      }
+    }
+
+    // Cooperative: worker exits on its own after receiving the message.
+    const cooperative = new StubWorker({
+      onPostMessage: (msg) => {
+        if (msg.type === 'cancel') {
+          queueMicrotask(() => cooperative.emit('exit', 0));
+        }
+      },
+    });
+    const { createJobQueue } = require('../src/code-index/job-queue');
+    function WorkerFactory() {
+      return cooperative;
+    }
+    const q1 = createJobQueue({ Worker: WorkerFactory, jobStore: {}, deps: {}, cancelGraceMs: 500 });
+    q1.startJob(1, {});
+    await q1.cancel(1);
+    expect(cooperative.terminateCalls).toBe(0);
+    expect(q1.getStatus(1)).toBe('cancelled');
+
+    // Stalled: worker never exits → terminated, and its thread's repo locks
+    // are cleaned up.
+    const sqlRunCalls = [],
+      stalled = new StubWorker({});
+    function StalledFactory() {
+      return stalled;
+    }
+    const q2 = createJobQueue({
+      Worker: StalledFactory,
+      jobStore: {},
+      deps: { sqlRun: (q, p) => sqlRunCalls.push([q, p]) },
+      cancelGraceMs: 50,
+    });
+    q2.startJob(2, {});
+    await q2.cancel(2);
+    expect(stalled.terminateCalls).toBe(1);
+    expect(sqlRunCalls[0][0]).toContain('repo_index_locks');
+    expect(sqlRunCalls[0][1][0]).toBe(`${process.pid}:5%`);
+  });
+
+  it('repo-lock holder ids embed pid and threadId, and the prefix cleanup deletes only matching rows', () => {
+    const dbModule = require('../db'),
+      repoLock = require('../src/code-index/repo-lock');
+    dbModule.ensureDb();
+
+    const holderId = repoLock.makeHolderId();
+    expect(holderId).toMatch(/^\d+:\d+:[0-9a-f]+$/);
+
+    dbModule.sqlRun("INSERT INTO repo_index_locks (repo_name, holder_id, host) VALUES ('r5', ?, 'h'), ('r6', ?, 'h')", [
+      `${process.pid}:5:aaaa`,
+      `${process.pid}:6:bbbb`,
+    ]);
+    repoLock.releaseLocksForHolderPrefix(dbModule.sqlRun, `${process.pid}:5`);
+    expect(
+      dbModule
+        .sqlJson('SELECT repo_name FROM repo_index_locks WHERE repo_name IN (?, ?)', ['r5', 'r6'])
+        .map((r) => r.repo_name),
+    ).toEqual(['r6']);
+    dbModule.sqlRun('DELETE FROM repo_index_locks WHERE repo_name = ?', ['r6']);
+  });
+
+  it('services/code-indexing exposes cancelIndexJobInternal', () => {
+    const service = require('../services/code-indexing');
+    expect(typeof service.cancelIndexJobInternal).toBe('function');
+  });
+});


### PR DESCRIPTION
Sixth batch from the 2026-09-06 full-codebase review. The indexer trio (#293–#295), one commit per issue, tests included.

## #293 — cochange builder: scale + bounded git output
- Commits touching many files generated N(N−1)/2 pairs (a routine 1000-file deps bump → ~500k rows) inserted as **millions of autocommit statements**. Pair generation now skips commits over `MAX_FILES_PER_COMMIT` (50), and the DELETE+inserts run in **one transaction** (better-sqlite3 nests it as a savepoint when already inside one).
- `git log` ran without `maxBuffer` → ENOBUFS on active repos, and the `{success:false}` was swallowed — cochange data was silently empty exactly where it matters. Now 10MB-buffered, warned, and surfaced through the `derived_errors` mechanism from #287.
- `Math.max(...values)` spread (throws on very large pair maps) replaced with a loop; the same 10MB `maxBuffer` applied to every `git-analysis.js` `execFileSync` (churn/provenance silently degraded on mature repos).

## #294 — deferred full-index no longer buffers the whole repo in RAM
In `deferIndexWrites` mode (always used by `indexRepository`), every parsed batch retained **each file's full source text and its live tree-sitter tree** until one final transaction — multi-GB RSS / OOM mid-index on large repos. `parsePhase` now precomputes a deferred entry per file (insert params, symbols, **scope bindings computed at parse time while content/tree are still available**), frees the WASM tree immediately, and buffers only compact write instructions. `commitParsedBatch` handles both entry shapes; the incremental path is unchanged.

## #295 — cancellation actually works now; no more stranded locks
Cancellation was dead-wired three ways: the worker's abort was swallowed by `emitProgress`, `cancel()` terminated without posting the cancel message, and nothing exposed cancel. Now:
- `emitProgress` rethrows the shared `CANCELLED` sentinel — the abort reaches the indexer.
- `cancel()` posts the cancel message, gives the worker a grace window to exit cleanly (releasing its repo lock via the normal `finally`), and only then terminates.
- `services/code-indexing.js` exposes `cancelIndexJobInternal`.
- Because worker threads share the parent pid, a terminated worker's repo lock used to look alive and stall every future index of that repo for 10 minutes. Holder ids now embed `(pid, threadId)`, and `cancel()` deletes locks under the terminated worker's holder prefix as a last resort.

## Tests
`test/p2-batch6-fixes.test.js`: pair-cap parsing (60-file commit → 0 pairs, mixed log), maxBuffer/transaction presence, deferred batches carry `fileParams` + symbols but **no `record`/content**, sentinel propagation vs. swallowed errors, cooperative-vs-forced cancel with lock cleanup, thread-aware holder ids + prefix cleanup, service exposure. Full-index `index-repo`/`comprehensive` suites exercise the refactored deferred path end-to-end.

Full suite: **148 files / 2068 tests passed**. Lint: 0 errors; format clean.

Fixes #293
Fixes #294
Fixes #295