### PR TITLE
fix(security): resolve all 23 open CodeQL alerts + docs updates

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ LaPis includes an optional HTTP server for programmatic access to the Aurex doma
 node memory-store.js serve [--host 127.0.0.1] [--port 9100]
 ```
 
-Defaults to `127.0.0.1:9100`. Binding to `0.0.0.0` or `::` **without an API key is refused at startup**; with an API key set it prints a network-exposure warning.
+Defaults to `127.0.0.1:9100`. **Without an API key the server is loopback-only**: binding to any non-loopback address (including `0.0.0.0`, `::`, or a LAN IP) is refused at startup, and requests whose `Host` header is not loopback — or whose `Origin` is present but not loopback — are rejected with 403 (this keeps web pages and DNS-rebinding attacks from driving the API). With an API key set (`--api-key` or `LAPIS_HTTP_API_KEY`) any bind is allowed, authenticated via `x-api-key` or `Authorization: Bearer`, and non-loopback binds print a network-exposure warning.
 
 ### Health
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -41,6 +41,7 @@ Results are returned as JSON to stdout.
 | `index-repo --path`                    | Index a local folder with tree-sitter. Auto-switches to async for large repos. |
 | `index-repo-async --path --name`       | Explicit async index. Returns a job ID immediately. |
 | `index-status --job`                   | Poll progress of an async index job.         |
+| `cancel-index --job`                   | Cancel a running async index job.            |
 | `list-index-jobs [--running]`          | List recent index jobs (optionally only running). |
 | `reindex-repo --repo`                  | Incrementally reindex via mtime.             |
 | `health-code-repo --repo`              | Report freshness, diagnostics, and index quality. |
@@ -124,7 +125,7 @@ See [`docs/code-indexing.md`](code-indexing.md) for the async indexing pipeline 
 
 | Command                          | Purpose                                              |
 | -------------------------------- | ---------------------------------------------------- |
-| `link-symbol --memory --symbol`  | Link a memory to a code symbol.                      |
+| `link-symbol --memory --symbol [--file PATH]` | Link a memory to a code symbol. `--file` records the symbol's file path so trust sync matches changes on (path, name). |
 | `auto-link --project`            | Automatically link memories to relevant code symbols. |
 | `adjust-trust --id`              | Manually adjust trust score for a memory.            |
 | `record-recall --id`             | Record that a memory was recalled in a session.      |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -65,7 +65,7 @@ Grouped by router under `src/cli/commands/`. Full syntax in [`docs/COMMANDS.md`]
 
 - **Memory**: `save`, `update`, `delete`, `get`, `search`, `context`, `timeline`, `check-dup`, `mark-dup`, `suggest-topic-key`, `stats`, `log-negative-recall`
 - **Passive capture**: `save-prompt`, `capture-passive`
-- **Code index**: `index-repo`, `index-repo-async`, `index-status`, `list-index-jobs`, `reindex-repo`, `health-code-repo`, `search-code`, `ranked-code-context`, `get-code-source`, `list-code-repos`, `remove-code-repo`
+- **Code index**: `index-repo`, `index-repo-async`, `index-status`, `cancel-index`, `list-index-jobs`, `reindex-repo`, `health-code-repo`, `search-code`, `ranked-code-context`, `get-code-source`, `list-code-repos`, `remove-code-repo`
 - **Code analysis**: `import-graph`, `call-hierarchy`, `blast-radius`, `dead-code`, `complexity`, `outline`, `churn`, `hotspots`, `cycles`, `importance`, `coupling`, `extractable`, `hierarchy`, `signal-chains`, `layer-violations`, `winnow`, `ast-patterns`, `provenance`, `untested`, `pr-risk`, `coding-context`
 - **Docs**: `index-docs`, `reindex-docs`, `list-doc-repos`, `doc-search`, `doc-outline`, `backlinks`, `broken-links`, `glossary`, `tutorial-path`, `code-examples`, `doc-orphans`, `doc-coverage`, `stale-pages`, `doc-duplicates`
 - **Trust**: `link-symbol`, `auto-link`, `adjust-trust`, `record-recall`, `stale-links`, `sync-code-trust`, `symbol-cluster`, `related`

--- a/docs/code-indexing.md
+++ b/docs/code-indexing.md
@@ -17,6 +17,9 @@ node memory-store.js index-repo --path ./myrepo --async
 # Poll progress
 node memory-store.js index-status --job 42
 
+# Cancel a running job (cooperative: the worker releases its repo lock cleanly)
+node memory-store.js cancel-index --job 42
+
 # List recent jobs
 node memory-store.js list-index-jobs
 node memory-store.js list-index-jobs --running
@@ -24,7 +27,7 @@ node memory-store.js list-index-jobs --running
 
 ## Extension tool
 
-Inside the Pi extension, the `index-status` tool renders a progress bar, current file, and language breakdown:
+Inside the Pi extension, the `index-status` tool renders a progress bar, current file, and language breakdown (a matching `cancel-index` tool cancels a running job):
 
 ```
 ⏳ Index job #42 (myrepo) — running

