### PR TITLE
fix: final batch — HTTP status correctness, atomic postinstall patching, P3 minors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -85,7 +85,14 @@ const {
       const { startHttpServer } = require('./src/http/server');
       await startHttpServer({
         host: args.host ?? '127.0.0.1',
-        port: Number(args.port ?? 9100),
+        port: (() => {
+          const parsed = Number(args.port ?? 9100);
+          if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+            console.error(`lapis serve: --port must be an integer between 1 and 65535, got "${args.port}"`);
+            process.exit(1);
+          }
+          return parsed;
+        })(),
         apiKey: args['api-key'] ?? args.apiKey ?? null,
       });
       return;

--- a/extensions/memory-layer/hooks/tool-guardrails.ts
+++ b/extensions/memory-layer/hooks/tool-guardrails.ts
@@ -247,7 +247,9 @@ export function registerToolGuardrails(pi: ExtensionAPI, deps: GuardrailsDeps) {
 
     const resultText = typeof event.result === 'string' ? event.result : JSON.stringify(event.result),
       // Match relative file paths like "src/foo.ts" or "extensions/memory-layer/hooks/tool-guardrails.ts"
-      filePaths = resultText.match(/[\w/.-]+\.(ts|js|tsx|jsx|mjs|cjs|py|go|rs)/g) || [];
+      // Longest-first alternation + boundary: short-first matched '.tsx' as
+      // '.ts', so harvested names pointed at files that do not exist (#304).
+      filePaths = resultText.match(/[\w/.-]+\.(tsx|jsx|mts|cts|mjs|cjs|ts|js|py|go|rs)\b/g) || [];
     for (const fp of filePaths) {
       deps.state.exploredFiles.add(fp.toLowerCase());
       const basename = fp.split('/').pop();

--- a/extensions/memory-layer/host/memory-client.ts
+++ b/extensions/memory-layer/host/memory-client.ts
@@ -195,6 +195,7 @@ export async function memStreaming(
 
       return getTimeout(cmd);
     })();
+  let timedOut = false;
   try {
     return await new Promise<MemResult | null>((resolve, reject) => {
       const child = spawn(process.execPath, [MEMORY_SCRIPT, ...argList], {
@@ -202,14 +203,24 @@ export async function memStreaming(
       });
 
       let stdout = '',
-        timer: ReturnType<typeof setTimeout> | null = null;
+        timer: ReturnType<typeof setTimeout> | null = null,
+        killTimer: ReturnType<typeof setTimeout> | null = null;
       {
         const resetTimer = () => {
           if (timer) {
             clearTimeout(timer);
           }
           timer = setTimeout(() => {
+            timedOut = true;
             child.kill();
+            // SIGTERM cannot interrupt a child wedged in a synchronous
+            // better-sqlite3 call — escalate to SIGKILL after a grace
+            // window so it cannot keep holding the DB (#304).
+            killTimer = setTimeout(() => {
+              try {
+                child.kill('SIGKILL');
+              } catch {}
+            }, 2000);
             reject(new Error(`${cmd} timed out after ${timeout}ms without output`));
           }, timeout + 5000);
         };
@@ -246,6 +257,9 @@ export async function memStreaming(
           if (timer) {
             clearTimeout(timer);
           }
+          if (killTimer) {
+            clearTimeout(killTimer);
+          }
           if (code !== 0 && !stdout.trim()) {
             reject(new Error(`${cmd} exited with code ${code}`));
             return;
@@ -267,6 +281,14 @@ export async function memStreaming(
       }
     });
   } catch {
+    // A timed-out child was already killed — re-running the whole command
+    // (for index-repo/reindex-repo: a second full index racing the first)
+    // is worse than reporting the timeout (#304). The mem() fallback stays
+    // for genuine spawn/startup failures.
+    if (timedOut) {
+      console.error(`[memory-layer] ${cmd} timed out and was terminated; not retrying`);
+      return null;
+    }
     return mem(cmd, args);
   }
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -43,6 +43,10 @@ const fs = require('fs'),
       integrity: 'sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==',
     },
   };
+  // Only copies at these (vulnerable) versions are patched. Overwriting a
+  // copy at an unrelated version could put a dependent outside its declared
+  // range (#303).
+  const VULNERABLE_VERSIONS = new Set(['5.0.6']);
 
   // Locate every nested copy of a target package under node_modules and return
   // The directory paths. Skips the top-level node_modules/<pkg> copy (which is
@@ -119,10 +123,30 @@ const fs = require('fs'),
     if (fs.existsSync(safeSrc)) {
       for (const dir of nestedDirs) {
         try {
+          // Only patch copies whose version is in the known-vulnerable set.
+          let currentVersion;
+          try {
+            currentVersion = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).version;
+          } catch {}
+          if (currentVersion && !VULNERABLE_VERSIONS.has(currentVersion)) {
+            continue;
+          }
+          // Atomic swap: stage the safe copy, then replace in one rename.
+          // The old rm-then-copy pair could leave node_modules without the
+          // package at all if the copy failed partway (ENOSPC/EACCES) — and
+          // the bare catch swallowed the evidence (#303).
+          const stagedDir = `${dir}.patched-${process.pid}`;
+          fs.rmSync(stagedDir, { recursive: true, force: true });
+          fs.cpSync(safeSrc, stagedDir, { recursive: true, force: true });
           fs.rmSync(dir, { recursive: true, force: true });
-          fs.cpSync(safeSrc, dir, { recursive: true, force: true });
+          fs.renameSync(stagedDir, dir);
           filesPatched = true;
-        } catch {}
+        } catch (e) {
+          console.error(`[postinstall] failed to patch nested ${pkg} at ${dir}: ${e.message}`);
+          try {
+            fs.rmSync(`${dir}.patched-${process.pid}`, { recursive: true, force: true });
+          } catch {}
+        }
       }
     }
 

--- a/scripts/cleanup-sessions.js
+++ b/scripts/cleanup-sessions.js
@@ -157,7 +157,20 @@ if (require.main === module) {
       softDeleteObservation = (id) => obsDA.softDeleteObservation({ sqlJson, sqlRun, sqlRaw }, id),
       deps = { sqlJson, sqlRun, sqlRaw, withTransaction, softDeleteObservation },
       opts = {
-        keepLast: args['keep-last'] ? parseInt(args['keep-last'], 10) : 10,
+        keepLast: (() => {
+          const raw = args['keep-last'];
+          if (!raw) {
+            return 10;
+          }
+          const parsed = parseInt(raw, 10);
+          // NaN used to flow into LIMIT ?/OFFSET ? and crash mid-transaction
+          // with a datatype mismatch (#304).
+          if (Number.isNaN(parsed) || parsed < 0) {
+            console.error(`cleanup-sessions: --keep-last must be a non-negative integer, got "${raw}"`);
+            process.exit(1);
+          }
+          return parsed;
+        })(),
         project: args.project || null,
         yes: args.yes === true,
         includeDream: args['include-dream'] === true,

--- a/src/http/handlers/broadcasts.js
+++ b/src/http/handlers/broadcasts.js
@@ -1,4 +1,4 @@
-const { jsonOk, jsonCreated } = require('../errors');
+const { jsonOk, jsonCreated, jsonError } = require('../errors');
 
 function writeBroadcast(repo) {
   return async (req, res, ctx) => {
@@ -33,7 +33,10 @@ function transitionBroadcast(repo) {
   return async (req, res, ctx) => {
     const { newStatus, actorId } = ctx.body,
       rows = repo.transitionBroadcast(ctx.params.id, newStatus);
-    jsonOk(res, rows[0] || { id: ctx.params.id, status: newStatus });
+    if (!rows || rows.length === 0) {
+      return jsonError(res, 404, 'not_found', 'Broadcast not found');
+    }
+    jsonOk(res, rows[0]);
   };
 }
 

--- a/src/http/handlers/code-index.js
+++ b/src/http/handlers/code-index.js
@@ -2,6 +2,18 @@ const { indexRepository, reindexRepository, getCodeRepoHealth } = require('../..
   { getDependencyCycles } = require('../../code-analysis/graph'),
   { getDb } = require('../../../db');
 
+// Indexer failures used to be written out with HTTP 200, so automation
+// checking the status code treated a failed index as success (#288).
+function sendIndexResult(res, result) {
+  if (result && result.error) {
+    const status = /not found/i.test(result.error) ? 404 : 500;
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify(result));
+  }
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  return res.end(JSON.stringify(result));
+}
+
 // Compute real dependency cycles; degrade gracefully to a zero-value so a
 // Graph-build failure never 500s the whole summary/graph endpoint.
 function safeDependencyCycles(db, repoId) {
@@ -22,8 +34,7 @@ function indexRepo(deps) {
     const path = require('path'),
       repoName = name || path.basename(repoPath),
       result = await indexRepository({ db: getDb(), args: {} }, repoPath, repoName);
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(result));
+    return sendIndexResult(res, result);
   };
 }
 
@@ -35,8 +46,7 @@ function reindexRepo(deps) {
       return res.end(JSON.stringify({ error: 'repo is required' }));
     }
     const result = await reindexRepository({ db: getDb(), args: {} }, repo, mode || 'incremental');
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(result));
+    return sendIndexResult(res, result);
   };
 }
 
@@ -48,8 +58,7 @@ function codeRepoHealthHandler(deps) {
       return res.end(JSON.stringify({ error: 'repo is required' }));
     }
     const result = await getCodeRepoHealth({ db: getDb(), args: {} }, repo);
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(result));
+    return sendIndexResult(res, result);
   };
 }
 

