### PR TITLE
feat(trust): path-aware symbol links — trust sync matches on (path, name)

### DIFF
--- a/data-access/symbols.js
+++ b/data-access/symbols.js
@@ -4,16 +4,17 @@ const { TRUST_DELTA } = require('../constants');
  * Upsert a symbol link for a memory (`symbolId` defaults to `'__unlinked__'`).
  * @returns {{ ok:boolean, memoryId, symbolId, repo, trustScore }}
  */
-function linkSymbol(deps, { memoryId, symbolId, repo, trust }) {
+function linkSymbol(deps, { memoryId, symbolId, repo, trust, symbolPath }) {
   const { sqlRun } = deps,
     symVal = symbolId || '__unlinked__';
-  sqlRun('INSERT OR REPLACE INTO symbol_links (memory_id, symbol_id, repo, trust_score) VALUES (?, ?, ?, ?)', [
-    memoryId,
-    symVal,
-    repo,
-    trust,
-  ]);
-  return { ok: true, memoryId, symbolId: symVal, repo, trustScore: trust };
+  // symbolPath records WHERE the symbol lives so trust sync can match
+  // changes on (path, name) — bare-name matching penalized same-named
+  // symbols in unrelated files (#300).
+  sqlRun(
+    'INSERT OR REPLACE INTO symbol_links (memory_id, symbol_id, repo, trust_score, symbol_path) VALUES (?, ?, ?, ?, ?)',
+    [memoryId, symVal, repo, trust, symbolPath || null],
+  );
+  return { ok: true, memoryId, symbolId: symVal, repo, trustScore: trust, symbolPath: symbolPath || null };
 }
 
 /**
@@ -83,7 +84,7 @@ function getStaleLinks(deps, repo) {
 function getAnchoredLinks(deps, repo) {
   const { sqlJson } = deps;
   return sqlJson(
-    `SELECT memory_id, symbol_id, trust_score, last_verified
+    `SELECT memory_id, symbol_id, trust_score, last_verified, symbol_path
      FROM symbol_links WHERE repo = ? AND symbol_id != '__unlinked__'`,
     [repo],
   );

--- a/db.js
+++ b/db.js
@@ -176,6 +176,7 @@ class MemoryError extends Error {
         { to: 24, run: runMigrationV24 },
         { to: 25, run: runMigrationV25 },
         { to: 26, run: runMigrationV26 },
+        { to: 27, run: runMigrationV27 },
       ],
       LATEST_MIGRATION_VERSION = MIGRATIONS.reduce((max, m) => Math.max(max, m.to), 0);
 
@@ -1131,6 +1132,27 @@ class MemoryError extends Error {
         });
       } catch (e) {
         errors.push(`V25: ${e.message}`);
+      }
+      return errors;
+    }
+
+    function runMigrationV27() {
+      const errors = [];
+      try {
+        withTransaction(() => {
+          // Record which file a linked symbol lives in, so trust sync can
+          // match changes on (path, name) instead of the bare name (#300).
+          try {
+            sqlRaw('ALTER TABLE symbol_links ADD COLUMN symbol_path TEXT');
+          } catch (e) {
+            if (!/duplicate column/i.test(e.message)) {
+              throw e;
+            }
+          }
+          sqlRaw('PRAGMA user_version = 27');
+        });
+      } catch (e) {
+        errors.push(`V27: ${e.message}`);
       }
       return errors;
     }

--- a/src/cli/commands/trust.js
+++ b/src/cli/commands/trust.js
@@ -1,6 +1,6 @@
 const symCmd = require('../../../commands/symbols'),
   USAGE = {
-    'link-symbol': '--memory-id ID --repo X [--trust N]',
+    'link-symbol': '--memory-id ID --repo X [--file PATH] [--trust N]',
     'auto-link': '--project X',
     'adjust-trust': '--memory-id ID [--delta N] [--reason R]',
     'record-recall': '--session-id ID --memory-id ID',

--- a/src/trust-sync/change-detector.js
+++ b/src/trust-sync/change-detector.js
@@ -187,10 +187,12 @@ function detectChangedSymbols(deps, repoName) {
     return {
       ok: true,
       repo: repoName,
+      repo_path: repoPath,
       old_head: storedHead,
       new_head: currentHead,
       changed_files: changedFiles.length,
       changed_symbols: changedSet.size,
+      changed_paths: indexedPaths,
       changedSet,
     };
   }

--- a/src/trust-sync/symbol-links.js
+++ b/src/trust-sync/symbol-links.js
@@ -66,14 +66,23 @@ function linkSymbol(deps, args) {
   const memoryId = args['memory-id'] || args.memoryId,
     symbolId = args['symbol-id'] || args.symbolId,
     repo = args.repo,
-    trust = parseFloat(args.trust || '0.5');
+    trust = parseFloat(args.trust || '0.5'),
+    // File path of the linked symbol — enables path-aware trust matching
+    // (#300). Accept relative (repo-root) or absolute paths.
+    symbolPath = args.file || args['file-path'] || args.symbolPath || null;
   if (!memoryId) {
     return deps.jsonErrNoExit('--memory-id required');
   }
   if (!repo) {
     return deps.jsonErrNoExit('--repo required');
   }
-  return getTrustSyncRepository(deps, ['linkSymbol']).linkSymbol({ memoryId, symbolId, repo, trust });
+  return getTrustSyncRepository(deps, ['linkSymbol']).linkSymbol({
+    memoryId,
+    symbolId,
+    repo,
+    trust,
+    symbolPath,
+  });
 }
 
 function autoLink(deps, args) {
@@ -173,7 +182,7 @@ function syncCodeTrust(deps, args) {
   // Evaluate trust adjustments
   const repository = getTrustSyncRepository(deps, ['getAnchoredLinks', 'updateLinkTrust', 'insertTrustAdjustment']),
     allLinks = repository.getAnchoredLinks(repo),
-    evaluated = evaluateTrustSync(allLinks, detected.changedSet),
+    evaluated = evaluateTrustSync(allLinks, detected.changedSet, detected.changed_paths, detected.repo_path),
     applyTrustUpdates = () => {
       for (const operation of evaluated.operations) {
         repository.updateLinkTrust({

--- a/src/trust-sync/trust-policy.js
+++ b/src/trust-sync/trust-policy.js
@@ -1,4 +1,5 @@
-const { TRUST_DELTA } = require('../../constants');
+const path = require('path'),
+  { TRUST_DELTA } = require('../../constants');
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -29,14 +30,73 @@ function isChangedLink(link, changedSet) {
   return false;
 }
 
+// True when a link's recorded file path is among the changed paths. Relative
+// link paths resolve against the repo root; both sides may also match via
+// realpath variants (the detector stores those).
+function pathInChangedPaths(symbolPath, changedPathSet, repoRoot) {
+  const resolved = path.isAbsolute(symbolPath) ? path.normalize(symbolPath) : path.resolve(repoRoot || '.', symbolPath);
+  if (changedPathSet.has(resolved)) {
+    return true;
+  }
+  // Suffix fallback: the recorded path may differ from the indexed absolute
+  // form by a symlinked or moved repo-root prefix.
+  const tail =
+    path.sep +
+    path
+      .normalize(symbolPath)
+      .replace(/^(?:[.]{1,2}[/\\])+/, '')
+      .replace(/^[/\\]+/, '');
+  for (const changed of changedPathSet) {
+    if (changed.endsWith(tail)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function clampTrust(value) {
   return Math.max(TRUST_DELTA.TRUST_FLOOR, Math.min(TRUST_DELTA.TRUST_CEILING, value));
 }
 
-function evaluateTrustSync(links, changedSet) {
+function evaluateTrustSync(links, changedSet, changedPaths, repoRoot) {
   const result = { total: links.length, adjusted: [], survived: [], unchanged: [], operations: [] };
+  const changedPathSet = changedPaths ? new Set(changedPaths) : null;
 
   for (const link of links) {
+    // Path-aware links (recorded with a file path) only react when THAT
+    // file changed — a same-named symbol changing in an unrelated file
+    // must not penalize them at all (#300). Legacy path-less links keep
+    // the name-based behavior below (exact full, fuzzy half).
+    if (link.symbol_path && changedPathSet) {
+      if (!pathInChangedPaths(link.symbol_path, changedPathSet, repoRoot)) {
+        if (link.trust_score < TRUST_DELTA.MAX_SURVIVED) {
+          const delta = TRUST_DELTA.SURVIVED_UNCHANGED,
+            newTrust = clampTrust(link.trust_score + delta);
+          result.survived.push({
+            memory_id: link.memory_id,
+            symbol_id: link.symbol_id,
+            old_trust: link.trust_score,
+            new_trust: newTrust,
+          });
+          result.operations.push({ link, newTrust, delta, reason: 'survived_unchanged' });
+        } else {
+          result.unchanged.push({ memory_id: link.memory_id, symbol_id: link.symbol_id });
+        }
+        continue;
+      }
+      // The anchor file itself changed — penalize (full). Coarse but
+      // conservative: every symbol in a changed file is a candidate.
+      const delta = TRUST_DELTA.SYMBOL_CHANGED,
+        newTrust = clampTrust(link.trust_score + delta);
+      result.adjusted.push({
+        memory_id: link.memory_id,
+        symbol_id: link.symbol_id,
+        old_trust: link.trust_score,
+        new_trust: newTrust,
+      });
+      result.operations.push({ link, newTrust, delta, reason: 'symbol_changed' });
+      continue;
+    }
     if (isChangedLink(link, changedSet)) {
       // Exact id equality is certain. A boundary match inside a larger
       // Symbol id is ambiguous — the same unqualified name usually also

--- a/test/review-fixes.test.js
+++ b/test/review-fixes.test.js
@@ -45,13 +45,16 @@ describe('review fixes', () => {
           hasTotalFilesChanged = churnCols.some((c) => c.name === 'total_files_changed'),
           hasTopFilesJson = churnCols.some((c) => c.name === 'top_files_json'),
           compressionCols = reopened.prepare('PRAGMA table_info(mission_compression_log)').all(),
-          hasImportantOutput = compressionCols.some((c) => c.name === 'important_output');
-        expect(version).toBe(26);
+          hasImportantOutput = compressionCols.some((c) => c.name === 'important_output'),
+          linkCols = reopened.prepare('PRAGMA table_info(symbol_links)').all(),
+          hasSymbolPath = linkCols.some((c) => c.name === 'symbol_path');
+        expect(version).toBe(27);
         expect(table).toBeTruthy();
         expect(sourceModuleCol).toBe(true);
         expect(hasTotalFilesChanged).toBe(true);
         expect(hasTopFilesJson).toBe(true);
         expect(hasImportantOutput).toBe(true);
+        expect(hasSymbolPath).toBe(true);
       }
     });
   });

--- a/test/storage-repositories.test.js
+++ b/test/storage-repositories.test.js
@@ -122,6 +122,7 @@ describe('platform storage repositories', () => {
     expect(trustSyncRepository.linkSymbol).toHaveBeenCalledWith({
       memoryId: '1',
       symbolId: 'S',
+      symbolPath: null,
       repo: 'repo',
       trust: 0.8,
     });

--- a/test/trust-sync.test.js
+++ b/test/trust-sync.test.js
@@ -49,6 +49,41 @@ describe('src/trust-sync trust policy', () => {
     expect(stripOperations(result).operations).toBeUndefined();
   });
 
+  it('path-aware links only react when their own file changed (#300)', () => {
+    const changedSet = new Set(['handler']),
+      changedPaths = ['/repo/src/handler.ts'],
+      links = [
+        // Linked to handler.ts (the changed file) -> penalized.
+        { memory_id: '1', symbol_id: 'handler', trust_score: 0.8, symbol_path: '/repo/src/handler.ts' },
+        // Same NAME, but anchored to an untouched file -> NOT penalized.
+        { memory_id: '2', symbol_id: 'handler', trust_score: 0.8, symbol_path: '/repo/src/other.ts' },
+        // Relative recorded path resolving into the changed file -> penalized.
+        { memory_id: '3', symbol_id: 'handler', trust_score: 0.8, symbol_path: 'src/handler.ts' },
+        // No recorded path -> legacy name-based behavior (fuzzy half).
+        { memory_id: '4', symbol_id: 'handler', trust_score: 0.8 },
+      ],
+      result = evaluateTrustSync(links, changedSet, changedPaths, '/repo');
+
+    const byMemory = Object.fromEntries(result.adjusted.map((a) => [a.memory_id, a]));
+    expect(byMemory['1'].new_trust).toBe(0.5); // full penalty
+    expect(byMemory['3'].new_trust).toBe(0.5); // full penalty
+    expect(result.survived.map((s) => s.memory_id)).toContain('2');
+    expect(result.adjusted.map((a) => a.memory_id)).not.toContain('2');
+    // Legacy path-less link: boundary match inside 'handler' is exact here,
+    // so full penalty applies.
+    expect(byMemory['4'].new_trust).toBe(0.5);
+  });
+
+  it('path-aware links earn survived recovery when their file is untouched', () => {
+    const changedSet = new Set(['handler']),
+      changedPaths = ['/repo/src/handler.ts'],
+      links = [{ memory_id: '9', symbol_id: 'handler', trust_score: 0.5, symbol_path: '/repo/src/other.ts' }],
+      result = evaluateTrustSync(links, changedSet, changedPaths, '/repo');
+    expect(result.survived).toHaveLength(1);
+    expect(result.survived[0].new_trust).toBe(0.55); // SURVIVED_UNCHANGED credit
+    expect(result.adjusted).toHaveLength(0);
+  });
+
   it('matches changed symbols only on symbol boundaries', () => {
     expect(symbolMatchesChange('pkg::bar', 'bar')).toBe(true);
     expect(symbolMatchesChange('pkg.Class.bar', 'bar')).toBe(true);


### PR DESCRIPTION
Implements the #300 follow-up that was deferred from the code review batch: instead of just *reducing* the penalty for ambiguous name matches, trust sync can now match changes on **(file path, symbol name)** — eliminating false penalties entirely for links that record where the symbol lives.

## Schema
Migration **V27**: `symbol_links.symbol_path TEXT` (nullable, standard duplicate-column tolerance).

## Behavior
- **`link-symbol --file <path>`** (CLI, also `symbolPath` via the repository API) records where the linked symbol lives. Relative paths resolve against the repo root at sync time.
- **`sync-code-trust`** passes the changed file paths (the detector already computed absolute + realpath variants) and the repo root into `evaluateTrustSync`.
- Links **with** a path: penalized only when *that file* is among the changed paths (full penalty — every symbol in a changed file is a candidate); when the file is untouched, the link earns the normal `survived_unchanged` recovery **even if a same-named symbol changed elsewhere** — this is the fix for the false-penalty bleed.
- Links **without** a path: legacy behavior unchanged (exact name match = full penalty, boundary match = half). Existing rows keep working; users upgrade to path awareness by re-linking with `--file`.

The suffix fallback on path comparison covers repo roots that moved or are symlinked (the detector stores realpath variants too).

## Tests
- Policy-level: path-matched link penalized, same-named link on an untouched file spared, relative path resolution, legacy path-less behavior intact, survived-recovery credit.
- Migration ladder updated to V27 with the new column asserted.
- `linkSymbol` persistence round-trip includes `symbol_path`.

Full suite: **151 files / 2106 tests passed**. Lint: 0 errors; format clean.

Closes #300 (follow-up)