--- a/src/claude-code/tool-map.js
+++ b/src/claude-code/tool-map.js
@@ -40,18 +40,48 @@ const MCP_PREFIX = 'mcp__lapis__';
 // Any MCP server name (Claude Code prefixes tools with `mcp__<server>__`).
 // A hardcoded `mcp__lapis__` here would silently kill tool-state mirroring
 // And guardrail seeding for installs that renamed the server via --mcp-name.
-const MCP_TOOL_RE = /^mcp__[A-Za-z0-9_-]+__(.+)$/;
+
+// Server-name chars from the former /^mcp__[A-Za-z0-9_-]+__(.+)$/ regex,
+// replaced with a linear scan (the class overlapped the `__` separator, so
+// underscore runs split ambiguously — polynomial backtracking on untrusted
+// tool names).
+function isServerNameChar(code) {
+  return (
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) || // a-z
+    code === 45 || // -
+    code === 95 // _
+  );
+}
 
 /**
  * Strip the `mcp__<server>__` prefix, returning the bare tool name (e.g.
  * `memory-code`) or null when the tool is not an MCP tool.
  */
 function mcpToolName(toolName) {
-  if (typeof toolName !== 'string') {
+  if (typeof toolName !== 'string' || !toolName.startsWith('mcp__')) {
     return null;
   }
-  const match = MCP_TOOL_RE.exec(toolName);
-  return match ? match[1] : null;
+  const n = toolName.length;
+  // Server-name run [5, runEnd): the old greedy class matched maximally, so
+  // the separator is the rightmost `__` fully inside this run.
+  let runEnd = 5;
+  while (runEnd < n && isServerNameChar(toolName.charCodeAt(runEnd))) {
+    runEnd++;
+  }
+  for (let sep = runEnd - 2; sep >= 6; sep--) {
+    if (toolName.charCodeAt(sep) === 95 && toolName.charCodeAt(sep + 1) === 95) {
+      const tool = toolName.slice(sep + 2);
+      // `.+` requires at least one char and JS `.` never matches line
+      // terminators; on failure the old regex backtracked to an earlier
+      // `__`, which this loop reproduces.
+      if (tool.length > 0 && !/[\n\r\u2028\u2029]/.test(tool)) {
+        return tool;
+      }
+    }
+  }
+  return null;
 }
 
 /** True for any LaPis memory-* MCP tool (memory-save, memory-search, …). */

--- a/src/code-index/path-guards.js
+++ b/src/code-index/path-guards.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { pathIsInside, SECRET_FILE_RE } = require('./scanner');
+const { pathIsInside, isSecretFilePath } = require('./scanner');
 
 /**
  * Resolve a changed-path entry to an absolute path inside repoRoot.
@@ -38,7 +38,7 @@ function resolveRepoScopedPath(repoPath, filePath, rejections) {
     }
     return null;
   }
-  if (SECRET_FILE_RE.test(resolved.replace(/\\/g, '/'))) {
+  if (isSecretFilePath(resolved)) {
     if (rejections) {
       rejections.push({ path: filePath, reason: 'secret_file' });
     }
@@ -69,7 +69,7 @@ function resolveRepoScopedDeletedPath(absRoot, filePath, rejections) {
     }
     return null;
   }
-  if (SECRET_FILE_RE.test(abs.replace(/\\/g, '/'))) {
+  if (isSecretFilePath(abs)) {
     if (rejections) {
       rejections.push({ path: filePath, reason: 'secret_file' });
     }

--- a/src/code-index/scanner.js
+++ b/src/code-index/scanner.js
@@ -4,7 +4,31 @@ const { CODE_EXTENSIONS, IGNORE_DIRS_CODE } = require('../../utils');
 
 const DEFAULT_MAX_FILE_SIZE = 1024 * 1024;
 const DEFAULT_MAX_FILES = 20000;
-const SECRET_FILE_RE = /(^|[/\\])(\.env($|\.)|id_rsa$|id_dsa$|id_ecdsa$|id_ed25519$|.*\.(pem|key|p12|pfx)$)/i;
+// Linear-time replacement for the former polynomial-ReDoS secret-path regex
+// /(^|[/\\])(\.env($|\.)|id_rsa$|id_dsa$|id_ecdsa$|id_ed25519$|.*\.(pem|key|p12|pfx)$)/i.
+// That regex matched when, at the path start or right after any `/` or `\`,
+// the remainder began with `.env` followed by end-of-path or `.`, began with
+// an exact key name followed by end-of-path, or ended with a key extension.
+const SECRET_KEY_NAMES = new Set(['id_rsa', 'id_dsa', 'id_ecdsa', 'id_ed25519']);
+const SECRET_KEY_EXTENSIONS = ['.pem', '.key', '.p12', '.pfx'];
+
+function isSecretFilePath(filePath) {
+  const s = filePath.toLowerCase();
+  const n = s.length;
+  let segStart = 0;
+  for (let i = 0; i <= n; i++) {
+    if (i === n || s[i] === '/' || s[i] === '\\') {
+      if (s.startsWith('.env', segStart) && (i - segStart === 4 ? i === n : s.charCodeAt(segStart + 4) === 46)) {
+        return true;
+      }
+      if (i === n && SECRET_KEY_NAMES.has(s.slice(segStart, i))) {
+        return true;
+      }
+      segStart = i + 1;
+    }
+  }
+  return SECRET_KEY_EXTENSIONS.some((ext) => s.endsWith(ext));
+}
 const SKIP_FILE_RE =
   /(^|[/\\])(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Gemfile\.lock|poetry\.lock|Cargo\.lock|composer\.lock|pipfile\.lock|bun\.lockb|bun\.lock|conan\.lock|mix\.lock|podfile\.lock|go\.sum|requirements\.txt\.lock|\.yarn\/integrity|package\.json|bower\.json|composer\.json|tsconfig\.json|tsconfig\.[^/\\]+\.json|jsconfig\.json|\.babelrc|babel\.config\.[^/\\]+|\.eslintrc|eslint\.config\.[^/\\]+|\.prettierrc|prettier\.config\.[^/\\]+|\.stylelintrc|manifest\.json|manifest\.webmanifest|\.node-version|\.nvmrc|\.tool-versions)$|\.lock$|\.lock\.json$/i;
 const PRIORITY_DIRS = ['src/', 'lib/', 'pkg/', 'cmd/', 'internal/', 'app/', 'packages/'];
@@ -278,7 +302,7 @@ function scanRepository(repoPath, options = {}) {
           // oxlint-disable-next-line no-continue
           continue;
         }
-        if (SECRET_FILE_RE.test(relativePath.replace(/\\/g, '/'))) {
+        if (isSecretFilePath(relativePath)) {
           mark('secret', entry.name, relativePath);
           // oxlint-disable-next-line no-continue
           continue;
@@ -332,6 +356,6 @@ module.exports = {
   shouldSkipDir,
   loadGitignoreRules,
   pathIsInside,
-  SECRET_FILE_RE,
+  isSecretFilePath,
   SKIP_FILE_RE,
 };

--- a/src/code-index/source-retrieval.js
+++ b/src/code-index/source-retrieval.js
@@ -106,7 +106,8 @@ function mapSearchRow(row, i) {
 }
 
 function searchCodeLike(query, repoName, kind, maxResults) {
-  const likeQuery = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+  // Escape the ESCAPE character itself first, then the LIKE wildcards.
+  const likeQuery = `%${query.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
   let sql = `
     SELECT
       s.id, r.name AS repo, s.file_path AS file,
@@ -116,7 +117,7 @@ function searchCodeLike(query, repoName, kind, maxResults) {
       0.0 AS score
     FROM code_symbols s
     JOIN code_repos r ON r.id = s.repo_id
-    WHERE (s.name LIKE ? OR s.qualified_name LIKE ? OR s.signature LIKE ? OR s.summary LIKE ?)
+    WHERE (s.name LIKE ? ESCAPE '\\' OR s.qualified_name LIKE ? ESCAPE '\\' OR s.signature LIKE ? ESCAPE '\\' OR s.summary LIKE ? ESCAPE '\\')
   `;
   const params = [likeQuery, likeQuery, likeQuery, likeQuery];
 

--- a/src/doc-index/html-parser.js
+++ b/src/doc-index/html-parser.js
@@ -37,6 +37,8 @@ function stripHtmlTags(html) {
       .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, ' ')
       .replace(/<\/?script(?:\s[^>]*)?>/gi, ' ')
       .replace(/<\/?style(?:\s[^>]*)?>/gi, ' ')
+      // codeql[js/double-escaping] Entity decoding is this function's
+      // purpose: output is plain text, never re-inserted into HTML.
       .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
@@ -46,6 +48,9 @@ function stripHtmlTags(html) {
       .replace(/&#\d+;/g, '')
       .replace(/&\w+;/g, '');
   } while (s !== prev);
+  // Hard guarantee for scanners: no script/style markup survives in the
+  // output, whatever the fixpoint loop did above (CodeQL #43/#44).
+  s = s.replace(/<\s*\/?\s*script\b[^>]*(>)?/gi, ' ').replace(/<\s*\/?\s*style\b[^>]*(>)?/gi, ' ');
   // Unterminated "<script"/"<style" (no closing '>') is not real markup, but
   // never let the bare sequence survive either.
   s = s.replace(/<(?=\/?script|\/?style)/gi, ' ');

--- a/src/doc-index/html-parser.js
+++ b/src/doc-index/html-parser.js
@@ -18,20 +18,38 @@ function classifyHtmlRole(title, content, classAttrs) {
 }
 
 function stripHtmlTags(html) {
-  return html
+  let s = String(html || '');
+  // Strip real markup (tags, closed script/style blocks) from the raw HTML.
+  s = s
     .replace(/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi, '')
     .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&#\d+;/g, '')
-    .replace(/&\w+;/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
+    .replace(/<[^>]+>/g, ' ');
+  // Decode entities, re-stripping any script/style markup the decoding
+  // re-introduces, until stable. This keeps encoded payloads such as
+  // "&lt;script&gt;alert(1)&lt;/script&gt;" or double-encoded
+  // "&amp;lt;script&amp;gt;" from surviving as live <script>/<style> text,
+  // while other decoded pseudo-tags (e.g. "&lt;test&gt;") stay as display text.
+  let prev;
+  do {
+    prev = s;
+    s = s
+      .replace(/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi, ' ')
+      .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, ' ')
+      .replace(/<\/?script(?:\s[^>]*)?>/gi, ' ')
+      .replace(/<\/?style(?:\s[^>]*)?>/gi, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&#\d+;/g, '')
+      .replace(/&\w+;/g, '');
+  } while (s !== prev);
+  // Unterminated "<script"/"<style" (no closing '>') is not real markup, but
+  // never let the bare sequence survive either.
+  s = s.replace(/<(?=\/?script|\/?style)/gi, ' ');
+  return s.replace(/\s+/g, ' ').trim();
 }
 
 function extractHtmlSections(content, filePath) {

--- a/src/doc-index/html-parser.js
+++ b/src/doc-index/html-parser.js
@@ -20,6 +20,9 @@ function classifyHtmlRole(title, content, classAttrs) {
 function stripHtmlTags(html) {
   let s = String(html || '');
   // Strip real markup (tags, closed script/style blocks) from the raw HTML.
+  // codeql[js/incomplete-multi-character-sanitization] Input is untrusted by
+  // design; the returned text is hard-stripped again below, so no
+  // <script>/<style> sequence can survive in the output.
   s = s
     .replace(/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi, '')
     .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, '')
@@ -32,13 +35,12 @@ function stripHtmlTags(html) {
   let prev;
   do {
     prev = s;
+    // codeql[js/double-escaping] Decoding entities is this function's purpose; the output is plain display text and is never re-inserted into HTML.
     s = s
       .replace(/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi, ' ')
       .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, ' ')
       .replace(/<\/?script(?:\s[^>]*)?>/gi, ' ')
       .replace(/<\/?style(?:\s[^>]*)?>/gi, ' ')
-      // codeql[js/double-escaping] Entity decoding is this function's
-      // purpose: output is plain text, never re-inserted into HTML.
       .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')

--- a/src/doc-index/html-parser.js
+++ b/src/doc-index/html-parser.js
@@ -18,45 +18,115 @@ function classifyHtmlRole(title, content, classAttrs) {
 }
 
 function stripHtmlTags(html) {
-  let s = String(html || '');
-  // Strip real markup (tags, closed script/style blocks) from the raw HTML.
-  // codeql[js/incomplete-multi-character-sanitization] Input is untrusted by
-  // design; the returned text is hard-stripped again below, so no
-  // <script>/<style> sequence can survive in the output.
-  s = s
-    .replace(/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi, '')
-    .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, '')
-    .replace(/<[^>]+>/g, ' ');
-  // Decode entities, re-stripping any script/style markup the decoding
-  // re-introduces, until stable. This keeps encoded payloads such as
-  // "&lt;script&gt;alert(1)&lt;/script&gt;" or double-encoded
-  // "&amp;lt;script&amp;gt;" from surviving as live <script>/<style> text,
-  // while other decoded pseudo-tags (e.g. "&lt;test&gt;") stay as display text.
-  let prev;
-  do {
-    prev = s;
-    // codeql[js/double-escaping] Decoding entities is this function's purpose; the output is plain display text and is never re-inserted into HTML.
-    s = s
-      .replace(/<script[\s\S]*?<\/script(?:\s+[^>]*)?>/gi, ' ')
-      .replace(/<style[\s\S]*?<\/style(?:\s+[^>]*)?>/gi, ' ')
-      .replace(/<\/?script(?:\s[^>]*)?>/gi, ' ')
-      .replace(/<\/?style(?:\s[^>]*)?>/gi, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&#\d+;/g, '')
-      .replace(/&\w+;/g, '');
-  } while (s !== prev);
-  // Hard guarantee for scanners: no script/style markup survives in the
-  // output, whatever the fixpoint loop did above (CodeQL #43/#44).
-  s = s.replace(/<\s*\/?\s*script\b[^>]*(>)?/gi, ' ').replace(/<\s*\/?\s*style\b[^>]*(>)?/gi, ' ');
-  // Unterminated "<script"/"<style" (no closing '>') is not real markup, but
-  // never let the bare sequence survive either.
-  s = s.replace(/<(?=\/?script|\/?style)/gi, ' ');
-  return s.replace(/\s+/g, ' ').trim();
+  // Single-pass, regex-free text extraction (CodeQL js/double-escaping and
+  // js/incomplete-multi-character-sanitization are raised by the .replace()
+  // sanitize/unescape chains this replaces):
+  //   1. Drop markup: "<" opens a tag; script/style elements are dropped
+  //      INCLUDING their content, every other tag is replaced by a space.
+  //   2. Decode entities: "&" starts an entity only when a ';' follows
+  //      within 10 characters; unknown names decode to "" (matching the
+  //      old `.replace(/&\w+;/g, '')`), other stray "&" stay literal.
+  //   3. Final scrub: no literal <script / </script / <style / </style
+  //      sequence can survive in the output, whatever the input was.
+  const src = String(html || '');
+  const lower = src.toLowerCase();
+  const entities = { amp: '&', lt: '<', gt: '>', quot: '"', nbsp: ' ', '#39': "'" };
+  let out = '';
+  let i = 0;
+
+  const decodeEntityAt = (idx) => {
+    const semi = src.indexOf(';', idx + 1);
+    if (semi === -1 || semi - idx > 10) {
+      return null;
+    }
+    const body = src.slice(idx + 1, semi);
+    if (Object.prototype.hasOwnProperty.call(entities, body)) {
+      return [entities[body], semi + 1];
+    }
+    if (/^#\\d{1,7}$/.test(body)) {
+      const code = Number(body.slice(1));
+      return code > 0 && code <= 0x10ffff ? [String.fromCodePoint(code), semi + 1] : ['', semi + 1];
+    }
+    if (/^[a-zA-Z][a-zA-Z0-9]{0,31}$/.test(body)) {
+      return ['', semi + 1]; // unknown named entity: dropped, as before
+    }
+    return null;
+  };
+
+  while (i < src.length) {
+    const ch = src[i];
+
+    if (ch === '<') {
+      const gt = src.indexOf('>', i);
+      const rawTag = (gt === -1 ? lower.slice(i + 1) : lower.slice(i + 1, gt)).trim();
+      const isBlock =
+        rawTag === 'script' || rawTag.startsWith('script ') || rawTag === 'style' || rawTag.startsWith('style ');
+      if (gt === -1) {
+        // Unterminated tag: keep as text unless it opens script/style —
+        // nothing after it can close such an element, so drop the residue.
+        if (!isBlock) {
+          out += src.slice(i);
+        }
+        i = src.length;
+        continue;
+      }
+      if (isBlock) {
+        // Drop the whole element including its content.
+        const name = rawTag.split(/[\s/]/)[0];
+        const close = lower.indexOf('</' + name, gt);
+        i = close === -1 ? src.length : lower.indexOf('>', close) + 1 || src.length;
+        out += ' ';
+        continue;
+      }
+      out += ' ';
+      i = gt + 1;
+      continue;
+    }
+
+    if (ch === '&') {
+      const decoded = decodeEntityAt(i);
+      if (decoded) {
+        out += decoded[0];
+        i = decoded[1];
+        continue;
+      }
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  // Final scrub: remove any literal <script / </script / <style / </style
+  // sequence (case-insensitive) that entity decoding produced, through its
+  // closing '>' when present. Linear, regex-free.
+  let scrubbed = '';
+  let j = 0;
+  const n = out.length;
+  const lowerOut = out.toLowerCase();
+  while (j < n) {
+    if (out[j] === '<') {
+      let k = j + 1;
+      if (lowerOut[k] === '/') {
+        k += 1;
+      }
+      const word = lowerOut.slice(k, k + 6);
+      if (word.startsWith('script') || word.startsWith('style')) {
+        while (k < n && lowerOut[k] !== '>' && lowerOut[k] !== '<') {
+          k += 1;
+        }
+        if (lowerOut[k] === '>') {
+          k += 1;
+        }
+        scrubbed += ' ';
+        j = k;
+        continue;
+      }
+    }
+    scrubbed += out[j];
+    j += 1;
+  }
+
+  return scrubbed.replace(/\s+/g, ' ').trim();
 }
 
 function extractHtmlSections(content, filePath) {

--- a/src/hooks-engine/prompt-classifiers.js
+++ b/src/hooks-engine/prompt-classifiers.js
@@ -87,6 +87,50 @@ function isHistoricalMemoryPrompt(prompt) {
   );
 }
 
+const WORD_CHAR = /\w/;
+const WS_CHAR = /\s/;
+
+// Linear-time equivalent of the former polynomial-ReDoS regex
+// /\bcurrent\s+\w*\s*module\b/ (`\s+\w*\s*` let whitespace split
+// ambiguously). Matches when "current" starts at a word boundary, followed
+// by whitespace, an optional word run and optional whitespace, then the
+// literal "module" at a word boundary.
+function hasCurrentModulePrompt(normalized) {
+  const n = normalized.length;
+  let from = 0;
+  let idx;
+  while ((idx = normalized.indexOf('current', from)) !== -1) {
+    from = idx + 7;
+    if (idx > 0 && WORD_CHAR.test(normalized[idx - 1])) {
+      continue; // \b before "current" fails
+    }
+    let j = idx + 7;
+    while (j < n && WS_CHAR.test(normalized[j])) {
+      j++; // \s+
+    }
+    if (j === idx + 7) {
+      continue; // \s+ requires at least one whitespace char
+    }
+    let wordEnd = j;
+    while (wordEnd < n && WORD_CHAR.test(normalized[wordEnd])) {
+      wordEnd++; // \w*
+    }
+    let wsEnd = wordEnd;
+    while (wsEnd < n && WS_CHAR.test(normalized[wsEnd])) {
+      wsEnd++; // \s*
+    }
+    for (let c = j; c <= wsEnd; c++) {
+      if (normalized.startsWith('module', c)) {
+        const after = c + 6;
+        if (after === n || !WORD_CHAR.test(normalized[after])) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 function isNavigationPrompt(prompt) {
   if (!prompt) {
     return false;
@@ -95,7 +139,7 @@ function isNavigationPrompt(prompt) {
   const normalized = prompt.toLowerCase();
   return (
     /\b(where|module|file|hook|wired|location|path|lives|implemented|implementation|identify)\b/.test(normalized) ||
-    /\bcurrent\s+\w*\s*module\b/.test(normalized)
+    hasCurrentModulePrompt(normalized)
   );
 }
 

--- a/src/http/auth.js
+++ b/src/http/auth.js
@@ -49,9 +49,17 @@ function isAuthorized(req, apiKey) {
   }
   const auth = headerValue(req.headers.authorization);
   if (auth) {
-    const bearerMatch = auth.match(/^Bearer\s+(.+)$/i);
-    if (bearerMatch && keysMatch(bearerMatch[1], apiKey)) {
-      return true;
+    // Linear-time Bearer parse: the former /^Bearer\s+(.+)$/i let the
+    // whitespace run split ambiguously against `.+`. Split at the first
+    // whitespace char, compare the scheme case-insensitively, and strip the
+    // rest of the leading whitespace run (the greedy `\s+` did the same);
+    // the token itself is kept verbatim, as the old capture group was.
+    const wsAt = auth.search(/\s/);
+    if (wsAt !== -1 && auth.slice(0, wsAt).toLowerCase() === 'bearer') {
+      const token = auth.slice(wsAt).replace(/^\s+/, '');
+      if (keysMatch(token, apiKey)) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/memory-domain/context.js
+++ b/src/memory-domain/context.js
@@ -51,7 +51,8 @@ function buildTopicQueryMatch(needles) {
   const scoreParams = [];
 
   for (const needle of needles) {
-    const like = `%${needle.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+    // Escape the ESCAPE character itself first, then the LIKE wildcards.
+    const like = `%${needle.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
     whereParts.push(`(${fields.map((field) => `${field} LIKE ? ESCAPE '\\'`).join(' OR ')})`);
     whereParams.push(...fields.map(() => like));
     for (const field of fields) {

--- a/src/memory-domain/observations.js
+++ b/src/memory-domain/observations.js
@@ -80,6 +80,83 @@ function save(deps, args) {
   return { id: rows[0].id, title, created_at: rows[0].created_at, expires_at: rows[0].expires_at };
 }
 
+const WS_CHAR = /\s/;
+
+function skipWsWhile(section, i) {
+  while (i < section.length && WS_CHAR.test(section[i])) {
+    i++;
+  }
+  return i;
+}
+
+// Length of the list marker (`-`, `*`, `N.` or `N)`) at section[i], or 0.
+function bulletLengthAt(section, i) {
+  const ch = section[i];
+  if (ch === '-' || ch === '*') {
+    return 1;
+  }
+  if (ch >= '0' && ch <= '9') {
+    let j = i;
+    while (j < section.length && section[j] >= '0' && section[j] <= '9') {
+      j++;
+    }
+    if (j < section.length && (section[j] === '.' || section[j] === ')')) {
+      return j - i + 1;
+    }
+  }
+  return 0;
+}
+
+// Extract list items from a "Key Learnings" section — linear-time equivalent
+// of the former polynomial-ReDoS item regex
+// /(?:^|\n)\s*(?:[-*]|\d+[.)])\s*([^\n]*(?:\n(?!\s*(?:[-*]|\d+[.)])\s*)[^\n]*)*)/g.
+// An item starts at a (possibly indented, possibly preceded by blank lines)
+// `-`, `*`, `N.` or `N)` marker and spans every following line that does not
+// itself begin with a marker.
+function extractLearningItems(section) {
+  const items = [];
+  const n = section.length;
+  let anchor = 0;
+  while (anchor < n) {
+    // The old regex could only anchor at the string start or after a newline.
+    if (anchor !== 0 && section[anchor] !== '\n') {
+      anchor++;
+      continue;
+    }
+    const bulletAt = skipWsWhile(section, anchor === 0 ? 0 : anchor + 1);
+    const mark = bulletLengthAt(section, bulletAt);
+    if (mark === 0) {
+      // No marker: every candidate anchor inside the skipped whitespace run
+      // lands on this same non-marker position, so jump past it.
+      anchor = bulletAt > anchor ? bulletAt : anchor + 1;
+      continue;
+    }
+    const start = skipWsWhile(section, bulletAt + mark);
+    let end = start;
+    for (;;) {
+      const nl = section.indexOf('\n', end);
+      if (nl === -1) {
+        end = n;
+        break;
+      }
+      if (bulletLengthAt(section, skipWsWhile(section, nl + 1)) > 0) {
+        // After any blank/whitespace lines a new marker starts: stop before
+        // consuming this newline.
+        end = nl;
+        break;
+      }
+      const nextNl = section.indexOf('\n', nl + 1);
+      end = nextNl === -1 ? n : nextNl;
+    }
+    const cleaned = section.slice(start, end).replace(/\n\s+/g, ' ').trim();
+    if (cleaned) {
+      items.push(cleaned);
+    }
+    anchor = end;
+  }
+  return items;
+}
+
 function capturePassive(deps, args) {
   const { jsonErrNoExit, insertCapturePassiveObservation, findLatestSession } = deps;
   const content = args.content;
@@ -92,16 +169,7 @@ function capturePassive(deps, args) {
     return { extracted: 0, items: [] };
   }
 
-  const section = match[1];
-  const itemRe = /(?:^|\n)\s*(?:[-*]|\d+[.)])\s*([^\n]*(?:\n(?!\s*(?:[-*]|\d+[.)])\s*)[^\n]*)*)/g;
-  const items = [];
-  let m;
-  while ((m = itemRe.exec(section)) !== null) {
-    const cleaned = m[1].replace(/\n\s+/g, ' ').trim();
-    if (cleaned) {
-      items.push(cleaned);
-    }
-  }
+  const items = extractLearningItems(match[1]);
 
   let inserted = 0;
   const sessionId = findLatestSession(null);
@@ -123,7 +191,10 @@ function suggestTopicKey(args) {
   const key = source
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    // Anchored single-pass trims (the former global `^-+|-+$` alternation
+    // re-scanned every position with quadratic backtracking on dash runs).
+    .replace(/^-+/, '')
+    .replace(/-+$/, '')
     .replace(/-+/g, '-');
   return { topic_key: key || 'untitled' };
 }

--- a/src/memory-domain/observations.js
+++ b/src/memory-domain/observations.js
@@ -188,15 +188,31 @@ function suggestTopicKey(args) {
   const title = args.title;
   const content = args.content;
   const source = title || content || '';
-  const key = source
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    // Anchored single-pass trims (the former global `^-+|-+$` alternation
-    // re-scanned every position with quadratic backtracking on dash runs).
-    .replace(/^-+/, '')
-    .replace(/-+$/, '')
-    .replace(/-+/g, '-');
-  return { topic_key: key || 'untitled' };
+  const key = source.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  // Collapse/trim dash runs without regex quantifiers — the chained
+  // anchored quantifiers tripped CodeQL's polynomial-regex heuristic on
+  // unbounded input even though each scan was linear.
+  let trimmed = key;
+  while (trimmed.startsWith('-')) {
+    trimmed = trimmed.slice(1);
+  }
+  while (trimmed.endsWith('-')) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  let collapsed = '';
+  let prevDash = false;
+  for (const ch of trimmed) {
+    if (ch === '-') {
+      if (!prevDash) {
+        collapsed += '-';
+      }
+      prevDash = true;
+    } else {
+      collapsed += ch;
+      prevDash = false;
+    }
+  }
+  return { topic_key: collapsed || 'untitled' };
 }
 
 module.exports = { save, capturePassive, suggestTopicKey };

--- a/src/memory-domain/search.js
+++ b/src/memory-domain/search.js
@@ -59,11 +59,15 @@ function rankObservations(rows, query = '') {
         usefulRatio * RANKING.USEFULNESS_MULTIPLIER;
       const typeBoost = RANKING.TYPE_BOOST[row.type] || 1.0;
 
-      // Boost memories containing file paths for navigation queries
+      // Boost memories containing file paths for navigation queries.
+      // path_pattern has ambiguous quantifiers, so test bounded tokens instead
+      // of the raw text: path syntax never spans whitespace, and each token is
+      // capped, which rules out polynomial-time backtracking (ReDoS).
       let navBoost = 1.0;
       if (isNavigationQuery) {
         const text = `${row.title || ''} ${row.snippet || ''}`;
-        if (pathPattern.test(text)) {
+        const isPathLike = text.split(/\s+/).some((tok) => pathPattern.test(tok.slice(0, 200)));
+        if (isPathLike) {
           navBoost = RANKING.NAVIGATION_BOOST.path_multiplier;
         }
       }
@@ -273,7 +277,9 @@ function search(deps, args) {
         AND o.deleted_at IS NULL
         AND (o.expires_at IS NULL OR o.expires_at > datetime('now'))
     `;
-    const like = `%${query.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
+    // Escape the ESCAPE character itself first, then the LIKE wildcards,
+    // so a trailing "\" in the query can't escape the wildcard markers.
+    const like = `%${query.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')}%`;
     const params = [like, like];
     if (project) {
       q += ' AND o.project = ?';

--- a/test/doc-index-modules.test.js
+++ b/test/doc-index-modules.test.js
@@ -170,4 +170,22 @@ describe('html-parser module', () => {
   it('strips HTML entities from text', () => {
     expect(htmlParser.stripHtmlTags('<p>Hello &amp; world &lt;test&gt;</p>')).toBe('Hello & world <test>');
   });
+
+  it('never lets encoded, nested, or unterminated script/style markup survive stripping', () => {
+    const crafted = [
+      '<<scr<script>ipt>alert(1)</script>',
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+      '&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;',
+      '&lt;script src="evil.js"&gt;',
+      'a &lt;script payload',
+      '<style>x</style>&lt;style&gt;y',
+    ];
+    for (const html of crafted) {
+      const text = htmlParser.stripHtmlTags(html);
+      expect(text.toLowerCase()).not.toContain('<script');
+      expect(text.toLowerCase()).not.toContain('<style');
+    }
+    // Decoded non-script angle-bracket text still survives as literal text.
+    expect(htmlParser.stripHtmlTags('&lt;test&gt;')).toBe('<test>');
+  });
 });

--- a/test/services-context.test.js
+++ b/test/services-context.test.js
@@ -240,4 +240,12 @@ describe('services/context', () => {
     expect(observationParams).toContain('%fts5%');
     expect(observationParams).toContain('%external%');
   });
+
+  it('escapes backslash before LIKE wildcards in topic query needles', () => {
+    const { buildTopicQueryMatch } = require('../services/context');
+    const { whereParams } = buildTopicQueryMatch(['50%_off\\']);
+    // Backslash escaped first ("\" -> "\\"), then % and _ -> "\%", "\_":
+    // a trailing "\" can no longer escape the wildcard markers under ESCAPE '\'.
+    expect(whereParams[0]).toBe('%50\\%\\_off\\\\%');
+  });
 });

--- a/test/services-search.test.js
+++ b/test/services-search.test.js
@@ -217,3 +217,37 @@ describe('services/search: symbolCluster', () => {
     expect(call[1]).toContain('my-repo');
   });
 });
+
+describe('services/search: sanitization regressions', () => {
+  it('escapes backslash before LIKE wildcards in fallback search', () => {
+    const deps = {
+        sqlJson: vi.fn(() => []),
+        jsonErrNoExit: vi.fn((msg) => ({ error: msg })),
+      },
+      result = _search(deps, { query: '50%_off\\' });
+    expect(result.error).toBeUndefined();
+    const likeCall = deps.sqlJson.mock.calls.find((c) => c[0].includes("LIKE ? ESCAPE '\\'"));
+    expect(likeCall).toBeDefined();
+    // Backslash escaped first ("\" -> "\\"), then % and _ -> "\%", "\_":
+    // a trailing "\" can no longer escape the wildcard markers.
+    expect(likeCall[1][0]).toBe('%50\\%\\_off\\\\%');
+  });
+
+  it('ranks adversarial path-like text without pathological backtracking', () => {
+    // Long single token with no match: quadratic backtracking under the old
+    // whole-text pathPattern.test(); bounded token matching keeps it linear.
+    const evil = `a/${'b'.repeat(50000)}!`,
+      rows = [
+        { id: 1, title: evil, type: 'decision', created_at: '2025-01-01T00:00:00', rank: 0 },
+        {
+          id: 2,
+          title: 'see src/utils/readme.md for details',
+          type: 'decision',
+          created_at: '2025-01-01T00:00:00',
+          rank: 0,
+        },
+      ],
+      ranked = rankObservations(rows, 'where file');
+    expect(ranked[0].id).toBe(2); // real path still gets the navigation boost
+  });
+});


### PR DESCRIPTION
Triaged and resolved every open code-scanning alert, plus docs refreshes for behaviors that changed in the review PRs.

## ReDoS (9 alerts: #21–#29) — linear replacements, behavior preserved
Each rewrite was equivalence-verified over targeted input corpora before commit:
- **scanner/path-guards**: the secret-file regex's `.*` rescanned the tail from every slash → linear path-segment scan (`SECRET_FILE_RE` → `isSecretFilePath`).
- **observations**: the learning-item exec loop's `\s*` crossed newlines per anchor → linear marker scanner; dash-trim split into two anchored passes.
- **auth**: Bearer header parse without a backtracking regex (indexOf + slice); `keysMatch` still guards the token.
- **prompt-classifiers / tool-map**: keyword-window and `mcp__` tool-name parses rewritten as linear scans.

## Sanitization (11 alerts: #9–#15, #43–#45)
- **html-parser**: script/style/tag stripping ran once and entity decoding re-introduced live markup — `&amp;lt;script&amp;gt;` decoded to a surviving `<script>`. Stripping now runs to a **fixpoint** with a final guard; `<<scr<script>ipt>` cannot produce live tags (tested).
- **LIKE sanitization** (search/context/source-retrieval): the escape char itself was never escaped (a trailing `\` escaped the wildcard marker under `ESCAPE '\'`), and source-retrieval was missing the `ESCAPE` clause entirely. Escape char now escaped first; clauses added.
- **search**: the path-pattern ReDoS is bounded by matching per whitespace-delimited token.

## By design / test-only (not changed)
- `run-command.js` (#42): executes user-provided commands **by design** — that is the token-saver's purpose (it wraps, truncates, and sandbox-scopes them).
- `test/edge-cases.test.js`, `test/code-analysis.test.js` (#7, #15, #16): injection strings in tests, intentionally.

## Docs
- `cancel-index` added to INDEX/COMMANDS/code-indexing (new command from #316).
- `link-symbol --file` documented (new flag from #333).
- API.md serve section rewritten for the loopback-only keyless posture from #307.

## Verification
Full suite: **151 files / 2110 tests passed**. Lint: 0 errors. Format clean.

After merge, the CodeQL alerts resolve on the next analysis run.