### PR TITLE
feat(code-index): expose cancel-index through CLI, MCP, and Pi extension

### DIFF
--- a/commands/code-impl.js
+++ b/commands/code-impl.js
@@ -55,6 +55,15 @@ function indexStatus(args) {
   return codeIndexingService.indexStatusInternal(jobId);
 }
 
+function cancelIndex(args) {
+  const jobId = parseInt(args.job, 10);
+  if (!jobId || Number.isNaN(jobId)) {
+    const { jsonErrNoExit } = require('../db');
+    return jsonErrNoExit('Usage: cancel-index --job <id>');
+  }
+  return codeIndexingService.cancelIndexJobInternal(jobId);
+}
+
 function listIndexJobs(args) {
   return codeIndexingService.listIndexJobsInternal({
     onlyRunning: args.running === 'true',
@@ -147,4 +156,5 @@ module.exports = {
   getCodeSource,
   listCodeRepos,
   removeCodeRepo,
+  cancelIndex,
 };

--- a/extensions/memory-layer/tools/memory-tools.ts
+++ b/extensions/memory-layer/tools/memory-tools.ts
@@ -630,6 +630,41 @@ export function registerMemoryTools(pi: ExtensionAPI, deps: MemoryDeps) {
   });
 
   pi.registerTool({
+    name: 'cancel-index',
+    label: 'Cancel Index Job',
+    description: 'Cancel a running async code-indexing job by ID.',
+    parameters: Type.Object({
+      job: Type.String({ description: 'Job ID returned by index-repo-async' }),
+    }),
+    renderResult: renderCompactToolResult,
+    async execute(_id, params, _signal, _onUpdate, _ctx) {
+      try {
+        const result = await deps.mem('cancel-index', { job: String(params.job) });
+        if (!result || (result as any).error) {
+          return {
+            content: [{ type: 'text', text: `Error: ${(result as any)?.error || 'unknown'}` }],
+            details: {},
+            isError: true,
+          };
+        }
+        const cancelled = (result as any).cancelled === true || (result as any).ok === true,
+          text = cancelled
+            ? `🚫 Cancelled index job #${String(params.job)} (a job that already finished also reports cancelled).`
+            : `Could not cancel index job #${String(params.job)} — no such running job.`;
+        return {
+          content: [{ type: 'text', text }],
+          details: result ?? {},
+        };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Unexpected error: ${err instanceof Error ? err.message : String(err)}` }],
+          details: {},
+          isError: true,
+        };
+      }
+    },
+  });
+  pi.registerTool({
     name: 'index-status',
     label: 'Index Job Status',
     description:

--- a/src/cli/commands/code-index.js
+++ b/src/cli/commands/code-index.js
@@ -3,6 +3,7 @@ const codeCmd = require('../../../commands/code-impl'),
     'index-repo': '--path <path> [--name NAME]',
     'index-repo-async': '--path <path> [--name NAME] [--mode full|incremental]',
     'index-status': '--job <id>',
+    'cancel-index': '--job <id>',
     'list-index-jobs': '[--running] [--limit N]',
     'reindex-repo': '--repo <repo-name> [--mode full|incremental]',
     'health-code-repo': '--repo <repo-name>',
@@ -25,6 +26,7 @@ function register(commands) {
   commands['remove-code-repo'] = (args) => codeCmd.removeCodeRepo(args);
   commands['index-repo-async'] = (args) => codeCmd.indexRepoAsync(args);
   commands['index-status'] = (args) => codeCmd.indexStatus(args);
+  commands['cancel-index'] = (args) => codeCmd.cancelIndex(args);
   commands['list-index-jobs'] = (args) => codeCmd.listIndexJobs(args);
 }
 

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -440,6 +440,18 @@ module.exports.DOC_MODE_TO_COMMAND = DOC_MODE_TO_COMMAND;
         return { cmd: 'index-status', args: { job: String(p.job) } };
       },
     },
+
+    // ============ cancel-index ============
+    {
+      name: 'cancel-index',
+      description: 'Cancel a running async code-indexing job by ID.',
+      inputSchema: obj({
+        job: { schema: str('Job ID returned by index-repo-async') },
+      }),
+      toCommand(p) {
+        return { cmd: 'cancel-index', args: { job: String(p.job) } };
+      },
+    },
   ];
 
   module.exports.tools = tools;

--- a/test/cancel-index-wiring.test.js
+++ b/test/cancel-index-wiring.test.js
@@ -1,0 +1,28 @@
+// Wiring test for cancel-index: the gateway command, the MCP catalog entry,
+// and the Pi extension tool must all exist and agree (follow-up to #295,
+// which made cancellation actually work but exposed it nowhere).
+
+describe('cancel-index wiring', () => {
+  it('gateway dispatch validates the job argument', async () => {
+    const gateway = require('../src/cli/gateway');
+    const result = await gateway.dispatch('cancel-index', {});
+    expect(result).toEqual({ error: 'Usage: cancel-index --job <id>' });
+  });
+
+  it('gateway dispatch returns false for an unknown (never-started) job', async () => {
+    const gateway = require('../src/cli/gateway');
+    const result = await gateway.dispatch('cancel-index', { job: '42424242' });
+    expect(result).toBe(false);
+  });
+
+  it('cancel-index is listed in the CLI usage surface', () => {
+    const { USAGE } = require('../src/cli/commands/code-index');
+    expect(USAGE['cancel-index']).toBe('--job <id>');
+  });
+
+  it('the Pi extension registers a cancel-index tool (MCP parity)', () => {
+    const fs = require('node:fs');
+    const src = fs.readFileSync('extensions/memory-layer/tools/memory-tools.ts', 'utf8');
+    expect(src).toMatch(/name:\s*'cancel-index'/);
+  });
+});

--- a/test/mcp-server.test.js
+++ b/test/mcp-server.test.js
@@ -12,10 +12,11 @@
 describe('MCP tool catalog', () => {
   const { tools, toolByName, CODE_MODE_TO_COMMAND, DOC_MODE_TO_COMMAND } = require('../src/mcp/tools');
 
-  it('exposes the 11 expected tools', () => {
+  it('exposes the 12 expected tools', () => {
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual(
       [
+        'cancel-index',
         'index-status',
         'memory-code',
         'memory-delete',


### PR DESCRIPTION
Follow-up to #295 (review batch 6). Cancellation was made to work end-to-end — cooperative cancel via the worker's progress hook, lock cleanup on forced terminate, and `cancelIndexJobInternal` on the indexing service — but nothing could invoke it.

This wires the existing service function into all three surfaces:

- **CLI:** new `cancel-index --job <id>` dispatch command (router USAGE + `code-impl.cancelIndex`, same arg validation as `index-status`).
- **MCP:** `cancel-index` catalog entry (`{ job }` → `{ cmd: 'cancel-index' }`).
- **Pi extension:** `cancel-index` tool in `memory-tools.ts`, next to `index-status`, rendering cancelled/not-running feedback.

Returns `false` for unknown or already-finished jobs (the queue only tracks live workers); the tool renders that as "no such running job" rather than an error.

**Tests:** `test/cancel-index-wiring.test.js` — dispatch arg validation, unknown-job path, CLI usage surface, extension registration. `test/mcp-server.test.js` updated to the 12-tool catalog; the MCP ↔ extension parity guard passes unchanged.