--- a/src/http/handlers/findings.js
+++ b/src/http/handlers/findings.js
@@ -1,4 +1,4 @@
-const { jsonOk, jsonCreated } = require('../errors');
+const { jsonOk, jsonCreated, jsonError } = require('../errors');
 
 function writeFinding(repo) {
   return async (req, res, ctx) => {
@@ -31,7 +31,10 @@ function transitionFinding(repo) {
   return async (req, res, ctx) => {
     const { newStatus, actorId, actorContext } = ctx.body,
       rows = repo.transitionFinding(ctx.params.id, newStatus);
-    jsonOk(res, rows[0] || { id: ctx.params.id, status: newStatus });
+    if (!rows || rows.length === 0) {
+      return jsonError(res, 404, 'not_found', 'Finding not found');
+    }
+    jsonOk(res, rows[0]);
   };
 }
 

--- a/src/http/handlers/memory.js
+++ b/src/http/handlers/memory.js
@@ -13,10 +13,21 @@ function mapSearchRows(rows) {
 
 function searchMemory(deps) {
   return async (req, res, ctx) => {
-    const { query, limit } = ctx.body,
+    const { query, limit, project, type, scope } = ctx.body,
       searchDeps = { sqlJson: deps.sqlJson, sqlRun: deps.sqlRun, jsonErrNoExit: (msg) => ({ error: msg }) },
       search = require('../../memory-domain/search').search,
-      result = search(searchDeps, { query, limit: String(limit || 10) });
+      // Non-numeric limits used to bind NaN into LIMIT ? and 500 (#304).
+      parsedLimit = Number.parseInt(limit, 10),
+      safeLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? String(Math.min(parsedLimit, 100)) : '10',
+      result = search(searchDeps, {
+        query,
+        limit: safeLimit,
+        // The underlying search supports these filters; dropping them made
+        // every route search cross-project silently (#304).
+        ...(project ? { project: String(project) } : {}),
+        ...(type ? { type: String(type) } : {}),
+        ...(scope ? { scope: String(scope) } : {}),
+      });
     if (result?.error) {
       return jsonError(res, 400, 'invalid_search', result.error);
     }

--- a/src/http/handlers/milestones.js
+++ b/src/http/handlers/milestones.js
@@ -1,4 +1,4 @@
-const { jsonOk, jsonCreated } = require('../errors');
+const { jsonOk, jsonCreated, jsonError } = require('../errors');
 
 function createMilestone(repo) {
   return async (req, res, ctx) => {
@@ -15,8 +15,14 @@ function createMilestone(repo) {
 function updateMilestoneStatus(repo) {
   return async (req, res, ctx) => {
     const { status } = ctx.body;
-    repo.updateMilestoneStatus(ctx.params.id, status);
-    jsonOk(res, { ok: true });
+    if (typeof status !== 'string' || status.trim().length === 0) {
+      return jsonError(res, 400, 'invalid_status', 'status is required and must be a non-empty string');
+    }
+    const rows = repo.updateMilestoneStatus(ctx.params.id, status);
+    if (!rows || rows.length === 0) {
+      return jsonError(res, 404, 'not_found', 'Milestone not found');
+    }
+    jsonOk(res, rows[0]);
   };
 }
 

--- a/src/http/handlers/missions.js
+++ b/src/http/handlers/missions.js
@@ -26,8 +26,14 @@ function getMission(repo) {
 function updateMissionStatus(repo) {
   return async (req, res, ctx) => {
     const { status } = ctx.body;
-    repo.updateMissionStatus(ctx.params.id, status);
-    jsonOk(res, { ok: true });
+    if (typeof status !== 'string' || status.trim().length === 0) {
+      return jsonError(res, 400, 'invalid_status', 'status is required and must be a non-empty string');
+    }
+    const rows = repo.updateMissionStatus(ctx.params.id, status);
+    if (!rows || rows.length === 0) {
+      return jsonError(res, 404, 'not_found', 'Mission not found');
+    }
+    jsonOk(res, rows[0]);
   };
 }
 

--- a/src/http/handlers/retry.js
+++ b/src/http/handlers/retry.js
@@ -1,15 +1,21 @@
-const { jsonOk } = require('../errors');
+const { jsonOk, jsonError } = require('../errors');
 
 function incrementRetry(repo) {
   return async (req, res, ctx) => {
     const result = repo.incrementRetry(ctx.params.milestoneId);
+    if (!result) {
+      return jsonError(res, 404, 'not_found', 'Milestone not found');
+    }
     jsonOk(res, result);
   };
 }
 
 function logRescope(repo) {
   return async (req, res, ctx) => {
-    repo.logRescope(ctx.params.milestoneId, ctx.body);
+    const created = repo.logRescope(ctx.params.milestoneId, ctx.body);
+    if (created === false) {
+      return jsonError(res, 404, 'not_found', 'Milestone not found');
+    }
     jsonOk(res, { ok: true });
   };
 }

--- a/src/http/handlers/units.js
+++ b/src/http/handlers/units.js
@@ -1,4 +1,4 @@
-const { jsonOk, jsonCreated } = require('../errors');
+const { jsonOk, jsonCreated, jsonError } = require('../errors');
 
 function createWorkingUnit(repo) {
   return async (req, res, ctx) => {
@@ -35,8 +35,14 @@ function getWorkingUnitsForMilestone(repo) {
 function updateWorkingUnitStatus(repo) {
   return async (req, res, ctx) => {
     const { status } = ctx.body;
-    repo.updateWorkingUnitStatus(ctx.params.id, status);
-    jsonOk(res, { ok: true });
+    if (typeof status !== 'string' || status.trim().length === 0) {
+      return jsonError(res, 400, 'invalid_status', 'status is required and must be a non-empty string');
+    }
+    const rows = repo.updateWorkingUnitStatus(ctx.params.id, status);
+    if (!rows || rows.length === 0) {
+      return jsonError(res, 404, 'not_found', 'Working unit not found');
+    }
+    jsonOk(res, rows[0]);
   };
 }
 

--- a/src/http/handlers/verdicts.js
+++ b/src/http/handlers/verdicts.js
@@ -20,8 +20,14 @@ function writeVerdict(repo) {
 function classifyVerdict(repo) {
   return async (req, res, ctx) => {
     const { classification } = ctx.body;
-    repo.classifyVerdict(ctx.params.id, classification);
-    jsonOk(res, { ok: true });
+    if (typeof classification !== 'string' || classification.trim().length === 0) {
+      return jsonError(res, 400, 'invalid_classification', 'classification is required and must be a non-empty string');
+    }
+    const rows = repo.classifyVerdict(ctx.params.id, classification);
+    if (!rows || rows.length === 0) {
+      return jsonError(res, 404, 'not_found', 'Verdict not found');
+    }
+    jsonOk(res, rows[0]);
   };
 }
 

--- a/src/platform/storage/repositories/aurex.js
+++ b/src/platform/storage/repositories/aurex.js
@@ -16,6 +16,9 @@ function createAurexRepository(deps) {
       },
       updateMissionStatus(id, status) {
         sqlRun('UPDATE missions SET status = ? WHERE id = ?', [status, id]);
+        // Re-select so handlers can 404 on a missing id instead of
+        // reporting blind success (#288).
+        return sqlJson('SELECT * FROM missions WHERE id = ?', [id]);
       },
 
       // --- Milestones ---
@@ -31,6 +34,7 @@ function createAurexRepository(deps) {
       },
       updateMilestoneStatus(id, status) {
         sqlRun('UPDATE milestones SET status = ? WHERE id = ?', [status, id]);
+        return sqlJson('SELECT * FROM milestones WHERE id = ?', [id]);
       },
       listMilestonesForMission(missionId) {
         return sqlJson('SELECT * FROM milestones WHERE mission_id = ? ORDER BY order_index ASC', [missionId]);
@@ -72,6 +76,7 @@ function createAurexRepository(deps) {
       },
       updateWorkingUnitStatus(id, status) {
         sqlRun('UPDATE working_units SET status = ? WHERE id = ?', [status, id]);
+        return sqlJson('SELECT * FROM working_units WHERE id = ?', [id]);
       },
 
       // --- Worker Handoffs ---
@@ -194,6 +199,7 @@ function createAurexRepository(deps) {
       },
       classifyVerdict(id, classification) {
         sqlRun('UPDATE validation_verdicts SET classification = ? WHERE id = ?', [classification, id]);
+        return sqlJson('SELECT * FROM validation_verdicts WHERE id = ?', [id]);
       },
       getVerdicts(milestoneId) {
         return sqlJson('SELECT * FROM validation_verdicts WHERE milestone_id = ?', [milestoneId]);
@@ -309,9 +315,15 @@ function createAurexRepository(deps) {
       incrementRetry(milestoneId) {
         sqlRun('UPDATE milestones SET retries = retries + 1 WHERE id = ?', [milestoneId]);
         const rows = sqlJson('SELECT retries, rescopes FROM milestones WHERE id = ?', [milestoneId]);
-        return rows.length > 0 ? rows[0] : { milestoneId, retries: 0, rescopes: 0 };
+        // null (not a fabricated counter object) when the milestone does
+        // not exist, so the handler can 404 (#288).
+        return rows.length > 0 ? rows[0] : null;
       },
       logRescope(milestoneId, event) {
+        const exists = sqlJson('SELECT id FROM milestones WHERE id = ?', [milestoneId]);
+        if (exists.length === 0) {
+          return false;
+        }
         sqlRun('UPDATE milestones SET rescopes = rescopes + 1 WHERE id = ?', [milestoneId]);
         sqlRun(
           'INSERT INTO rescope_events (id, milestone_id, contract_id, reason, previous_scope, new_scope) VALUES (?, ?, ?, ?, ?, ?)',
@@ -324,6 +336,7 @@ function createAurexRepository(deps) {
             event.newScope || '',
           ],
         );
+        return true;
       },
 
       // --- Todo Ledgers ---

--- a/test/final-batch8.test.js
+++ b/test/final-batch8.test.js
@@ -1,0 +1,215 @@
+// Regression tests for review batch 8: #288 (HTTP mutations report missing
+// ids / invalid statuses instead of blind 200s; code-index endpoints map
+// errors to real statuses), #303 (postinstall atomic, version-checked
+// patching), #304 (minors: memory-route limit/filters, harvest regex,
+// NaN args, streaming timeout escalation). Isolated temp DB.
+const fs = require('node:fs'),
+  os = require('node:os'),
+  path = require('node:path');
+
+process.env.LAPIS_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'lapis-batch8-'));
+
+const dbModule = require('../db');
+
+function mockRes() {
+  return {
+    statusCode: null,
+    body: null,
+    writeHead(code) {
+      this.statusCode = code;
+    },
+    end(body) {
+      this.body = body;
+    },
+  };
+}
+
+describe('#288 aurex mutations report existence', () => {
+  it('updateMissionStatus returns the row for a real mission and [] for a missing one', () => {
+    dbModule.ensureDb();
+    dbModule.sqlRun("INSERT INTO missions (id, description, status) VALUES ('m-b8', 'desc', 'planning')");
+
+    const { createAurexRepository } = require('../src/platform/storage/repositories/aurex'),
+      repo = createAurexRepository({ sqlJson: dbModule.sqlJson, sqlRun: dbModule.sqlRun }),
+      hit = repo.updateMissionStatus('m-b8', 'running'),
+      miss = repo.updateMissionStatus('m-nope', 'running');
+
+    expect(hit).toHaveLength(1);
+    expect(hit[0].status).toBe('running');
+    expect(miss).toHaveLength(0);
+    expect(repo.incrementRetry('m-nope')).toBeNull();
+  });
+});
+
+describe('#288 handlers return 400/404 instead of blind success', () => {
+  function makeRepo(overrides = {}) {
+    return {
+      updateMissionStatus: () => [],
+      updateMilestoneStatus: () => [],
+      updateWorkingUnitStatus: () => [],
+      classifyVerdict: () => [],
+      transitionBroadcast: () => [],
+      transitionFinding: () => [],
+      incrementRetry: () => null,
+      logRescope: () => false,
+      ...overrides,
+    };
+  }
+
+  async function call(handler, ctx) {
+    const res = mockRes();
+    await handler({}, res, ctx);
+    return res;
+  }
+
+  it('updateMissionStatus: missing id -> 404, missing status -> 400, hit -> 200', async () => {
+    const { updateMissionStatus } = require('../src/http/handlers/missions');
+    const miss = await call(updateMissionStatus(makeRepo()), { params: { id: 'm-x' }, body: { status: 'running' } });
+    expect(miss.statusCode).toBe(404);
+
+    const invalid = await call(updateMissionStatus(makeRepo({ updateMissionStatus: () => [{ id: 'm' }] })), {
+      params: { id: 'm-x' },
+      body: {},
+    });
+    expect(invalid.statusCode).toBe(400);
+
+    const hit = await call(
+      updateMissionStatus(makeRepo({ updateMissionStatus: () => [{ id: 'm-x', status: 'running' }] })),
+      {
+        params: { id: 'm-x' },
+        body: { status: 'running' },
+      },
+    );
+    expect(hit.statusCode).toBe(200);
+  });
+
+  it('updateMilestoneStatus / updateWorkingUnitStatus / classifyVerdict validate and 404', async () => {
+    const { updateMilestoneStatus } = require('../src/http/handlers/milestones'),
+      { updateWorkingUnitStatus } = require('../src/http/handlers/units'),
+      { classifyVerdict } = require('../src/http/handlers/verdicts');
+
+    const ms = await call(updateMilestoneStatus(makeRepo()), { params: { id: 'ms-x' }, body: { status: 'done' } });
+    expect(ms.statusCode).toBe(404);
+
+    const wu = await call(updateWorkingUnitStatus(makeRepo()), { params: { id: 'wu-x' }, body: {} });
+    expect(wu.statusCode).toBe(400);
+
+    const vv = await call(classifyVerdict(makeRepo()), { params: { id: 'vv-x' }, body: {} });
+    expect(vv.statusCode).toBe(400);
+  });
+
+  it('transitionBroadcast/transitionFinding never fabricate a success body', async () => {
+    const { transitionBroadcast } = require('../src/http/handlers/broadcasts'),
+      { transitionFinding } = require('../src/http/handlers/findings'),
+      b = await call(transitionBroadcast(makeRepo()), { params: { id: 'nope' }, body: { newStatus: 'resolved' } }),
+      f = await call(transitionFinding(makeRepo()), { params: { id: 'nope' }, body: { newStatus: 'verified' } });
+    expect(b.statusCode).toBe(404);
+    expect(b.body).not.toContain('"id":"nope"');
+    expect(f.statusCode).toBe(404);
+  });
+
+  it('incrementRetry/logRescope 404 on a missing milestone', async () => {
+    const { incrementRetry, logRescope } = require('../src/http/handlers/retry'),
+      r = await call(incrementRetry(makeRepo()), { params: { milestoneId: 'ms-x' }, body: {} }),
+      l = await call(logRescope(makeRepo()), { params: { milestoneId: 'ms-x' }, body: {} });
+    expect(r.statusCode).toBe(404);
+    expect(l.statusCode).toBe(404);
+  });
+
+  it('code-index endpoints map {error} results to non-200 statuses', () => {
+    const src = fs.readFileSync('src/http/handlers/code-index.js', 'utf8');
+    expect(src).toContain('function sendIndexResult');
+    expect(src.match(/return sendIndexResult\(res, result\)/g)).toHaveLength(3);
+    expect(src).toMatch(/not found\/i/);
+  });
+});
+
+describe('#303 postinstall patches atomically and only vulnerable versions', () => {
+  it('patches via staged rename, version-gates, and logs failures', () => {
+    const src = fs.readFileSync('postinstall.js', 'utf8');
+    expect(src).toContain('VULNERABLE_VERSIONS');
+    expect(src).toMatch(/stagedDir/);
+    expect(src).toMatch(/renameSync\(stagedDir, dir\)/);
+    expect(src).toMatch(/failed to patch nested/);
+    // The old rm-then-copy-then-swallow must be gone.
+    expect(src).not.toMatch(/rmSync\(dir, \{ recursive: true, force: true \}\);\n\s*fs\.cpSync\(safeSrc, dir/);
+  });
+});
+
+describe('#304 minors', () => {
+  it('memory route clamps non-numeric limits and forwards filters', async () => {
+    const { searchMemory } = require('../src/http/handlers/memory'),
+      captured = [],
+      deps = {
+        sqlJson: (sql, params) => {
+          captured.push({ sql, params });
+          return [];
+        },
+        sqlRun: () => {},
+      };
+
+    const res = mockRes();
+    await searchMemory(deps)({}, res, { body: { query: 'x', limit: 'abc' } });
+    expect(res.statusCode).toBe(200);
+    // search() fetches a multiple of the requested limit internally; what
+    // matters is that the bind is a real number, not the NaN that used to
+    // crash the query (#304).
+    const limitBind = Number(captured[0].params[captured[0].params.length - 1]);
+    expect(Number.isFinite(limitBind)).toBe(true);
+    expect(limitBind).toBeGreaterThan(0);
+
+    const res2 = mockRes();
+    await searchMemory(deps)({}, res2, { body: { query: 'x', limit: 250, project: 'demo', type: 'decision' } });
+    const clamped = Number(captured[1].params[captured[1].params.length - 1]);
+    expect(Number.isFinite(clamped)).toBe(true);
+    expect(clamped).toBeLessThan(2000); // a 250-limit is capped, not amplified 8x
+    const scopedSql = captured[1].sql;
+    expect(scopedSql).toContain('project');
+    expect(scopedSql).toContain('type');
+  });
+
+  it('harvest regex alternation is longest-first with a boundary', () => {
+    const src = fs.readFileSync('extensions/memory-layer/hooks/tool-guardrails.ts', 'utf8');
+    expect(src).toMatch(/\.\(tsx\|jsx\|mts\|cts\|mjs\|cjs\|ts\|js\|py\|go\|rs\)\\b\/g/);
+    // Behavior: the same shape the source uses now.
+    const matches = 'src/Widget.tsx test/foo.jsx'.match(/[\w/.-]+\.(tsx|jsx|mts|cts|mjs|cjs|ts|js|py|go|rs)\b/g);
+    expect(matches).toEqual(['src/Widget.tsx', 'test/foo.jsx']);
+  });
+
+  it('cleanup-sessions rejects a non-numeric --keep-last instead of crashing', () => {
+    const { execFileSync } = require('node:child_process');
+    // parseArgs slices argv[3+], so the script needs a leading filler token
+    // for --keep-last to be seen.
+    let threw = false;
+    try {
+      execFileSync('node', ['scripts/cleanup-sessions.js', 'run', '--keep-last', 'abc', '--json'], {
+        encoding: 'utf8',
+      });
+    } catch (e) {
+      threw = true;
+      expect(String(e.stderr)).toContain('non-negative integer');
+      expect(e.status).toBe(1);
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('serve rejects an invalid port instead of crashing in listen', () => {
+    const { execFileSync } = require('node:child_process');
+    let threw = false;
+    try {
+      execFileSync('node', ['cli.js', 'serve', '--port', 'not-a-port'], { encoding: 'utf8', timeout: 15000 });
+    } catch (e) {
+      threw = true;
+      expect(String(e.stderr) + String(e.stdout)).toContain('between 1 and 65535');
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('memStreaming escalates to SIGKILL and does not double-run after a timeout', () => {
+    const src = fs.readFileSync('extensions/memory-layer/host/memory-client.ts', 'utf8');
+    expect(src).toMatch(/killTimer/);
+    expect(src).toMatch(/child\.kill\('SIGKILL'\)/);
+    expect(src).toMatch(/timedOut = true;/);
+    expect(src).toMatch(/if \(timedOut\) \{[\s\S]*?not retrying/);
+  });
+});


### PR DESCRIPTION
Final batch from the 2026-09-06 full-codebase review — this closes out all 25 filed issues (#280–#304).

## #288 — HTTP routes stop reporting failures as success
- **Blind mutations now 404.** `updateMissionStatus` and friends ran `UPDATE … WHERE id = ?` and returned `200 {ok:true}` regardless; `transitionBroadcast`/`transitionFinding` fabricated a success body (`rows[0] || {id, status}`) for missing rows; `incrementRetry` fabricated a zeroed counter; `logRescope` inserted rescope events under nonexistent milestones. The aurex mutations now re-SELECT the row (or return `null`/`false`), and all handlers return **404** when the target does not exist — matching how the todo routes always behaved.
- **Status/classification bodies are validated** (non-empty string → else 400) instead of crashing into a raw 500 that leaked the SQLite `NOT NULL constraint failed` message.
- **code-index endpoints** (`/code/index`, `/code/reindex`, `/code/health/:repo`) mapped indexer `{error}` results to HTTP **200**; they now return 404 (not-found errors) or 500 (everything else).

## #303 — postinstall: atomic, version-gated, logged patching
`patchTransitiveVulns` replaced nested `brace-expansion` copies with `rmSync` + `cpSync` inside a bare `catch`: a copy failing partway (ENOSPC/EACCES) after the rm left node_modules **without the package**, silently. It also overwrote every nested copy regardless of installed version. Now: stage to a sibling temp dir and **rename** (atomic swap), patch **only copies at the known-vulnerable version**, log failures, clean up staging.

## #304 — P3 minors
- **memory-search route**: non-numeric `limit` bound NaN into `LIMIT ?` → 500; now clamped 1..100. `project`/`type`/`scope` filters are forwarded instead of silently dropped (search was always cross-project).
- **Guardrail path harvest**: extension alternation matched `.tsx` as `.ts`, harvesting nonexistent file names; now longest-first with a word boundary.
- **`cleanup-sessions --keep-last abc`** crashed with a NaN bind inside the delete transaction → validated, exits with a usage error.
- **`lapis serve --port abc`** crashed inside `listen` → validated (integer 1–65535).
- **`memStreaming` timeouts**: escalate to SIGKILL after a grace window (SIGTERM can't interrupt a child wedged in synchronous better-sqlite3 code), and a timed-out command is **no longer re-run in full** via the `mem()` fallback — two `index-repo` children racing the same repo was worse than reporting the timeout.

## Verification
Full suite: **150 files / 2098 tests passed**. Lint: 0 errors; format clean.

Fixes #288
Fixes #303
Fixes #304