### PR TITLE
fix(crosshash): data-integrity batch — index/remove transactions, surfaced AI write errors, strict row mappers

### DIFF
--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -407,6 +407,11 @@ async fn index_one_repo(
     let mut source_by_file = HashMap::new();
     let mut exported_added = 0usize;
 
+    // All writes below (entity/version/hash upserts, edge removal + reinsert)
+    // run in one transaction: a mid-index failure used to leave the repo
+    // half-written with all edges deleted (#320).
+    let tx = storage.transaction()?;
+
     for file in files {
         let rel = file
             .strip_prefix(&root)
@@ -492,6 +497,9 @@ async fn index_one_repo(
     for edge in &cross_repo_edges {
         storage.insert_edge(edge)?;
     }
+    // Committed before the AI phase: LLM calls are slow network I/O and must
+    // not hold the write lock; the static graph is already consistent here.
+    tx.commit()?;
     let edge_count = edges.len() + cross_repo_edges.len();
     let exports = storage.get_public_api_surface(repo.id)?.len();
 
@@ -600,12 +608,16 @@ async fn index_one_repo(
                         .await
                     {
                         Ok(suggestions) => {
-                            let suggested = suggestions.len();
                             let auto_accepted = engine.accept_high_confidence(&suggestions);
-                            let auto_count = auto_accepted.len();
+                            let mut auto_count = 0usize;
                             for edge in &auto_accepted {
-                                let _ = storage.insert_edge(edge);
+                                if let Err(e) = storage.insert_edge(edge) {
+                                    eprintln!("[index] failed to persist edge {}: {e}", edge.id);
+                                } else {
+                                    auto_count += 1;
+                                }
                             }
+                            let mut stored_suggestions = 0usize;
                             for suggestion in &suggestions {
                                 let status =
                                     if suggestion.confidence >= engine.auto_accept_threshold {
@@ -613,7 +625,7 @@ async fn index_one_repo(
                                     } else {
                                         "pending"
                                     };
-                                let _ = storage.insert_ai_edge_suggestion(
+                                if let Err(e) = storage.insert_ai_edge_suggestion(
                                     &suggestion.id,
                                     &suggestion.exporter_entity_id,
                                     &suggestion.consumer_entity_id,
@@ -621,10 +633,17 @@ async fn index_one_repo(
                                     &suggestion.reasoning,
                                     suggestion.confidence,
                                     status,
-                                );
+                                ) {
+                                    eprintln!(
+                                        "[index] failed to persist AI edge suggestion {}: {e}",
+                                        suggestion.id
+                                    );
+                                } else {
+                                    stored_suggestions += 1;
+                                }
                             }
                             let input_est = surface_a.entities.len() as u64 * 4;
-                            let output_est = suggested as u64 * 20;
+                            let output_est = stored_suggestions as u64 * 20;
                             let cost = (input_est + output_est) as f64 * 0.00001;
                             let log_id = Uuid::now_v7();
                             let reason_str = format!(
@@ -634,7 +653,7 @@ async fn index_one_repo(
                                     .first()
                                     .unwrap_or(&crosshash_ai::GateReason::Forced)
                             );
-                            let _ = storage.insert_ai_inference_log(
+                            if let Err(e) = storage.insert_ai_inference_log(
                                 &log_id,
                                 &reason_str,
                                 &decision.scope,
@@ -643,12 +662,17 @@ async fn index_one_repo(
                                 input_est,
                                 output_est,
                                 cost,
-                                suggested,
+                                stored_suggestions,
                                 auto_count,
-                            );
-                            ai_edges_suggested += suggested;
+                            ) {
+                                eprintln!(
+                                    "[index] failed to persist AI inference log {log_id}: {e}"
+                                );
+                            } else {
+                                ai_cost += cost;
+                            }
+                            ai_edges_suggested += stored_suggestions;
                             ai_edges_auto_accepted += auto_count;
-                            ai_cost += cost;
                         }
                         Err(e) => {
                             eprintln!(
@@ -988,19 +1012,26 @@ async fn execute_discover_edges(
                     .await
                 {
                     Ok(suggestions) => {
-                        let suggested = suggestions.len();
                         let auto_accepted = engine.accept_high_confidence(&suggestions);
-                        let auto_count = auto_accepted.len();
+                        let mut auto_count = 0usize;
                         for edge in &auto_accepted {
-                            let _ = storage.insert_edge(edge);
+                            if let Err(e) = storage.insert_edge(edge) {
+                                eprintln!(
+                                    "[discover-edges] failed to persist edge {}: {e}",
+                                    edge.id
+                                );
+                            } else {
+                                auto_count += 1;
+                            }
                         }
+                        let mut stored_suggestions = 0usize;
                         for suggestion in &suggestions {
                             let status = if suggestion.confidence >= engine.auto_accept_threshold {
                                 "accepted"
                             } else {
                                 "pending"
                             };
-                            let _ = storage.insert_ai_edge_suggestion(
+                            if let Err(e) = storage.insert_ai_edge_suggestion(
                                 &suggestion.id,
                                 &suggestion.exporter_entity_id,
                                 &suggestion.consumer_entity_id,
@@ -1008,10 +1039,17 @@ async fn execute_discover_edges(
                                 &suggestion.reasoning,
                                 suggestion.confidence,
                                 status,
-                            );
+                            ) {
+                                eprintln!(
+                                    "[discover-edges] failed to persist AI edge suggestion {}: {e}",
+                                    suggestion.id
+                                );
+                            } else {
+                                stored_suggestions += 1;
+                            }
                         }
                         let input_est = surface_a.entities.len() as u64 * 4;
-                        let output_est = suggested as u64 * 20;
+                        let output_est = stored_suggestions as u64 * 20;
                         let cost = (input_est + output_est) as f64 * 0.00001;
                         let log_id = Uuid::now_v7();
                         let reason_str = format!(
@@ -1021,7 +1059,7 @@ async fn execute_discover_edges(
                                 .first()
                                 .unwrap_or(&crosshash_ai::GateReason::Forced)
                         );
-                        let _ = storage.insert_ai_inference_log(
+                        if let Err(e) = storage.insert_ai_inference_log(
                             &log_id,
                             &reason_str,
                             &decision.scope,
@@ -1030,14 +1068,19 @@ async fn execute_discover_edges(
                             input_est,
                             output_est,
                             cost,
-                            suggested,
+                            stored_suggestions,
                             auto_count,
-                        );
-                        ai_edges_suggested += suggested;
+                        ) {
+                            eprintln!(
+                                "[discover-edges] failed to persist AI inference log {log_id}: {e}"
+                            );
+                        } else {
+                            total_input_tokens += input_est;
+                            total_output_tokens += output_est;
+                            total_cost += cost;
+                        }
+                        ai_edges_suggested += stored_suggestions;
                         ai_edges_auto_accepted += auto_count;
-                        total_input_tokens += input_est;
-                        total_output_tokens += output_est;
-                        total_cost += cost;
                     }
                     Err(e) => {
                         let name = &surfaces[i].1;

--- a/crosshash/crates/crosshash-graph/src/storage.rs
+++ b/crosshash/crates/crosshash-graph/src/storage.rs
@@ -82,17 +82,17 @@ impl GraphStorage {
                 let last_indexed_str: String = row.get("last_indexed_at")?;
 
                 Ok(Repo {
-                    id: Uuid::parse_str(&row.get::<_, String>("id")?).unwrap(),
+                    id: db_parse(Uuid::parse_str(&row.get::<_, String>("id")?))?,
                     name: row.get("name")?,
                     root_path: row.get("root_path")?,
                     git_remote: row.get("git_remote")?,
                     default_branch: row.get("default_branch")?,
-                    languages: serde_json::from_str(&languages_str).unwrap_or_default(),
-                    workspace_type: serde_json::from_str(&ws_type_str)
-                        .unwrap_or(WorkspaceType::None),
-                    last_indexed_at: chrono::DateTime::parse_from_rfc3339(&last_indexed_str)
-                        .unwrap()
-                        .to_utc(),
+                    languages: db_parse(serde_json::from_str(&languages_str))?,
+                    workspace_type: db_parse(serde_json::from_str(&ws_type_str))?,
+                    last_indexed_at: db_parse(chrono::DateTime::parse_from_rfc3339(
+                        &last_indexed_str,
+                    ))?
+                    .with_timezone(&chrono::Utc),
                     commit_hash: row.get("commit_hash")?,
                 })
             })
@@ -115,17 +115,17 @@ impl GraphStorage {
                 let last_indexed_str: String = row.get("last_indexed_at")?;
 
                 Ok(Repo {
-                    id: Uuid::parse_str(&row.get::<_, String>("id")?).unwrap(),
+                    id: db_parse(Uuid::parse_str(&row.get::<_, String>("id")?))?,
                     name: row.get("name")?,
                     root_path: row.get("root_path")?,
                     git_remote: row.get("git_remote")?,
                     default_branch: row.get("default_branch")?,
-                    languages: serde_json::from_str(&languages_str).unwrap_or_default(),
-                    workspace_type: serde_json::from_str(&ws_type_str)
-                        .unwrap_or(WorkspaceType::None),
-                    last_indexed_at: chrono::DateTime::parse_from_rfc3339(&last_indexed_str)
-                        .unwrap()
-                        .to_utc(),
+                    languages: db_parse(serde_json::from_str(&languages_str))?,
+                    workspace_type: db_parse(serde_json::from_str(&ws_type_str))?,
+                    last_indexed_at: db_parse(chrono::DateTime::parse_from_rfc3339(
+                        &last_indexed_str,
+                    ))?
+                    .with_timezone(&chrono::Utc),
                     commit_hash: row.get("commit_hash")?,
                 })
             })
@@ -276,17 +276,17 @@ impl GraphStorage {
                 let last_indexed_str: String = row.get("last_indexed_at")?;
 
                 Ok(Repo {
-                    id: Uuid::parse_str(&row.get::<_, String>("id")?).unwrap(),
+                    id: db_parse(Uuid::parse_str(&row.get::<_, String>("id")?))?,
                     name: row.get("name")?,
                     root_path: row.get("root_path")?,
                     git_remote: row.get("git_remote")?,
                     default_branch: row.get("default_branch")?,
-                    languages: serde_json::from_str(&languages_str).unwrap_or_default(),
-                    workspace_type: serde_json::from_str(&ws_type_str)
-                        .unwrap_or(WorkspaceType::None),
-                    last_indexed_at: chrono::DateTime::parse_from_rfc3339(&last_indexed_str)
-                        .unwrap()
-                        .to_utc(),
+                    languages: db_parse(serde_json::from_str(&languages_str))?,
+                    workspace_type: db_parse(serde_json::from_str(&ws_type_str))?,
+                    last_indexed_at: db_parse(chrono::DateTime::parse_from_rfc3339(
+                        &last_indexed_str,
+                    ))?
+                    .with_timezone(&chrono::Utc),
                     commit_hash: row.get("commit_hash")?,
                 })
             })
@@ -340,6 +340,12 @@ impl GraphStorage {
             Some(r) => r,
             None => return Ok(()),
         };
+        // The 5 dependent DELETEs are atomic — a partial remove would leave
+        // orphaned versions/hashes/edges behind (#320).
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| CoreError::StorageError(e.to_string()))?;
         self.remove_edges_for_repo(repo.id)?;
         self.conn
             .execute(
@@ -364,6 +370,8 @@ impl GraphStorage {
                 "DELETE FROM repos WHERE id = ?1",
                 params![repo.id.to_string()],
             )
+            .map_err(|e| CoreError::StorageError(e.to_string()))?;
+        tx.commit()
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
         Ok(())
     }
@@ -452,7 +460,7 @@ impl GraphStorage {
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
 
         let edges = stmt
-            .query_map([], |row| Ok(row_to_edge(row)))
+            .query_map([], row_to_edge)
             .map_err(|e| CoreError::StorageError(e.to_string()))?
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
@@ -504,7 +512,7 @@ impl GraphStorage {
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
 
         let edges = stmt
-            .query_map(params![repo_id.to_string()], |row| Ok(row_to_edge(row)))
+            .query_map(params![repo_id.to_string()], row_to_edge)
             .map_err(|e| CoreError::StorageError(e.to_string()))?
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
@@ -523,12 +531,19 @@ impl GraphStorage {
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
 
         let edges = stmt
-            .query_map(params![entity_id.to_string()], |row| Ok(row_to_edge(row)))
+            .query_map(params![entity_id.to_string()], row_to_edge)
             .map_err(|e| CoreError::StorageError(e.to_string()))?
             .collect::<std::result::Result<Vec<_>, _>>()
             .map_err(|e| CoreError::StorageError(e.to_string()))?;
 
         Ok(edges)
+    }
+
+    /// Begin a transaction on this connection. The CLI's index write phase
+    /// wraps its writes so a mid-index failure cannot leave a half-written
+    /// repo (#320). unchecked_transaction keeps &self working.
+    pub fn transaction(&self) -> rusqlite::Result<rusqlite::Transaction<'_>> {
+        self.conn.unchecked_transaction()
     }
 
     pub fn remove_edges_for_repo(&self, repo_id: Uuid) -> Result<()> {
@@ -580,7 +595,7 @@ impl GraphStorage {
                 let to_arr = |v: Vec<u8>| -> [u8; 32] { safe_hash_from_slice(&v) };
 
                 Ok(EntityVersion {
-                    entity_id: Uuid::parse_str(&row.get::<_, String>(0).unwrap()).unwrap(),
+                    entity_id: db_parse(Uuid::parse_str(&row.get::<_, String>(0).unwrap()))?,
                     commit_hash: row.get(1).unwrap(),
                     name: row.get(2).unwrap(),
                     qualified_name: row.get(3).unwrap(),
@@ -590,9 +605,8 @@ impl GraphStorage {
                     structural_hash: to_arr(struct_hash),
                     identity_hash: to_arr(ident_hash),
                     context_hash: to_arr(ctx_hash),
-                    snapshot_at: chrono::DateTime::parse_from_rfc3339(&snapshot_str)
-                        .unwrap()
-                        .to_utc(),
+                    snapshot_at: db_parse(chrono::DateTime::parse_from_rfc3339(&snapshot_str))?
+                        .with_timezone(&chrono::Utc),
                 })
             })
             .map_err(|e| CoreError::StorageError(e.to_string()))?
@@ -857,7 +871,17 @@ fn safe_hash_from_slice(v: &[u8]) -> [u8; 32] {
     arr
 }
 
-fn row_to_edge(row: &rusqlite::Row) -> Edge {
+/// Map a parse failure on DB-derived data to a rusqlite error so the caller's
+/// map_err turns it into CoreError::StorageError instead of panicking on
+/// corrupt/foreign rows (#325). Row mappers must not unwrap DB strings.
+fn db_parse<T, E>(result: std::result::Result<T, E>) -> rusqlite::Result<T>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    result.map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+}
+
+fn row_to_edge(row: &rusqlite::Row) -> rusqlite::Result<Edge> {
     use crosshash_core::{EdgeKind, EdgeSource};
     let kind_str: String = row.get("kind").unwrap();
     let source_str: String = row.get("source").unwrap();
@@ -865,25 +889,27 @@ fn row_to_edge(row: &rusqlite::Row) -> Edge {
     let created_at_str: String = row.get("created_at").unwrap();
     let validated_at_str: Option<String> = row.get("validated_at").unwrap_or(None);
 
-    Edge {
-        id: Uuid::parse_str(&row.get::<_, String>("id").unwrap()).unwrap(),
-        source_entity_id: Uuid::parse_str(&row.get::<_, String>("source_entity_id").unwrap())
-            .unwrap(),
-        target_entity_id: Uuid::parse_str(&row.get::<_, String>("target_entity_id").unwrap())
-            .unwrap(),
-        kind: serde_json::from_str(&kind_str).unwrap_or(EdgeKind::Calls),
+    // Corrupt kind/source values are an error, NOT silently reclassified as
+    // Calls/Static — that corrupted graph semantics invisibly (#327).
+    Ok(Edge {
+        id: db_parse(Uuid::parse_str(&row.get::<_, String>("id").unwrap()))?,
+        source_entity_id: db_parse(Uuid::parse_str(
+            &row.get::<_, String>("source_entity_id").unwrap(),
+        ))?,
+        target_entity_id: db_parse(Uuid::parse_str(
+            &row.get::<_, String>("target_entity_id").unwrap(),
+        ))?,
+        kind: db_parse(serde_json::from_str(&kind_str))?,
         confidence: row.get("confidence").unwrap_or(1.0),
-        source: serde_json::from_str(&source_str).unwrap_or(EdgeSource::Static),
+        source: db_parse(serde_json::from_str(&source_str))?,
         metadata: metadata_str.and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok()),
-        created_at: chrono::DateTime::parse_from_rfc3339(&created_at_str)
-            .unwrap()
-            .to_utc(),
+        created_at: db_parse(chrono::DateTime::parse_from_rfc3339(&created_at_str))?.to_utc(),
         validated_at: validated_at_str.and_then(|s| {
             chrono::DateTime::parse_from_rfc3339(&s)
                 .map(|d| d.to_utc())
                 .ok()
         }),
-    }
+    })
 }
 
 fn row_to_entity(row: &rusqlite::Row) -> Entity {

--- a/crosshash/crates/crosshash-graph/src/storage.rs
+++ b/crosshash/crates/crosshash-graph/src/storage.rs
@@ -1,4 +1,4 @@
-use crosshash_core::{CoreError, Edge, Entity, EntityVersion, Repo, Result, WorkspaceType};
+use crosshash_core::{CoreError, Edge, Entity, EntityVersion, Repo, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::path::Path;
 use uuid::Uuid;
@@ -882,7 +882,6 @@ where
 }
 
 fn row_to_edge(row: &rusqlite::Row) -> rusqlite::Result<Edge> {
-    use crosshash_core::{EdgeKind, EdgeSource};
     let kind_str: String = row.get("kind").unwrap();
     let source_str: String = row.get("source").unwrap();
     let metadata_str: Option<String> = row.get("metadata").unwrap_or(None);
@@ -952,7 +951,7 @@ fn row_to_entity(row: &rusqlite::Row) -> Entity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crosshash_core::{EdgeKind, EdgeSource, EntityKind, Language, Visibility};
+    use crosshash_core::{EdgeKind, EdgeSource, EntityKind, Language, Visibility, WorkspaceType};
 
     fn test_repo() -> Repo {
         Repo {


### PR DESCRIPTION
Second crosshash batch from the Rust review: the data-integrity cluster (#320, #322, #325, #327).

## #320 — index and remove writes are atomic
`index_one_repo`'s write phase (entity/version/file-hash upserts, `mark_entities_deleted`, `remove_edges_for_repo`, static + cross-repo edge inserts) ran with **no transaction** — a crash or one unreadable file left the repo half-written with all edges deleted. The whole write phase now runs in one transaction (opened before the parse loop, **committed before the AI phase** so LLM network calls never hold the write lock). `remove_repo`'s 5 dependent DELETEs are wrapped the same way. Implemented with `unchecked_transaction` so `&self` storage methods keep working.

## #322 — AI write paths stop swallowing errors
All six `let _ = storage.insert_edge/insert_ai_edge_suggestion/insert_ai_inference_log` sites discarded failures while still incrementing `ai_edges_auto_accepted`/cost and printing success — a locked DB or FK rejection of a hallucinated entity id was invisible. Failures now log to stderr with the failing edge id and are **excluded from the accepted/suggested/cost tallies**; all-success behavior is byte-identical.

## #325/#327 — row mappers can't panic or silently reclassify
Row-mapping closures called `Uuid::parse_str(...).unwrap()`, `DateTime::parse_from_rfc3339(...).unwrap()`, and `serde_json::from_str::<Language>(...).unwrap()` on DB-derived strings — a corrupt or foreign-schema DB made every read command **panic**. Parses now go through a `db_parse` helper mapping into `rusqlite::Error::ToSqlConversionFailure`, which the existing `map_err` turns into `CoreError::StorageError`. `row_to_edge` returns `Result`, and unknown edge kind/source values are **errors instead of being silently reclassified** as `Calls`/`Static` (#327 — a `Contains` edge becoming a call edge corrupted graph semantics invisibly).

## Verification
`cargo check --workspace`: 0 errors. `cargo test --workspace`: **24 binaries, 282 tests, 0 failures** (storage suite includes the #318 edge-preservation test from the previous PR). `cargo fmt --all` clean.

Fixes #320
Fixes #322
Fixes #325
Fixes #327