### PR TITLE
fix(crosshash): the three P1s — index abort on swift/dart/zig, edge-wipe on re-index, unicode panic

### DIFF
--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -432,7 +432,13 @@ async fn index_one_repo(
             continue;
         };
         // Skip languages that don't support entity extraction
-        if matches!(language, Language::Html | Language::Css | Language::Unknown) {
+        // Swift/Dart/Zig have language detection + extractors dispatched but
+        // no working parser grammar yet — without skipping them, parse_file
+        // errors and the `?` aborts the whole index run (#317).
+        if matches!(
+            language,
+            Language::Html | Language::Css | Language::Unknown | Language::Swift | Language::Dart | Language::Zig
+        ) {
             skipped_files += 1;
             continue;
         }

--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -437,7 +437,12 @@ async fn index_one_repo(
         // errors and the `?` aborts the whole index run (#317).
         if matches!(
             language,
-            Language::Html | Language::Css | Language::Unknown | Language::Swift | Language::Dart | Language::Zig
+            Language::Html
+                | Language::Css
+                | Language::Unknown
+                | Language::Swift
+                | Language::Dart
+                | Language::Zig
         ) {
             skipped_files += 1;
             continue;

--- a/crosshash/crates/crosshash-graph/src/edge_extractor.rs
+++ b/crosshash/crates/crosshash-graph/src/edge_extractor.rs
@@ -115,7 +115,11 @@ fn parse_ts_import_names(line: &str) -> Option<Vec<String>> {
 }
 
 fn parse_ts_module_path(line: &str) -> Option<String> {
-    let lower = line.to_lowercase();
+    // to_ascii_lowercase is byte-length-preserving, so the offset found here
+    // maps exactly onto `line` and the slice stays on a char boundary.
+    // to_lowercase is NOT length-preserving ('İ' grows) and panicked on
+    // non-char boundaries for valid identifiers (#319).
+    let lower = line.to_ascii_lowercase();
     let pos = lower.find(" from ")?;
     let rest = line[pos + 6..].trim();
     if rest.is_empty() {
@@ -1360,5 +1364,14 @@ mod tests {
             parse_ts_module_path("export { X } from '../bar'"),
             Some("../bar".to_string())
         );
+    }
+
+    #[test]
+    fn parse_ts_module_path_handles_non_ascii_before_from() {
+        // 'İ' (U+0130) lowercases to a 3-byte sequence, so offsets from the
+        // lowercased line used to slice `line` mid-character and panic
+        // (#319). to_ascii_lowercase keeps byte lengths identical.
+        let line = "import { İ } from './x';";
+        assert_eq!(parse_ts_module_path(line).as_deref(), Some("./x"));
     }
 }

--- a/crosshash/crates/crosshash-graph/src/storage.rs
+++ b/crosshash/crates/crosshash-graph/src/storage.rs
@@ -532,11 +532,17 @@ impl GraphStorage {
     }
 
     pub fn remove_edges_for_repo(&self, repo_id: Uuid) -> Result<()> {
+        // Only re-index-derived (Static) edges are removed. AI-inferred edges
+        // — including user-accepted ones — and other repos' cross-repo edges
+        // must survive a re-index (#318).
         self.conn
             .execute(
-                "DELETE FROM edges WHERE source_entity_id IN (SELECT id FROM entities WHERE repo_id = ?1) \
-                 OR target_entity_id IN (SELECT id FROM entities WHERE repo_id = ?1)",
-                params![repo_id.to_string()],
+                "DELETE FROM edges WHERE source = ?1 \
+                 AND (source_entity_id IN (SELECT id FROM entities WHERE repo_id = ?2) \
+                 OR target_entity_id IN (SELECT id FROM entities WHERE repo_id = ?2))",
+                // '"Static"' is the serde encoding of EdgeSource::Static,
+                // matching how insert_edge stores the column.
+                params!["\"Static\"".to_string(), repo_id.to_string()],
             )
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
         Ok(())
@@ -1030,6 +1036,47 @@ mod tests {
             validated_at: None,
         };
         storage.insert_edge(&edge).unwrap();
+    }
+
+    #[test]
+    fn test_remove_edges_for_repo_preserves_non_static() {
+        let storage = GraphStorage::open_in_memory().unwrap();
+        let repo = test_repo();
+        storage.insert_repo(&repo).unwrap();
+
+        let entity_a = test_entity(repo.id);
+        let mut entity_b = test_entity(repo.id);
+        entity_b.id = Uuid::now_v7();
+        entity_b.name = "world".to_string();
+        storage.insert_entity(&entity_a).unwrap();
+        storage.insert_entity(&entity_b).unwrap();
+
+        let mk = |source: EdgeSource, kind: EdgeKind| Edge {
+            id: Uuid::now_v7(),
+            source_entity_id: entity_a.id,
+            target_entity_id: entity_b.id,
+            kind,
+            confidence: 1.0,
+            source,
+            metadata: None,
+            created_at: chrono::Utc::now(),
+            validated_at: None,
+        };
+
+        storage.insert_edge(&mk(EdgeSource::Static, EdgeKind::Calls)).unwrap();
+        storage.insert_edge(&mk(EdgeSource::AiInferred, EdgeKind::Calls)).unwrap();
+
+        storage.remove_edges_for_repo(repo.id).unwrap();
+
+        let remaining = storage
+            .conn
+            .prepare("SELECT COUNT(*) FROM edges")
+            .unwrap()
+            .query_row([], |row| row.get::<_, i64>(0))
+            .unwrap();
+        // Only the Static edge is re-index-derived; the user-facing
+        // AiInferred edge must survive (issue #318).
+        assert_eq!(remaining, 1);
     }
 
     #[test]

--- a/crosshash/crates/crosshash-graph/src/storage.rs
+++ b/crosshash/crates/crosshash-graph/src/storage.rs
@@ -1063,8 +1063,12 @@ mod tests {
             validated_at: None,
         };
 
-        storage.insert_edge(&mk(EdgeSource::Static, EdgeKind::Calls)).unwrap();
-        storage.insert_edge(&mk(EdgeSource::AiInferred, EdgeKind::Calls)).unwrap();
+        storage
+            .insert_edge(&mk(EdgeSource::Static, EdgeKind::Calls))
+            .unwrap();
+        storage
+            .insert_edge(&mk(EdgeSource::AiInferred, EdgeKind::Calls))
+            .unwrap();
 
         storage.remove_edges_for_repo(repo.id).unwrap();
 


### PR DESCRIPTION
Fixes the three P1 findings from the Rust review of `crosshash/` (#317, #318, #319), one commit per issue.

## #317 — `crosshash index` aborted on repos with .swift/.dart/.zig files
`repo add` detects all three languages and extractors exist for them, but the parser's grammar gate returns `UnsupportedLanguage` while the index loop's skip list only covered `Html | Css | Unknown` — so the `?` on `parse_file` aborted the **entire run** on the first such file. Now skipped like the other non-extractable languages.

## #318 — re-index wiped all edges for the repo
`remove_edges_for_repo` had no source filter: every re-index destroyed AI-inferred edges (including **user-accepted** ones from `feedback accept`), and in multi-repo setups indexing repo B deleted repo A's A→B edges, making cross-repo results depend on index order. The delete is now filtered to `source = '"Static"'` — the serde encoding the re-index path itself re-inserts. A new storage test asserts the `AiInferred` edge survives while the `Static` one is removed.

## #319 — Unicode byte-slice panic in TS module parsing
`parse_ts_module_path` searched `" from "` in `line.to_lowercase()` but sliced `line` with that byte offset. `to_lowercase` is not length-preserving (`İ` U+0130 grows to 3 bytes), so a valid identifier containing such a character panicked on a non-char boundary. Fixed with `to_ascii_lowercase` (byte-length-preserving) plus a regression test with the exact `İ` case.

## Verification
Workspace builds clean; `cargo test -p crosshash-graph`: **48 passed / 0 failed** (46 before + 2 new regression tests).

Fixes #317
Fixes #318
Fixes #319