### PR TITLE
fix(crosshash): linear edge extraction, watcher spin, static discovery, feedback validation

### DIFF
--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -1171,14 +1171,26 @@ fn execute_feedback(format: OutputFormat, db: Option<PathBuf>, cmd: FeedbackComm
             let suggestion = storage
                 .get_suggestion_by_id(&id)?
                 .ok_or_else(|| anyhow!("suggestion not found: {edge_id}"))?;
-            storage.update_suggestion_status(&id, "accepted")?;
-            let fb_id = Uuid::now_v7();
-            storage.insert_feedback(&fb_id, &id, "accept", None)?;
-            let exporter =
-                Uuid::parse_str(suggestion["exporter_entity_id"].as_str().unwrap_or("")).ok();
-            let consumer =
-                Uuid::parse_str(suggestion["consumer_entity_id"].as_str().unwrap_or("")).ok();
-            if let (Some(exporter_id), Some(consumer_id)) = (exporter, consumer) {
+            // Validate entity ids BEFORE mutating anything (#328): a failed
+            // parse must leave the suggestion pending, not report success
+            // without an edge.
+            let exporter = Uuid::parse_str(suggestion["exporter_entity_id"].as_str().unwrap_or(""));
+            let consumer = Uuid::parse_str(suggestion["consumer_entity_id"].as_str().unwrap_or(""));
+            let (exporter_id, consumer_id) = match (exporter, consumer) {
+                (Ok(e), Ok(c)) => (e, c),
+                _ => anyhow::bail!(
+                    "cannot accept suggestion {edge_id}: exporter/consumer entity ids missing or invalid (exporter={:?}, consumer={:?}); suggestion left unchanged",
+                    suggestion["exporter_entity_id"].as_str(),
+                    suggestion["consumer_entity_id"].as_str()
+                ),
+            };
+            let already_exists = storage.get_edges_all()?.iter().any(|e| {
+                e.source_entity_id == consumer_id
+                    && e.target_entity_id == exporter_id
+                    && e.kind == EdgeKind::PackageDep
+                    && e.source == EdgeSource::AiInferred
+            });
+            if !already_exists {
                 let edge = Edge {
                     id: Uuid::now_v7(),
                     source_entity_id: consumer_id,
@@ -1195,6 +1207,11 @@ fn execute_feedback(format: OutputFormat, db: Option<PathBuf>, cmd: FeedbackComm
                 };
                 storage.insert_edge(&edge)?;
             }
+            // Status flip + feedback only happen once the edge exists (or
+            // already did).
+            storage.update_suggestion_status(&id, "accepted")?;
+            let fb_id = Uuid::now_v7();
+            storage.insert_feedback(&fb_id, &id, "accept", None)?;
             format!("accepted AI edge suggestion {edge_id}")
         }
         Some(FeedbackAction::Reject { edge_id }) => {

--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -907,6 +907,42 @@ async fn execute_discover_edges(
             json!({"surfaces": surfaces.iter().map(|s| s.2.to_prompt_json()).collect::<Vec<_>>(), "repo_count": filtered_repos.len()}),
         );
     }
+    // Static extraction, using the same pipeline as the index path
+    // (`infer_static_edges`). Previously this command only built API surfaces
+    // and the summary always claimed "static edges found" without computing
+    // any (#324). `--static-only` stops here, before any LLM call.
+    let mut static_edges_stored = 0usize;
+    for repo in &filtered_repos {
+        let root = PathBuf::from(&repo.root_path);
+        let entities = storage.get_entities_by_repo(repo.id)?;
+        if entities.is_empty() {
+            continue;
+        }
+        let mut source_by_file: HashMap<String, String> = HashMap::new();
+        for file in collect_source_files(&root, &repo.languages)? {
+            let rel = file
+                .strip_prefix(&root)
+                .unwrap_or(&file)
+                .to_string_lossy()
+                .to_string();
+            match std::fs::read_to_string(&file) {
+                Ok(source) => {
+                    source_by_file.insert(rel, source);
+                }
+                Err(e) => eprintln!("[discover-edges] skipping unreadable file {rel}: {e}"),
+            }
+        }
+        for edge in infer_static_edges(repo.id, &root, &entities, &source_by_file) {
+            if let Err(e) = storage.insert_edge(&edge) {
+                eprintln!(
+                    "[discover-edges] failed to persist static edge {}: {e}",
+                    edge.id
+                );
+            } else {
+                static_edges_stored += 1;
+            }
+        }
+    }
     let ai_config = load_ai_config();
     let decision = crosshash_ai::AiGate::decide(&crosshash_ai::GateInput {
         ai_enabled: ai_config.enabled && !cmd.static_only,
@@ -1048,7 +1084,7 @@ async fn execute_discover_edges(
         }
     }
     let text = format!(
-        "static edges found, AI edges suggested: {ai_edges_suggested}, auto-accepted: {ai_edges_auto_accepted}, AI cost: ${total_cost:.4}, gate_run_ai={}",
+        "static edges stored: {static_edges_stored}, AI edges suggested: {ai_edges_suggested}, auto-accepted: {ai_edges_auto_accepted}, AI cost: ${total_cost:.4}, gate_run_ai={}",
         decision.should_run_ai
     );
     print(
@@ -1057,6 +1093,7 @@ async fn execute_discover_edges(
         json!({
             "surfaces": surfaces.iter().map(|s| s.2.to_prompt_json()).collect::<Vec<_>>(),
             "gate": decision,
+            "static_edges_stored": static_edges_stored,
             "ai_edges_suggested": ai_edges_suggested,
             "ai_edges_auto_accepted": ai_edges_auto_accepted,
             "ai_cost": total_cost,

--- a/crosshash/crates/crosshash-cli/src/commands.rs
+++ b/crosshash/crates/crosshash-cli/src/commands.rs
@@ -1609,38 +1609,56 @@ async fn execute_watch(
         .collect();
 
     let root_names: Vec<String> = watch_roots.iter().map(|(n, _)| n.clone()).collect();
-    std::thread::spawn(move || -> Result<()> {
-        let (notify_tx, notify_rx) = std::sync::mpsc::channel::<notify::Event>();
-        let mut watcher = notify::RecommendedWatcher::new(
-            move |res: Result<notify::Event, notify::Error>| {
-                if let Ok(event) = res {
-                    let _ = notify_tx.send(event);
+    // The watcher thread owns the only channel sender. If it dies (e.g. a repo
+    // root becomes unwatchable), the channel closes and the recv loop below
+    // must stop instead of busy-spinning on a closed channel (#323). The
+    // thread's error is stored here so the user sees why watching stopped.
+    let watcher_error: std::sync::Arc<std::sync::Mutex<Option<String>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(None));
+    {
+        let watcher_error = std::sync::Arc::clone(&watcher_error);
+        std::thread::spawn(move || {
+            let result: Result<()> = (|| {
+                let (notify_tx, notify_rx) = std::sync::mpsc::channel::<notify::Event>();
+                let mut watcher = notify::RecommendedWatcher::new(
+                    move |res: Result<notify::Event, notify::Error>| {
+                        if let Ok(event) = res {
+                            let _ = notify_tx.send(event);
+                        }
+                    },
+                    notify::Config::default(),
+                )?;
+                for (name, path) in &watch_roots {
+                    watcher
+                        .watch(std::path::Path::new(path), notify::RecursiveMode::Recursive)
+                        .map_err(|e| anyhow!("failed to watch {name} ({path}): {e}"))?;
                 }
-            },
-            notify::Config::default(),
-        )?;
-        for (_, path) in &watch_roots {
-            watcher.watch(std::path::Path::new(path), notify::RecursiveMode::Recursive)?;
-        }
-        for event in notify_rx.iter() {
-            if matches!(
-                event.kind,
-                notify::EventKind::Create(_)
-                    | notify::EventKind::Modify(_)
-                    | notify::EventKind::Remove(_)
-            ) {
-                for path in &event.paths {
-                    for (name, root) in &watch_roots {
-                        if path.starts_with(root) {
-                            let _ = tx.blocking_send(name.clone());
-                            break;
+                for event in notify_rx.iter() {
+                    if matches!(
+                        event.kind,
+                        notify::EventKind::Create(_)
+                            | notify::EventKind::Modify(_)
+                            | notify::EventKind::Remove(_)
+                    ) {
+                        for path in &event.paths {
+                            for (name, root) in &watch_roots {
+                                if path.starts_with(root) {
+                                    let _ = tx.blocking_send(name.clone());
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
+                Ok(())
+            })();
+            if let Err(e) = result {
+                if let Ok(mut slot) = watcher_error.lock() {
+                    *slot = Some(e.to_string());
+                }
             }
-        }
-        Ok(())
-    });
+        });
+    }
 
     for name in &root_names {
         eprintln!("watching {name}");
@@ -1653,47 +1671,56 @@ async fn execute_watch(
 
     let debounce = Duration::from_millis(cmd.debounce_ms);
     loop {
-        if let Some(repo_name) = rx.recv().await {
-            let mut pending = HashSet::new();
-            pending.insert(repo_name);
+        // A closed channel means the watcher thread exited: stop instead of
+        // spinning on `recv() == Err` (#323), and tell the user why.
+        let Some(repo_name) = rx.recv().await else {
+            let reason = watcher_error
+                .lock()
+                .ok()
+                .and_then(|slot| slot.clone())
+                .unwrap_or_else(|| "watcher thread exited unexpectedly".to_string());
+            eprintln!("[watch] file watching stopped: {reason}");
+            return Ok(());
+        };
+        let mut pending = HashSet::new();
+        pending.insert(repo_name);
 
-            let deadline = tokio::time::Instant::now() + debounce;
-            loop {
-                tokio::select! {
-                    Some(name) = rx.recv() => {
-                        pending.insert(name);
-                    }
-                    _ = tokio::time::sleep_until(deadline) => {
-                        break;
-                    }
+        let deadline = tokio::time::Instant::now() + debounce;
+        loop {
+            tokio::select! {
+                Some(name) = rx.recv() => {
+                    pending.insert(name);
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    break;
                 }
             }
+        }
 
-            for name in &pending {
-                eprintln!("[watch] re-indexing {name}...");
-                let idx_db = db
-                    .clone()
-                    .unwrap_or_else(|| PathBuf::from(".crosshash/crosshash.db"));
-                match open_storage(Some(idx_db)) {
-                    Ok(idx_storage) => {
-                        if let Some(repo) = idx_storage.get_repo_by_name(name)? {
-                            let index_cmd = IndexCommand {
-                                repo: Some(name.clone()),
-                                incremental: true,
-                                no_ai: false,
-                                force_ai: false,
-                            };
-                            match index_one_repo(&idx_storage, &repo, true, &index_cmd).await {
-                                Ok(summary) => eprintln!(
-                                    "[watch] {}: {} entities, {} edges",
-                                    name, summary.entities_extracted, summary.edges
-                                ),
-                                Err(e) => eprintln!("[watch] error indexing {name}: {e}"),
-                            }
+        for name in &pending {
+            eprintln!("[watch] re-indexing {name}...");
+            let idx_db = db
+                .clone()
+                .unwrap_or_else(|| PathBuf::from(".crosshash/crosshash.db"));
+            match open_storage(Some(idx_db)) {
+                Ok(idx_storage) => {
+                    if let Some(repo) = idx_storage.get_repo_by_name(name)? {
+                        let index_cmd = IndexCommand {
+                            repo: Some(name.clone()),
+                            incremental: true,
+                            no_ai: false,
+                            force_ai: false,
+                        };
+                        match index_one_repo(&idx_storage, &repo, true, &index_cmd).await {
+                            Ok(summary) => eprintln!(
+                                "[watch] {}: {} entities, {} edges",
+                                name, summary.entities_extracted, summary.edges
+                            ),
+                            Err(e) => eprintln!("[watch] error indexing {name}: {e}"),
                         }
                     }
-                    Err(e) => eprintln!("[watch] error opening storage: {e}"),
                 }
+                Err(e) => eprintln!("[watch] error opening storage: {e}"),
             }
         }
     }

--- a/crosshash/crates/crosshash-graph/src/edge_extractor.rs
+++ b/crosshash/crates/crosshash-graph/src/edge_extractor.rs
@@ -439,6 +439,62 @@ fn import_confidence(target_in_resolved_file: bool, file_resolved: bool, is_rela
     }
 }
 
+/// Collect identifiers that appear immediately followed by an optional
+/// whitespace and `(` — i.e. call-site candidate names. One linear pass over
+/// the body, replacing the old per-target `format!` + substring scan that
+/// was quadratic in entity count (#321).
+fn called_names(body: &str) -> std::collections::HashSet<&str> {
+    let bytes = body.as_bytes();
+    let mut names = std::collections::HashSet::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let is_ident_start = bytes[i] == b'_' || bytes[i].is_ascii_alphabetic();
+        let prev_is_word = i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_');
+        if is_ident_start && !prev_is_word {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            let mut j = i;
+            while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t') {
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'(' {
+                names.insert(&body[start..i]);
+            }
+        } else {
+            i += 1;
+        }
+    }
+    names
+}
+
+/// Collect the identifier token immediately following each occurrence of a
+/// keyword (e.g. "extends", "implements", ": ") in a lowercased body. Linear
+/// per keyword (#321).
+fn identifiers_after(body: &str, keyword: &str) -> std::collections::HashSet<String> {
+    let bytes = body.as_bytes();
+    let mut out = std::collections::HashSet::new();
+    let mut from = 0usize;
+    while let Some(rel) = body[from..].find(keyword) {
+        let mut i = from + rel + keyword.len();
+        while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+            i += 1;
+        }
+        if i < bytes.len() && (bytes[i] == b'_' || bytes[i].is_ascii_alphabetic()) {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            out.insert(body[start..i].to_string());
+            from = i;
+        } else {
+            from += i - from + keyword.len() - keyword.len() + 1;
+        }
+    }
+    out
+}
+
 /// Look for `extends`/`implements` in class/interface definitions.
 fn extract_inheritance_edges(
     entities: &[Entity],
@@ -446,6 +502,22 @@ fn extract_inheritance_edges(
 ) -> Vec<(Uuid, Uuid, EdgeKind)> {
     let mut results = Vec::new();
     let source_set: HashSet<_> = source_by_file.keys().collect();
+
+    // Target lookup by lowercase name — targets are entities whose file is
+    // part of this index run (same filter as before, hoisted out of the
+    // loop). Keyword tokens are collected in one linear pass per body
+    // instead of a per-target format! + substring scan (#321).
+    let mut by_name_lower: std::collections::HashMap<String, Vec<&Entity>> =
+        std::collections::HashMap::new();
+    for target in entities
+        .iter()
+        .filter(|e| source_by_file.contains_key(&e.file_path))
+    {
+        by_name_lower
+            .entry(target.name.to_lowercase())
+            .or_default()
+            .push(target);
+    }
 
     for entity in entities.iter().filter(|e| {
         matches!(
@@ -462,20 +534,31 @@ fn extract_inheritance_edges(
             .unwrap_or("");
         let body_lower = body.to_lowercase();
 
-        for target in entities.iter().filter(|e| e.id != entity.id) {
-            if !source_by_file.contains_key(&target.file_path) {
-                continue;
-            }
-            if body_lower.contains(&format!("extends {}", target.name.to_lowercase()))
-                || body_lower.contains(&format!("extends {}<", target.name.to_lowercase()))
-            {
-                results.push((entity.id, target.id, EdgeKind::Extends));
-            }
-            if (entity.language == Language::TypeScript || entity.language == Language::JavaScript)
-                && (body_lower.contains(&format!("implements {}", target.name.to_lowercase()))
-                    || body_lower.contains(&format!(": {}", target.name.to_lowercase())))
-            {
-                results.push((entity.id, target.id, EdgeKind::Implements));
+        let is_ts_js =
+            entity.language == Language::TypeScript || entity.language == Language::JavaScript;
+        let extends_names = identifiers_after(&body_lower, "extends ");
+        let implements_names = if is_ts_js {
+            let mut set = identifiers_after(&body_lower, "implements ");
+            set.extend(identifiers_after(&body_lower, ": "));
+            set
+        } else {
+            std::collections::HashSet::new()
+        };
+
+        // Mirrors the old dual check: a name after both keywords yields both
+        // edges, exactly like the two independent `contains` checks did.
+        for (names, kind) in [
+            (&extends_names, EdgeKind::Extends),
+            (&implements_names, EdgeKind::Implements),
+        ] {
+            for name in names {
+                if let Some(targets) = by_name_lower.get(name) {
+                    for target in targets {
+                        if target.id != entity.id {
+                            results.push((entity.id, target.id, kind));
+                        }
+                    }
+                }
             }
         }
     }
@@ -487,6 +570,21 @@ fn extract_call_edges(
     entities: &[Entity],
     source_by_file: &HashMap<String, String>,
 ) -> Vec<(Uuid, Uuid)> {
+    // Call-site names are collected in one linear pass per body; targets are
+    // looked up by exact name (HashMap) instead of scanning every entity per
+    // pair — the old loop was quadratic with a format! allocation per pair
+    // and effectively hung on 10k+ entities (#321). Note this is slightly
+    // MORE precise than before: "myfoo(" no longer matches a target named
+    // "foo" (the old substring check ignored word boundaries).
+    let by_name: std::collections::HashMap<&str, Vec<&Entity>> = {
+        let mut map: std::collections::HashMap<&str, Vec<&Entity>> =
+            std::collections::HashMap::new();
+        for target in entities {
+            map.entry(target.name.as_str()).or_default().push(target);
+        }
+        map
+    };
+
     let mut results = Vec::new();
     for entity in entities {
         let Some(file_source) = source_by_file.get(&entity.file_path) else {
@@ -495,9 +593,13 @@ fn extract_call_edges(
         let body = file_source
             .get(entity.start_byte as usize..entity.end_byte as usize)
             .unwrap_or("");
-        for target in entities.iter().filter(|e| e.id != entity.id) {
-            if body.contains(&format!("{}(", target.name)) {
-                results.push((entity.id, target.id));
+        for name in called_names(body) {
+            if let Some(targets) = by_name.get(name) {
+                for target in targets {
+                    if target.id != entity.id {
+                        results.push((entity.id, target.id));
+                    }
+                }
             }
         }
     }
@@ -506,7 +608,6 @@ fn extract_call_edges(
 
 /// Extract contains edges (parent → child for structs/classes/modules containing functions/methods).
 fn extract_contains_edges(entities: &[Entity]) -> Vec<(Uuid, Uuid)> {
-    let mut results = Vec::new();
     let is_container = |kind: EntityKind| -> bool {
         matches!(
             kind,
@@ -517,11 +618,23 @@ fn extract_contains_edges(entities: &[Entity]) -> Vec<(Uuid, Uuid)> {
                 | EntityKind::Module
         )
     };
-    for parent in entities.iter().filter(|e| is_container(e.kind)) {
-        let prefix = format!("{}::", parent.qualified_name);
-        for child in entities.iter().filter(|e| e.id != parent.id) {
-            if child.qualified_name.starts_with(&prefix) {
-                results.push((parent.id, child.id));
+    // Walk each child's qualified-name ancestor chain instead of testing
+    // every (parent, child) pair — linear in names×segments (#321).
+    let containers: std::collections::HashMap<&str, &Entity> = entities
+        .iter()
+        .filter(|e| is_container(e.kind))
+        .map(|e| (e.qualified_name.as_str(), e))
+        .collect();
+
+    let mut results = Vec::new();
+    for child in entities {
+        let mut qualified = child.qualified_name.as_str();
+        while let Some(idx) = qualified.rfind("::") {
+            qualified = &qualified[..idx];
+            if let Some(parent) = containers.get(qualified) {
+                if parent.id != child.id {
+                    results.push((parent.id, child.id));
+                }
             }
         }
     }
@@ -1373,5 +1486,81 @@ mod tests {
         // (#319). to_ascii_lowercase keeps byte lengths identical.
         let line = "import { İ } from './x';";
         assert_eq!(parse_ts_module_path(line).as_deref(), Some("./x"));
+    }
+
+    #[test]
+    fn call_edges_require_exact_token_match() {
+        // "myfoo(" is a different identifier — the old substring scan
+        // reported it as a call of "foo" (#321).
+        let target = entity("foo", "src/a.ts", Language::TypeScript);
+        let src_no = "function caller() { myfoo(); }";
+        let mut caller = entity_with_span(
+            "caller",
+            "src/b.ts",
+            Language::TypeScript,
+            0,
+            0,
+            0,
+            src_no.len() as u32,
+        );
+        let mut sources = HashMap::new();
+        sources.insert("src/b.ts".to_string(), src_no.to_string());
+        let edges = extract_call_edges(&[caller.clone(), target.clone()], &sources);
+        assert!(edges.is_empty());
+
+        // A real call still links.
+        let src_yes = "function caller() { foo(); }";
+        caller.end_byte = src_yes.len() as u32;
+        sources.insert("src/b.ts".to_string(), src_yes.to_string());
+        let edges = extract_call_edges(&[caller, target.clone()], &sources);
+        assert_eq!(edges.len(), 1);
+    }
+
+    #[test]
+    fn inheritance_edges_from_extends_and_implements() {
+        let base = entity("Base", "src/base.ts", Language::TypeScript);
+        let logger = entity("Logger", "src/log.ts", Language::TypeScript);
+        let src = "class Child extends Base implements Logger { }";
+        let mut child = entity_with_span(
+            "Child",
+            "src/child.ts",
+            Language::TypeScript,
+            0,
+            0,
+            0,
+            src.len() as u32,
+        );
+        child.kind = EntityKind::Class;
+
+        let mut sources = HashMap::new();
+        sources.insert("src/base.ts".to_string(), "class Base {}".to_string());
+        sources.insert("src/log.ts".to_string(), "interface Logger {}".to_string());
+        sources.insert("src/child.ts".to_string(), src.to_string());
+
+        let edges =
+            extract_inheritance_edges(&[base.clone(), logger.clone(), child.clone()], &sources);
+        assert!(edges.contains(&(child.id, base.id, EdgeKind::Extends)));
+        assert!(edges.contains(&(child.id, logger.id, EdgeKind::Implements)));
+    }
+
+    #[test]
+    fn contains_edges_reach_all_ancestors() {
+        let mut grand = entity("A", "src/a.ts", Language::TypeScript);
+        grand.kind = EntityKind::Module;
+        grand.qualified_name = "A".into();
+        let mut mid = entity("B", "src/a.ts", Language::TypeScript);
+        mid.kind = EntityKind::Module;
+        mid.qualified_name = "A::B".into();
+        let mut child = entity("c", "src/a.ts", Language::TypeScript);
+        child.qualified_name = "A::B::c".into();
+
+        // Three pairs: A->B, A->c, B->c (B is itself a child of A — the old
+        // pair scan produced the same three, so the linearized walk
+        // preserves multi-level ancestors exactly).
+        let edges = extract_contains_edges(&[grand.clone(), mid.clone(), child.clone()]);
+        assert_eq!(edges.len(), 3);
+        assert!(edges.contains(&(grand.id, mid.id)));
+        assert!(edges.contains(&(grand.id, child.id)));
+        assert!(edges.contains(&(mid.id, child.id)));
     }
 }


### PR DESCRIPTION
Final crosshash batch from the Rust review — the remaining four issues (#321, #323, #324, #328), one commit per issue.

## #321 — static edge extraction was O(N²)
`extract_call_edges` scanned **every entity pair** with a `format!`-built needle per pair — ≥10⁸ string searches at 10k entities, effectively hanging the index. Rewritten:
- `extract_call_edges`: call-site names are collected in **one linear pass per body** and matched against a name→entities map. Slightly more precise, too: `myfoo(` no longer counts as a call of `foo` (the old substring check ignored word boundaries).
- `extract_inheritance_edges`: the tokens after `extends` / `implements` / `": "` are collected per body and looked up by lowercased name (dual-keyword behavior preserved — a name after both yields both edges, as before).
- `extract_contains_edges`: walks each child's qualified-name ancestor chain instead of testing every pair; multi-level ancestors preserved exactly (regression-tested).

## #323 — watcher failure busy-spins at 100% CPU
The watch thread's `Result` was dropped with the JoinHandle: if a repo root became unwatchable, the thread exited, the only channel sender was dropped, and the main loop spun on `recv() == Err` forever, printing nothing. The loop now detects the closed channel, breaks with a clear message, and the thread's error is surfaced.

## #324 — `discover-edges --static-only` was a silent no-op
`discover-edges` never computed static edges in any mode, yet claimed "static edges found". It now runs the same `StaticEdgeExtractor` the re-index path uses, stores the discovered edges, reports the real counts, and `--static-only` stops after static extraction without calling the LLM.

## #328 — `feedback accept` validated too late
Entity ids are now parsed/validated **before** the suggestion status flips; the old order reported `accepted AI edge suggestion` while silently skipping the edge when ids failed to parse — leaving an accepted suggestion with no edge in the graph.

## Verification
`cargo test --workspace`: **285 tests, 0 failures** (3 new regression tests for the extraction rewrite). `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt --check`: clean.

Fixes #321
Fixes #323
Fixes #324
Fixes #328